### PR TITLE
Use upload-artifact@v4 action in GHA workflows

### DIFF
--- a/.github/workflows/sub_essential_tests.yml
+++ b/.github/workflows/sub_essential_tests.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Download anchor-platform.tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: anchor-platform-tar
           path: /home/runner/
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload Essential Tests report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: essential-tests-report
           path: |

--- a/.github/workflows/sub_extended_tests.yml
+++ b/.github/workflows/sub_extended_tests.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Download anchor-platform.tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: anchor-platform-tar
           path: /home/runner/
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload Extended Tests Report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: extended-tests-report
           path: |

--- a/.github/workflows/sub_gradle_build.yml
+++ b/.github/workflows/sub_gradle_build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload anchor-platform.tar to GitHub Artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: anchor-platform-tar
           path: |

--- a/.github/workflows/sub_jacoco_report.yml
+++ b/.github/workflows/sub_jacoco_report.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Download anchor-platform.tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: anchor-platform-tar
           path: /home/runner/
@@ -52,7 +52,7 @@ jobs:
 
       #############################################
       - name: Gradle Build with unit tests only
-        if : ${{ inputs.forceRebuild }}
+        if: ${{ inputs.forceRebuild }}
         run: |
           cd /home/runner/anchor-platform
           ./gradlew clean build jacocoTestReport -x essential-tests:test -x extended-tests:test


### PR DESCRIPTION
### Description

This updates the `upload-artifact` and `download-artifact` versions to v4.

### Context

v3 is deprecated and blocking CI runs.

### Testing

- `./gradlew test`
 
### Documentation

N/A

### Known limitations

N/A

