### PR TITLE
[CHORE] Replace java-stellar-anchor-sdk with anchor-platform

### DIFF
--- a/.run/Custody Server_ custody.run.xml
+++ b/.run/Custody Server_ custody.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Custody Server: custody" type="JetRunConfigurationType" folderName="Run Single Server">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunCustodyServer" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Docker - Run Dev Stack - Kafka, Postgres, SEP24 Reference UI.run.xml
+++ b/.run/Docker - Run Dev Stack - Kafka, Postgres, SEP24 Reference UI.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Docker - Run Dev Stack - Kafka, Postgres, SEP24 Reference UI" type="JetRunConfigurationType">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunDockerDevStack" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Event Processing Server_ default.run.xml
+++ b/.run/Event Processing Server_ default.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Event Processing Server: default" type="JetRunConfigurationType" folderName="Run Single Server">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunEventProcessingServer" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Platform Server_ default.run.xml
+++ b/.run/Platform Server_ default.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Platform Server: default" type="JetRunConfigurationType" folderName="Run Single Server">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunPlatformServer" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Reference Server_ default.run.xml
+++ b/.run/Reference Server_ default.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="default" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunKotlinReferenceServer" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Sep Server_ default.run.xml
+++ b/.run/Sep Server_ default.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Sep Server: default" type="JetRunConfigurationType" folderName="Run Single Server">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunSepServer" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Stellar Observer_ default.run.xml
+++ b/.run/Stellar Observer_ default.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Stellar Observer: default" type="JetRunConfigurationType" folderName="Run Single Server">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunStellarObserver" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ auth-apikey-custody.run.xml
+++ b/.run/Test Profile_ auth-apikey-custody.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="auth-apikey-custody" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ auth-apikey-platform.run.xml
+++ b/.run/Test Profile_ auth-apikey-platform.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="auth-apikey-platform" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ auth-jwt-custody.run.xml
+++ b/.run/Test Profile_ auth-jwt-custody.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="auth-jwt-custody" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ auth-jwt-platform.run.xml
+++ b/.run/Test Profile_ auth-jwt-platform.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="auth-jwt-platform" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ custody.run.xml
+++ b/.run/Test Profile_ custody.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="custody" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ default.run.xml
+++ b/.run/Test Profile_ default.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test Profile: default" type="JetRunConfigurationType" folderName="Run Test Profile">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ deployment.run.xml
+++ b/.run/Test Profile_ deployment.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="deployment" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ host.docker.internal.run.xml
+++ b/.run/Test Profile_ host.docker.internal.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test Profile: host.docker.internal" type="JetRunConfigurationType" folderName="Run Test Profile">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ kafka-sasl-ssl.run.xml
+++ b/.run/Test Profile_ kafka-sasl-ssl.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="kafka-sasl-ssl" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Test Profile_ rpc.run.xml
+++ b/.run/Test Profile_ rpc.run.xml
@@ -4,7 +4,7 @@
       <env name="TEST_PROFILE_NAME" value="rpc" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunTestProfile" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/Wallet Reference Server_ default.run.xml
+++ b/.run/Wallet Reference Server_ default.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Wallet Reference Server: default" type="JetRunConfigurationType" folderName="Run Single Server">
     <option name="MAIN_CLASS_NAME" value="org.stellar.anchor.platform.run_profiles.RunWalletServer" />
-    <module name="java-stellar-anchor-sdk.service-runner.main" />
+    <module name="anchor-platform.service-runner.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,38 +6,38 @@
 * Implement end-to-end tests for SEP-24 done in GitHub Actions.
 
 ## 1.2.13
