### PR TITLE
Update on_release_created_or_updated.yml

### DIFF
--- a/.github/workflows/on_release_created_or_updated.yml
+++ b/.github/workflows/on_release_created_or_updated.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
       - name: Get EXPECTED_RELEASE_TAG
         shell: bash
         run: |


### PR DESCRIPTION
### Description

Github is default to use JDK11 and causing the incompatible issue here: https://github.com/stellar/anchor-platform/actions/runs/12356621680/job/34483414510#step:3:13

