### PR TITLE
[ANCHOR-926] Ignore transfer_received_at field in API tests

### DIFF
--- a/.github/workflows/sub_essential_tests.yml
+++ b/.github/workflows/sub_essential_tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       #############################################
       # Setup JDK 17
-      # Download, and Extract java-stellar-anchor-sdk.tar
+      # Download, and Extract anchor-platform.tar
       # Setup hostnames (/etc/hosts)
       #############################################
       - name: Set up JDK 17
@@ -20,17 +20,17 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Download java-stellar-anchor-sdk.tar
+      - name: Download anchor-platform.tar
         uses: actions/download-artifact@v3
         with:
-          name: java-stellar-anchor-sdk-tar
+          name: anchor-platform-tar
           path: /home/runner/
 
-      - name: Extract java-stellar-anchor-sdk.tar
+      - name: Extract anchor-platform.tar
         run: |
           cd /home/runner
-          tar -xf /home/runner/java-stellar-anchor-sdk.tar
-          cd /home/runner/java-stellar-anchor-sdk
+          tar -xf /home/runner/anchor-platform.tar
+          cd /home/runner/anchor-platform
 
       - name: Set up hostnames (/etc/hosts)
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Run Kafka, Postgres, and Sep24 UI with docker compose
         env:
           TEST_PROFILE_NAME: default
-        run: docker compose -f /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
+        run: docker compose -f /home/runner/anchor-platform/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
 
       - name: Run sep server, platform server, observer, and reference servers for integration tests
         env:
@@ -65,13 +65,13 @@ jobs:
           RUN_KOTLIN_REFERENCE_SERVER: true
           RUN_EVENT_PROCESSING_SERVER: true
           RUN_WALLET_SERVER: true
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
-          SEP1_TOML_VALUE: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/stellar.host.docker.internal.toml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
+          SEP1_TOML_VALUE: /home/runner/anchor-platform/service-runner/src/main/resources/config/stellar.host.docker.internal.toml
           SEP10_WEB_AUTH_DOMAIN: host.docker.internal:8080
           SEP10_HOME_DOMAINS: host.docker.internal:8080,*.stellar.org
-          TOML_PATH: /home/runner/java-stellar-anchor-sdk/wallet-reference-server/src/main/resources/toml
+          TOML_PATH: /home/runner/anchor-platform/wallet-reference-server/src/main/resources/toml
         run: |
-          cp /home/runner/java-stellar-anchor-sdk/service-runner/build/libs/anchor-platform-runner-*.jar /home/runner/anchor-platform-runner.jar
+          cp /home/runner/anchor-platform/service-runner/build/libs/anchor-platform-runner-*.jar /home/runner/anchor-platform-runner.jar
           java -jar /home/runner/anchor-platform-runner.jar -t &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -99,12 +99,12 @@ jobs:
           RUN_DOCKER: false
           ANCHOR_DOMAIN: http://host.docker.internal:8080
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew runEssentialTests
 
       - name: Run Stellar validation tool
         run: |
-          docker run --network host -v /home/runner/java-stellar-anchor-sdk/platform/src/test/resources://config stellar/anchor-tests:v0.6.20 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
+          docker run --network host -v /home/runner/anchor-platform/platform/src/test/resources://config stellar/anchor-tests:v0.6.20 --home-domain http://host.docker.internal:8080 --seps 1 6 10 12 24 31 38 --sep-config //config/stellar-anchor-tests-sep-config.json --verbose
 
       - name: Upload Essential Tests report
         if: always()
@@ -112,8 +112,8 @@ jobs:
         with:
           name: essential-tests-report
           path: |
-            /home/runner/java-stellar-anchor-sdk/api-schema/build/reports/
-            /home/runner/java-stellar-anchor-sdk/core/build/reports/
-            /home/runner/java-stellar-anchor-sdk/platform/build/reports/
-            /home/runner/java-stellar-anchor-sdk/essential-tests/build/reports/
+            /home/runner/anchor-platform/api-schema/build/reports/
+            /home/runner/anchor-platform/core/build/reports/
+            /home/runner/anchor-platform/platform/build/reports/
+            /home/runner/anchor-platform/essential-tests/build/reports/
         

--- a/.github/workflows/sub_extended_tests.yml
+++ b/.github/workflows/sub_extended_tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       #############################################
       # Setup JDK 17
-      # Download, and Extract java-stellar-anchor-sdk.tar
+      # Download, and Extract anchor-platform.tar
       # Setup hostnames (/etc/hosts)
       #############################################
       - name: Set up JDK 17
@@ -20,17 +20,17 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Download java-stellar-anchor-sdk.tar
+      - name: Download anchor-platform.tar
         uses: actions/download-artifact@v3
         with:
-          name: java-stellar-anchor-sdk-tar
+          name: anchor-platform-tar
           path: /home/runner/
 
-      - name: Extract java-stellar-anchor-sdk.tar
+      - name: Extract anchor-platform.tar
         run: |
           cd /home/runner
-          tar -xf /home/runner/java-stellar-anchor-sdk.tar
-          cd /home/runner/java-stellar-anchor-sdk
+          tar -xf /home/runner/anchor-platform.tar
+          cd /home/runner/anchor-platform
 
       - name: Set up hostnames (/etc/hosts)
         run: |
@@ -47,15 +47,15 @@ jobs:
       #############################################
 
       - name: Run Kafka, Postgres, and Sep24 UI with docker compose
-        run: docker compose -f /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
+        run: docker compose -f /home/runner/anchor-platform/service-runner/src/main/resources/docker-compose-test.yaml up -d --build
 
       # `custody` Tests
       - name: Start `custody` configuration
         env:
           TEST_PROFILE_NAME: custody
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew startServersWithTestProfile &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -69,7 +69,7 @@ jobs:
         env:
           TEST_PROFILE_NAME: custody
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew :service-runner:clean :extended-tests:clean :extended-tests:test --tests org.stellar.anchor.platform.suite.CustodyTestSuite         
           kill -9 $PID
 
