### PR TITLE
[ANCHOR-431] Set callback-api-request.enabled default to false

### DIFF
--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -166,7 +166,7 @@ event_processor:
   # The configuration of the event delivery to the anchor business server
   callback_api_request:
     # Whether to enable the event delivery to the anchor business server
-    enabled: true
+    enabled: false
 
 ######################
 ## Platform Server Configuration

--- a/service-runner/src/main/resources/profiles/default/config.env
+++ b/service-runner/src/main/resources/profiles/default/config.env
@@ -18,6 +18,7 @@ languages=en,es-AR
 events.enabled=true
 events.queue.type=kafka
 events.queue.kafka.bootstrap_server=kafka:29092
+event_processor.callback_api_request.enabled=true
 # callback API endpoint
 callback_api.base_url=http://reference-server:8091/
 # platform API endpoint


### PR DESCRIPTION
### Description

- Set callback-api-request.enabled default to false
- The "What's Changed" from v2 to v3 will document this. 

### Context

- Improvements

### Testing

- `./gradlew test`

### Documentation

The "What's Changed" from v2 to v3 will document this. 

### Known limitations

This would be a breaking change. It should be part of the v3 release.
