### PR TITLE
Add instructions for local kubernetes setup

### DIFF
--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -1,0 +1,34 @@
+# Getting Started
+
+```bash
+minikube start
+
+# Install external-secrets
+helm repo add external-secrets https://charts.external-secrets.io
+helm install external-secrets \
+   external-secrets/external-secrets \
+    -n external-secrets \
+    --create-namespace
+
+# Install postgres
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install postgresql-ref bitnami/postgresql --set global.postgresql.auth.postgresPassword=123456789
+helm install postgresql bitnami/postgresql --set global.postgresql.auth.postgresPassword=123456789
+
+# Install Kafka
+kubectl create secret generic ap-kafka-secrets --from-literal=client-passwords=123456789 --from-literal=controller-password=123456789 --from-literal=inter-broker-password=123456789 --from-literal=system-user-password=123456789
+helm install kafka bitnami/kafka --set sasl.existingSecret=ap-kafka-secrets
+
+# Install the secret store
+helm upgrade --install fake-secret-store ./secret-store/
+
+# Build the Anchor Platform image locally
+eval $(minikube -p minikube docker-env)
+docker build -t anchor-platform:local ../
+
+# Install the reference server
+helm upgrade --install reference-server ./reference-server/ -f ./reference-server/values.yaml
+
+# Install the Anchor Platform
+helm upgrade --install anchor-platform ./sep-service/ -f ./sep-service/values.yaml
+```

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+The following instructions will guide you through the process of setting up the Anchor Platform on a local Kubernetes cluster using Minikube.
+
 ```bash
 minikube start
 
@@ -31,4 +33,14 @@ helm upgrade --install reference-server ./reference-server/ -f ./reference-serve
 
 # Install the Anchor Platform
 helm upgrade --install anchor-platform ./sep-service/ -f ./sep-service/values.yaml
+
+# Install the ingress controller
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+  
+# Port forward the ingress controller
+kubectl port-forward svc/ingress-nginx-controller 8080:80 -n ingress-nginx
+
+# Now you can access the Anchor Platform at http://localhost:8080
 ```