@@ -77,9 +77,9 @@ jobs:
       - name: Start `rpc` configuration
         env:
           TEST_PROFILE_NAME: rpc
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew startServersWithTestProfile &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -93,7 +93,7 @@ jobs:
         env:
           TEST_PROFILE_NAME: rpc
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.RpcTestSuite         
           kill -9 $PID      
 
@@ -101,9 +101,9 @@ jobs:
       - name: Start `auth-apikey-custody` configuration
         env:
           TEST_PROFILE_NAME: auth-apikey-custody
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew startServersWithTestProfile &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -117,7 +117,7 @@ jobs:
         env:
           TEST_PROFILE_NAME: auth-apikey-custody
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.AuthApikeyCustodyTestSuite         
           kill -9 $PID           
 
@@ -125,9 +125,9 @@ jobs:
       - name: Start `auth-jwt-custody` configuration
         env:
           TEST_PROFILE_NAME: auth-jwt-custody
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew startServersWithTestProfile &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -141,7 +141,7 @@ jobs:
         env:
           TEST_PROFILE_NAME: auth-jwt-custody
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.AuthJwtCustodyTestSuite         
           kill -9 $PID    
 
@@ -149,9 +149,9 @@ jobs:
       - name: Start `auth-apikey-platform` configuration
         env:
           TEST_PROFILE_NAME: auth-apikey-platform
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew startServersWithTestProfile &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -166,7 +166,7 @@ jobs:
         env:
           TEST_PROFILE_NAME: auth-apikey-platform
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.AuthApikeyPlatformTestSuite         
           kill -9 $PID
 
@@ -174,9 +174,9 @@ jobs:
       - name: Start `auth-jwt-platform` configuration
         env:
           TEST_PROFILE_NAME: auth-jwt-platform
-          KT_REFERENCE_SERVER_CONFIG: /home/runner/java-stellar-anchor-sdk/service-runner/src/main/resources/config/reference-config.yaml
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew startServersWithTestProfile &
           echo "PID=$!" >> $GITHUB_ENV
 
@@ -191,7 +191,7 @@ jobs:
         env:
           TEST_PROFILE_NAME: auth-jwt-platform
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.AuthJwtPlatformTestSuite         
           kill -9 $PID   
 
@@ -201,5 +201,5 @@ jobs:
         with:
           name: extended-tests-report
           path: |
-            /home/runner/java-stellar-anchor-sdk/extended-tests/build/reports/
+            /home/runner/anchor-platform/extended-tests/build/reports/
         

--- a/.github/workflows/sub_gradle_build.yml
+++ b/.github/workflows/sub_gradle_build.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Archive Project Folder
         run: |
-          cd /home/runner/work/java-stellar-anchor-sdk
-          tar -cf /home/runner/java-stellar-anchor-sdk.tar ./java-stellar-anchor-sdk
+          cd /home/runner/work/anchor-platform
+          tar -cf /home/runner/anchor-platform.tar ./anchor-platform
 
-      - name: Upload java-stellar-anchor-sdk.tar to GitHub Artifacts
+      - name: Upload anchor-platform.tar to GitHub Artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: java-stellar-anchor-sdk-tar
+          name: anchor-platform-tar
           path: |
-            /home/runner/java-stellar-anchor-sdk.tar
+            /home/runner/anchor-platform.tar

--- a/.github/workflows/sub_jacoco_report.yml
+++ b/.github/workflows/sub_jacoco_report.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       #############################################
       # Setup JDK 17
-      # Download, and Extract java-stellar-anchor-sdk.tar
+      # Download, and Extract anchor-platform.tar
       # Setup hostnames (/etc/hosts)
       #############################################
       - name: Set up JDK 17
@@ -26,17 +26,17 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Download java-stellar-anchor-sdk.tar
+      - name: Download anchor-platform.tar
         uses: actions/download-artifact@v3
         with:
-          name: java-stellar-anchor-sdk-tar
+          name: anchor-platform-tar
           path: /home/runner/
 
-      - name: Extract java-stellar-anchor-sdk.tar
+      - name: Extract anchor-platform.tar
         run: |
           cd /home/runner
-          tar -xf /home/runner/java-stellar-anchor-sdk.tar
-          cd /home/runner/java-stellar-anchor-sdk
+          tar -xf /home/runner/anchor-platform.tar
+          cd /home/runner/anchor-platform
 
       - name: Set up hostnames (/etc/hosts)
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Gradle Build with unit tests only
         if : ${{ inputs.forceRebuild }}
         run: |
-          cd /home/runner/java-stellar-anchor-sdk
+          cd /home/runner/anchor-platform
           ./gradlew clean build jacocoTestReport -x essential-tests:test -x extended-tests:test
 
       - name: Add coverage to the Pull Request

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/custody/PlatformApiCustodyTests.kt
@@ -161,6 +161,7 @@ class PlatformApiCustodyTests : AbstractIntegrationTests(TestConfig("custody")) 
       actualResult,
       CustomComparator(
         JSONCompareMode.LENIENT,
+        Customization("[*].result.transfer_received_at") { _, _ -> true },
         Customization("[*].result.started_at") { _, _ -> true },
         Customization("[*].result.updated_at") { _, _ -> true },
         Customization("[*].result.completed_at") { _, _ -> true },


### PR DESCRIPTION
### Description

This fixes the extended-tests after the Testnet reset. It also fixes the broken paths in the CI workflows after the repo was renamed.

### Context

Testnet reset

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