-* Allow zero fees in `PATCH /transactions` request [#871](https://github.com/stellar/java-stellar-anchor-sdk/pull/871)
+* Allow zero fees in `PATCH /transactions` request [#871](https://github.com/stellar/anchor-platform/pull/871)
 
 ## 1.2.12
-* Don't set amount_out for indicative quote. [#823](https://github.com/stellar/java-stellar-anchor-sdk/pull/823)
+* Don't set amount_out for indicative quote. [#823](https://github.com/stellar/anchor-platform/pull/823)
 * Add docker-compose files to run e2e tests with containers
 
 ## 1.2.11
-* Fix validation failing indicative quote. [#810](https://github.com/stellar/java-stellar-anchor-sdk/pull/810)
+* Fix validation failing indicative quote. [#810](https://github.com/stellar/anchor-platform/pull/810)
 
 ## 1.2.10
-* Fix asset being set incorrectly when quote is null. [#805](https://github.com/stellar/java-stellar-anchor-sdk/pull/805)
+* Fix asset being set incorrectly when quote is null. [#805](https://github.com/stellar/anchor-platform/pull/805)
 
 ## 1.2.6
-* Add bank_account_type to SEP-9 and customer field [#750](https://github.com/stellar/java-stellar-anchor-sdk/pull/750)
+* Add bank_account_type to SEP-9 and customer field [#750](https://github.com/stellar/anchor-platform/pull/750)
 
 ## 1.2.5
-* Fix DETELE endpoint to take customer types into account [#734](https://github.com/stellar/java-stellar-anchor-sdk/pull/734)
+* Fix DETELE endpoint to take customer types into account [#734](https://github.com/stellar/anchor-platform/pull/734)
 
 ## 1.2.4
-* Fix customer type not being properly resolved (when multiple types are configured) [#721](https://github.com/stellar/java-stellar-anchor-sdk/pull/721)
-* Add cbu_alias and cbu_number fields to core and platform [#728](https://github.com/stellar/java-stellar-anchor-sdk/pull/728)
+* Fix customer type not being properly resolved (when multiple types are configured) [#721](https://github.com/stellar/anchor-platform/pull/721)
+* Add cbu_alias and cbu_number fields to core and platform [#728](https://github.com/stellar/anchor-platform/pull/728)
 
 ## 1.2.2
-* Detects and handle silent and errored SSEStream. [#632](https://github.com/stellar/java-stellar-anchor-sdk/issues/632)
+* Detects and handle silent and errored SSEStream. [#632](https://github.com/stellar/anchor-platform/issues/632)
 * When the health status is RED, set the status code to 500.
 
 ## 1.2.1
-* Fix gson serialization error of the Refunds object. [#626](https://github.com/stellar/java-stellar-anchor-sdk/issues/626) 
+* Fix gson serialization error of the Refunds object. [#626](https://github.com/stellar/anchor-platform/issues/626) 
 
 ## 1.2.0
-* Add Stellar observer retries with exponential back-off timer [#607](https://github.com/stellar/java-stellar-anchor-sdk/pull/607)
-* Add health check endpoint to the Stellar observer [#602](https://github.com/stellar/java-stellar-anchor-sdk/pull/602)
+* Add Stellar observer retries with exponential back-off timer [#607](https://github.com/stellar/anchor-platform/pull/607)
+* Add health check endpoint to the Stellar observer [#602](https://github.com/stellar/anchor-platform/pull/602)
 
 ## 1.1.1
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -63,11 +63,11 @@ publishing {
           pom {
             name.set("stellar-anchor-sdk")
             description.set("Stellar Anchor SDK - Java")
-            url.set("https://github.com/stellar/java-stellar-anchor-sdk")
+            url.set("https://github.com/stellar/anchor-platform")
             licenses {
               license {
                 name.set("Apache 2.0")
-                url.set("https://github.com/stellar/java-stellar-anchor-sdk/blob/main/LICENSE")
+                url.set("https://github.com/stellar/anchor-platform/blob/main/LICENSE")
               }
             }
             developers {
@@ -88,9 +88,9 @@ publishing {
               }
             }
             scm {
-              connection.set("scm:git:git://github.com/stellar/java-stellar-anchor-sdk")
-              developerConnection.set("scm:git:git://github.com/stellar/java-stellar-anchor-sdk")
-              url.set("https://github.com/stellar/java-stellar-anchor-sdk")
+              connection.set("scm:git:git://github.com/stellar/anchor-platform")
+              developerConnection.set("scm:git:git://github.com/stellar/anchor-platform")
+              url.set("https://github.com/stellar/anchor-platform")
             }
           }
         }

--- a/docs/01 - Contributing/A - Development Environment.md
+++ b/docs/01 - Contributing/A - Development Environment.md
@@ -43,13 +43,13 @@ java -version
 To check out the project, run:
 
 ```shell
-git clone git@github.com:stellar/java-stellar-anchor-sdk.git 
+git clone git@github.com:stellar/anchor-platform.git 
 ```
 
 or
 
 ```shell
-git clone https://github.com/stellar/java-stellar-anchor-sdk.git
+git clone https://github.com/stellar/anchor-platform.git
 ```
 
 ## Set up `docker`
@@ -155,7 +155,7 @@ The project is mostly developed with IntelliJ, therefore we will only cover the 
 1. Clone the repository:
 
     ```shell
-    git clone git@github.com:stellar/java-stellar-anchor-sdk.git
+    git clone git@github.com:stellar/anchor-platform.git
     ```
 2. Install IntelliJ
 3. Install and configure `google-java-format`
@@ -167,7 +167,7 @@ The project is mostly developed with IntelliJ, therefore we will only cover the 
     2. File -> Settings -> Editor -> ktfmt -> Check `Enable ktfmt` and choose `Google (internal)` -> Apply
 5. Use IntelliJ to open as a Gradle project:
     1. Launch IntelliJ
-    2. File -> Open, choose the folder `java-stellar-anchor-sdk` where you cloned the repository.
+    2. File -> Open, choose the folder `anchor-platform` where you cloned the repository.
     3. When asked, choose `Open as Project`.
     4. IntelliJ will parse Gradle buildscript `build.gradle.kts` file and configure the project accordingly.
 6. Configure Gradle to build & run using IntelliJ IDEA:

--- a/docs/01 - Contributing/B - Git Guidelines.md
+++ b/docs/01 - Contributing/B - Git Guidelines.md
@@ -50,10 +50,10 @@ project.
 ## How to access GitHub workflow artifacts
 The following artifacts are available for each workflow run:
 - `/etc/hosts`: The hosts file of the runner.
-- `/java-stellar-anchor-sdk/api-schema/build/libs`: The build artifact of the `api-schema` subproject.
-- `java-stellar-anchor-sdk/core/build/reports`: The test reports of the `core` subproject.
-- `java-stellar-anchor-sdk/platform/build/reports`: The test reports of the `platform` subproject.
-- `java-stellar-anchor-sdk/essential-tests/build/reports`: The test reports of the `essential-tests` subproject.
+- `/anchor-platform/api-schema/build/libs`: The build artifact of the `api-schema` subproject.
+- `anchor-platform/core/build/reports`: The test reports of the `core` subproject.
+- `anchor-platform/platform/build/reports`: The test reports of the `platform` subproject.
+- `anchor-platform/essential-tests/build/reports`: The test reports of the `essential-tests` subproject.
 
 To access the artifacts, follow these steps:
 1. Go to the `Actions` tab of the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
-[![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/LICENSE)
-[![GitHub Version](https://badgen.net/github/release/stellar/java-stellar-anchor-sdk?icon=github&label=Latest%20release)](https://github.com/stellar/java-stellar-anchor-sdk/releases)
+[![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
+[![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
 [![Docker](https://badgen.net/badge/Latest%20Release/v3.0.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.0.1)
-![Develop Branch](https://github.com/stellar/java-stellar-anchor-sdk/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
+![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">
 <img alt="Stellar" src="https://github.com/stellar/.github/raw/master/stellar-logo.png" width="558" />
@@ -25,7 +25,7 @@ anchor, allowing businesses to focus on the core business logic necessary to pro
 
 To get started, visit the [Anchor Platform documentation](https://developers.stellar.org/docs/category/anchor-platform).
 Release notes can be found on the
-project's [releases page](https://github.com/stellar/java-stellar-anchor-sdk/releases).
+project's [releases page](https://github.com/stellar/anchor-platform/releases).
 
 ## Contributing
 

--- a/docs/resources/deployment-examples/example-fargate/readme.md
+++ b/docs/resources/deployment-examples/example-fargate/readme.md
@@ -12,7 +12,7 @@ This documentation will configure AWS Infrastructure, Anchor Platform and a samp
 
 # Steps
 1. Pre-requisites
-   1. Fork the [stellar-java-anchor-sdk](https://github.com/stellar/java-stellar-anchor-sdk) github repository
+   1. Fork the [stellar-java-anchor-sdk](https://github.com/stellar/anchor-platform) github repository
    2. Create AWS Account and IAM account with deployment permissions
    3. Create DNS Hosted Zone for Anchor Platform with public DNS
    4. Configure Terraform Cloud Account 

--- a/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
@@ -55,7 +55,7 @@ variable "codebuild_source_version" {
 
 variable "anchor_config_repository" {
   type = string
-  default = "https://github.com/reecexlm/anchor-platform"
+  default = "https://github.com/reecexlm/java-stellar-anchor-sdk"
 }
 
 variable "aws_account" {

--- a/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
+++ b/docs/resources/deployment-examples/example-fargate/terraform/variables.tf
@@ -55,7 +55,7 @@ variable "codebuild_source_version" {
 
 variable "anchor_config_repository" {
   type = string
-  default = "https://github.com/reecexlm/java-stellar-anchor-sdk"
+  default = "https://github.com/reecexlm/anchor-platform"
 }
 
 variable "aws_account" {

--- a/docs/resources/deployment-examples/example-k8s/anchor-platform-dev/readme.md
+++ b/docs/resources/deployment-examples/example-k8s/anchor-platform-dev/readme.md
@@ -2,13 +2,13 @@
 This directory contains the Kubernetes manifests used to deploy SDF-hosted reference implementation of the Anchor Platform together with a sample Receiving Anchor Application.  
 
 This includes:
-- [reference-server](https://github.com/stellar/java-stellar-anchor-sdk/tree/main/anchor-reference-server) [config-map](reference-server-config-map.yaml), [deployment](reference-server-deployment.yaml), [ingress](reference-server-ingress.yaml), and [service](reference-server-service.yaml) manifests for an sample Receiving Anchor application integrated with the deployed Anchor Platform.
+- [reference-server](https://github.com/stellar/anchor-platform/tree/main/anchor-reference-server) [config-map](reference-server-config-map.yaml), [deployment](reference-server-deployment.yaml), [ingress](reference-server-ingress.yaml), and [service](reference-server-service.yaml) manifests for an sample Receiving Anchor application integrated with the deployed Anchor Platform.
 
-- [Anchor Platform SEP Server](https://github.com/stellar/java-stellar-anchor-sdk/tree/main/core) [config-map](sep-server-config-map.yaml), [deployment](sep-server-deployment.yaml), [ingress](sep-server-ingress.yaml) and [service](sep-server-service.yaml) manifests. 
+- [Anchor Platform SEP Server](https://github.com/stellar/anchor-platform/tree/main/core) [config-map](sep-server-config-map.yaml), [deployment](sep-server-deployment.yaml), [ingress](sep-server-ingress.yaml) and [service](sep-server-service.yaml) manifests. 
 - Kafka [service](zookeeper-kafka-deployment.yaml) deployed for event publishing between Anchor Platform and Reference Server for end-end testing.
 
 # Validation Testing
-- [Anchor Validator](https://anchor-tests.stellar.org/) - You can run the Stellar Validation Test Suite against this deployment using the SDF Anchor Validation. Use HOME DOMAIN set to `https://anchor-sep-server-dev.stellar.org` and [sample config](https://github.com/stellar/java-stellar-anchor-sdk/blob/d972f7142fbfd3ca3ade3ea3b8edeacf1591ef11/platform/src/test/resources/stellar-anchor-tests-sep-config.json) to upload.
+- [Anchor Validator](https://anchor-tests.stellar.org/) - You can run the Stellar Validation Test Suite against this deployment using the SDF Anchor Validation. Use HOME DOMAIN set to `https://anchor-sep-server-dev.stellar.org` and [sample config](https://github.com/stellar/anchor-platform/blob/d972f7142fbfd3ca3ade3ea3b8edeacf1591ef11/platform/src/test/resources/stellar-anchor-tests-sep-config.json) to upload.
 - [Demo Wallet](https://demo-wallet.stellar.org/) - The Stellar Demo Wallet can also be used to test end-end Anchor Platform Processing.  
   
 

--- a/helm-charts/reference-server/Chart.yaml
+++ b/helm-charts/reference-server/Chart.yaml
@@ -5,6 +5,6 @@ maintainers:
   - name: Philip Liu
     email: philip.liu@stellar.org
 sources:
-  - "https://github.com/stellar/java-stellar-anchor-sdk"
+  - "https://github.com/stellar/anchor-platform"
 name: ap-reference-server
 version: 0.1.0

--- a/helm-charts/secret-store/Chart.yaml
+++ b/helm-charts/secret-store/Chart.yaml
@@ -5,6 +5,6 @@ maintainers:
   - name: Philip Liu
     email: philip.liu@stellar.org
 sources:
-  - "https//github.com/stellar/java-stellar-anchor-sdk"
+  - "https//github.com/stellar/anchor-platform"
 name: ap-secret-store
 version: 0.1.0

--- a/helm-charts/sep-service/Chart.yaml
+++ b/helm-charts/sep-service/Chart.yaml
@@ -5,6 +5,6 @@ maintainers:
   - name: Philip Liu
     email: philip.liu@stellar.org
 sources:
-  - https://github.com/stellar/java-stellar-anchor-sdk
+  - https://github.com/stellar/anchor-platform
 name: sep
 version: 1.0.0

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
@@ -332,7 +332,7 @@ public class StellarPaymentObserver implements HealthCheckable {
     // Fetch the latest cursor from the stellar network
     Page<OperationResponse> pageOpResponse;
     try {
-      infoF("Fetching  the latest payments records. (limit={})", MIN_RESULTS);
+      infoF("Fetching the latest payments records. (limit={})", MIN_RESULTS);
       pageOpResponse =
           server.payments().order(RequestBuilder.Order.DESC).limit(MIN_RESULTS).execute();
     } catch (NetworkException e) {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
@@ -332,7 +332,7 @@ public class StellarPaymentObserver implements HealthCheckable {
     // Fetch the latest cursor from the stellar network
     Page<OperationResponse> pageOpResponse;
     try {
-      infoF("Fetching the latest payments records. (limit={})", MIN_RESULTS);
+      infoF("Fetching  the latest payments records. (limit={})", MIN_RESULTS);
       pageOpResponse =
           server.payments().order(RequestBuilder.Order.DESC).limit(MIN_RESULTS).execute();
     } catch (NetworkException e) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "java-stellar-anchor-sdk"
+rootProject.name = "anchor-platform"
 
 /** APIs and Schemas */
 include("api-schema")


### PR DESCRIPTION
### Description

Replace java-stellar-anchor-sdk with anchor-platform

### Context

Code base maintenance. 

### Testing

- `./gradlew test`

### Documentation

NA

### Known limitations

NA