--- a/helm-charts/secret-store/templates/secretstore.yaml
+++ b/helm-charts/secret-store/templates/secretstore.yaml
@@ -11,20 +11,20 @@ spec:
           value: |
             {
               "POSTGRES_USER": "postgres",
-              "POSTGRES_PASSWORD": "cdb1ajkMih",
+              "POSTGRES_PASSWORD": "123456789",
               "SEP24_INTERACTIVE_URL_JWT_SECRET": "c5457e3a349df9002117543efa7e316dd89e666a5ce6f33a0deb13e90f3f1e9d",
               "SEP24_MORE_INFO_URL_JWT_SECRET": "b106cce1e32ebe342ea1e38d363fe048c7dc9c1b773658f83e22b78125785d89",
               "SEP6_MORE_INFO_URL_JWT_SECRET": "3a614cf5da456aaad61dc7532f6c422fc2b833c0c05102b47b1ac2e8f0bff2e8",
               "SEP10_JWT_SECRET": "10bb04a51338a1df86c2e807f8fe36168cf9a480d70c233452ec7e198ab33b7c",
               "SEP10_SIGNING_SEED": "SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X",
               "EVENTS_QUEUE_KAFKA_USERNAME": "user1",
-              "EVENTS_QUEUE_KAFKA_PASSWORD": "INfioH5l7N",
+              "EVENTS_QUEUE_KAFKA_PASSWORD": "123456789",
             }
         - key: {{ .Values.namespace}}/reference-server-secrets
           value: |
             {
               "POSTGRES_USER": "postgres",
-              "POSTGRES_PASSWORD": "XgvqTkecnv",
+              "POSTGRES_PASSWORD": "123456789",
               "SEP6_SECRET": "SAJW2O2NH5QMMVWYAN352OEXS2RUY675A2HPK5HEG2FRR2NXPYA4OLYN",
               "SEP24_INTERACTIVE_JWT_KEY": "0005686076237201446d93d2ea92d1419647283e2acddbc2fffbf8d53db36b7d",
               "SEP24_SECRET": "SAJ34AG5XC7BWGK3GGQGCXERSEP7LZYXBBDMD33NMBASZVNKACEMNEIY",

--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -182,149 +182,121 @@ sep1_toml: |
 
 assets_config: |
   items:
-  - id: stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
-    significant_decimals: 2
-    sep6:
-      enabled: true
-      deposit:
+    # Stellar assets
+    - id: stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+      distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
+      significant_decimals: 7
+      sep6:
         enabled: true
-        min_amount: 1
-        methods:
-          - SEPA
-          - SWIFT
-      withdraw:
+        deposit:
+          enabled: true
+          min_amount: 1
+          max_amount: 10
+          methods:
+            - SEPA
+            - SWIFT
+        withdraw:
+          enabled: true
+          min_amount: 1
+          max_amount: 10
+          methods:
+            - bank_account
+            - cash
+      sep24:
         enabled: true
-        min_amount: 1
-        max_amount: 1000000
-        methods:
-          - bank_account
-          - cash
-    sep24:
-      enabled: true
-      deposit:
+        deposit:
+          enabled: true
+          min_amount: 1
+          max_amount: 10
+          methods:
+            - SEPA
+            - SWIFT
+        withdraw:
+          enabled: true
+          min_amount: 1
+          max_amount: 10
+          methods:
+            - bank_account
+            - cash
+      sep31:
         enabled: true
-        min_amount: 1
-        methods:
-          - SEPA
-          - SWIFT
-      withdraw:
+        receive:
+          min_amount: 1
+          max_amount: 1000000
+          methods:
+            - SEPA
+            - SWIFT
+        quotes_supported: true
+        quotes_required: false
+      sep38:
         enabled: true
-        min_amount: 1
-        max_amount: 1000000
-        methods:
-          - bank_account
-          - cash
-    sep31:
-      enabled: true
-      receive:
-        min_amount: 1
-        max_amount: 1000000
-        methods:
-          - SEPA
-          - SWIFT
-      quotes_supported: true
-      quotes_required: false
-    sep38:
-      enabled: true
-      exchangeable_assets:
-        - iso4217:USD
-  - id: stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
-    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
-    significant_decimals: 2
-    sep24:
-      enabled: true
-      deposit:
+        exchangeable_assets:
+          - iso4217:USD
+          - iso4217:CAD
+
+    # Native asset
+    - id: stellar:native
+      distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
+      significant_decimals: 7
+      sep6:
+        enabled: false
+      sep24:
         enabled: true
-        min_amount: 1
-        max_amount: 1000000
-      withdraw:
+        deposit:
+          enabled: true
+          min_amount: 1
+          max_amount: 10
+          methods:
+            - SEPA
+            - SWIFT
+        withdraw:
+          enabled: true
+          min_amount: 1
+          max_amount: 10
+          methods:
+            - bank_account
+            - cash
+      sep31:
+        enabled: false
+      sep38:
+        enabled: false
+
+    # Fiat
+    - id: iso4217:USD
+      significant_decimals: 4
+      sep31:
+        enabled: false
+        receive:
+          min_amount: 0
+          max_amount: 1000000
+      sep38:
         enabled: true
-        min_amount: 1
-        max_amount: 1000000
-    sep31:
-      enabled: true
-      receive:
-        min_amount: 1
-        max_amount: 1000000
-        methods:
-          - SEPA
-          - SWIFT
-      quotes_supported: true
-      quotes_required: false
-    sep38:
-      enabled: true
-      exchangeable_assets:
-        - iso4217:USD
-  - id: stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
-    significant_decimals: 4
-    sep6:
-      enabled: false
-    sep24:
-      enabled: true
-      deposit:
+        exchangeable_assets:
+          - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+        country_codes:
+          - USA
+        sell_delivery_methods:
+          - name: WIRE
+            description: Send USD directly to the Anchor's bank account.
+        buy_delivery_methods:
+          - name: WIRE
+            description: Have USD sent directly to your bank account.
+    - id: iso4217:CAD
+      significant_decimals: 4
+      sep31:
+        enabled: false
+        receive:
+          min_amount: 0
+          max_amount: 1000000
+      sep38:
         enabled: true
-      withdraw:
-        enabled: true
-    sep31:
-      enabled: true
-      receive:
-        methods:
-          - SEPA
-          - SWIFT
-      quotes_supported: true
-      quotes_required: false
-    sep38:
-      enabled: true
-      exchangeable_assets:
-        - iso4217:USD
-  - id: iso4217:USD
-    significant_decimals: 7
-    sep31:
-      enabled: false
-      receive:
-        min_amount: 0
-        max_amount: 10000
-        methods:
-          - SEPA
-          - SWIFT
-    sep38:
-      enabled: true
-      exchangeable_assets:
-        - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-        - stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
-      country_codes:
-        - USA
-      sell_delivery_methods:
-        - name: WIRE
-          description: Send USD directly to the Anchor's bank account.
-      buy_delivery_methods:
-        - name: WIRE
-          description: Have USD sent directly to your bank account.
-  - id: stellar:native
-    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
-    significant_decimals: 7
-    sep6:
-      enabled: false
-    sep24:
-      enabled: true
-      deposit:
-        enabled: true
-        max_amount: 1000000
-      withdraw:
-        enabled: true
-        max_amount: 1000000
-    sep31:
-      enabled: true
-      receive:
-        max_amount: 1000000
-        methods:
-          - SEPA
-          - SWIFT
-      quotes_supported: true
-      quotes_required: true
-    sep38:
-      enabled: true
-      exchangeable_assets:
-        - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+        exchangeable_assets:
+          - stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP
+        country_codes:
+          - CAN
+        sell_delivery_methods:
+          - name: WIRE
+            description: Send CAD directly to the Anchor's bank account.
+        buy_delivery_methods:
+          - name: WIRE
+            description: Have CAD sent directly to your bank account.

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Config.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/data/Config.kt
@@ -3,7 +3,7 @@ package org.stellar.reference.data
 import com.sksamuel.hoplite.ConfigAlias
 import org.stellar.sdk.KeyPair
 
-data class LocationConfig(val ktReferenceServerConfig: String)
+data class LocationConfig(val ktReferenceServerConfig: String?)
 
 data class Config(
   @ConfigAlias("app") val appSettings: AppSettings,

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ConfigContainer.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/di/ConfigContainer.kt
@@ -36,7 +36,6 @@ class ConfigContainer(envMap: Map<String, String>?) {
         cfgBuilder.addMapSource(this)
       }
 
-      //
       val locationConfig = locationCfgBuilder.build().loadConfigOrThrow<LocationConfig>()
       if (locationConfig.ktReferenceServerConfig != null) {
         cfgBuilder.addFileSource(locationConfig.ktReferenceServerConfig)


### PR DESCRIPTION
### Description

This adds the instructions for setting up AP locally using minikube.

### Context

N/A

### Testing

- `./gradlew test`
- Tested against demo wallet locally.

### Documentation

N/A

### Known limitations

Event processing doesn't seem to be working and needs to be fixed.
