### PR TITLE
[ANCHOR-935] Remove SEP-dependent Sep24DepositInfoGenerator bean creation

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -94,7 +94,6 @@ public class PlatformServerBeans {
   }
 
   @Bean
-  @ConditionalOnAnySepsEnabled(seps = {"sep24"})
   Sep24DepositInfoGenerator sep24DepositInfoGenerator(
       Sep24Config sep24Config, Optional<CustodyApiClient> custodyApiClient)
       throws InvalidConfigException {


### PR DESCRIPTION
### Description

- Remove SEP-dependent Sep24DepositInfoGenerator bean creation

### Context

- To fix a bug reported at: https://discord.com/channels/897514728459468821/961080541711568966/1324777127152713849

### Testing

- `./gradlew test`

### Documentation

N/A

- Attach stellar-docs pull request, documenting new feature
- If it's an urgent feature request, please create a ticket and attach ticket number to this PR

### Known limitations

N/A