### PR TITLE
[ANCHOR-768]  Implement SEP-6 withdraw flows for contract accounts 

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6TransactionStore.java
@@ -29,4 +29,7 @@ public interface Sep6TransactionStore {
 
   Sep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
+
+  Sep6Transaction findOneByWithdrawAnchorAccountAndFromAccountAndStatus(
+      String withdrawAnchorAccount, String fromAccount, String status);
 }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -485,12 +485,12 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
 
     waitStatus(withdraw.id, COMPLETED, sep6Client)
 
-    val completedDepositTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id))
+    val completedWithdrawTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id))
     val transactionByStellarId: GetTransactionResponse =
       sep6Client.getTransaction(
-        mapOf("stellar_transaction_id" to completedDepositTxn.transaction.stellarTransactionId)
+        mapOf("stellar_transaction_id" to completedWithdrawTxn.transaction.stellarTransactionId)
       )
-    assertEquals(completedDepositTxn.transaction.id, transactionByStellarId.transaction.id)
+    assertEquals(completedWithdrawTxn.transaction.id, transactionByStellarId.transaction.id)
   }
 
   @Test
@@ -636,12 +636,12 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
 
     waitStatus(withdraw.id, COMPLETED, sep6Client)
 
-    val completedDepositTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id))
+    val completedWithdrawTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id))
     val transactionByStellarId: GetTransactionResponse =
       sep6Client.getTransaction(
-        mapOf("stellar_transaction_id" to completedDepositTxn.transaction.stellarTransactionId)
+        mapOf("stellar_transaction_id" to completedWithdrawTxn.transaction.stellarTransactionId)
       )
-    assertEquals(completedDepositTxn.transaction.id, transactionByStellarId.transaction.id)
+    assertEquals(completedWithdrawTxn.transaction.id, transactionByStellarId.transaction.id)
   }
 
   private suspend fun assertWalletReceivedStatuses(

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep6End2EndTest.kt
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.e2etest
 
 import io.ktor.http.*
+import java.math.BigInteger
 import java.net.URI
 import kotlin.test.DefaultAsserter.fail
 import kotlin.test.assertEquals
@@ -26,7 +27,14 @@ import org.stellar.anchor.platform.TestConfig
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.anchor.util.Log
 import org.stellar.reference.wallet.WalletServerClient
-import org.stellar.sdk.SorobanServer
+import org.stellar.sdk.*
+import org.stellar.sdk.AbstractTransaction.MIN_BASE_FEE
+import org.stellar.sdk.Auth.authorizeEntry
+import org.stellar.sdk.operations.InvokeHostFunctionOperation
+import org.stellar.sdk.scval.Scv
+import org.stellar.sdk.xdr.SCVal
+import org.stellar.sdk.xdr.SCValType
+import org.stellar.sdk.xdr.SorobanAuthorizationEntry
 import org.stellar.walletsdk.anchor.MemoType
 import org.stellar.walletsdk.anchor.auth
 import org.stellar.walletsdk.anchor.customer
@@ -37,6 +45,7 @@ import org.stellar.walletsdk.horizon.sign
 open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
   private val maxTries = 30
   private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
+  private val rpc = SorobanServer("https://soroban-testnet.stellar.org")
   private val gson = GsonUtils.getInstance()
 
   companion object {
@@ -147,11 +156,7 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val homeDomain = "http://${URI.create(webAuthDomain).authority}"
 
     val sep45Client =
-      Sep45Client(
-        toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT"),
-        SorobanServer("https://soroban-testnet.stellar.org"),
-        CLIENT_WALLET_SECRET,
-      )
+      Sep45Client(toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT"), rpc, CLIENT_WALLET_SECRET)
     val challenge =
       sep45Client.getChallenge(
         ChallengeRequest.builder()
@@ -292,11 +297,7 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     val homeDomain = "http://${URI.create(webAuthDomain).authority}"
 
     val sep45Client =
-      Sep45Client(
-        toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT"),
-        SorobanServer("https://soroban-testnet.stellar.org"),
-        CLIENT_WALLET_SECRET,
-      )
+      Sep45Client(toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT"), rpc, CLIENT_WALLET_SECRET)
     val challenge =
       sep45Client.getChallenge(
         ChallengeRequest.builder()
@@ -423,6 +424,76 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
   }
 
   @Test
+  fun `test typical withdraw to contract account end-to-end`() = runBlocking {
+    val webAuthDomain = toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT")
+    val homeDomain = "http://${URI.create(webAuthDomain).authority}"
+
+    val sep45Client =
+      Sep45Client(toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT"), rpc, CLIENT_WALLET_SECRET)
+    val challenge =
+      sep45Client.getChallenge(
+        ChallengeRequest.builder()
+          .account(CLIENT_SMART_WALLET_ACCOUNT)
+          .homeDomain(homeDomain)
+          .build()
+      )
+    val token = sep45Client.validate(sep45Client.sign(challenge)).token
+    val sep12Client = Sep12Client(toml.getString("KYC_SERVER"), token)
+    val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token)
+
+    val customerRequest =
+      gson.fromJson(
+        gson.toJson(basicInfoFields.associateWith { customerInfo[it]!! }),
+        Sep12PutCustomerRequest::class.java,
+      )
+    val customer = sep12Client.putCustomer(customerRequest)!!
+
+    val withdraw =
+      sep6Client.withdraw(
+        mapOf("asset_code" to USDC.code, "amount" to "1", "type" to "bank_account")
+      )
+    Log.info("Withdrawal initiated: ${withdraw.id}")
+
+    val additionalRequiredFields =
+      sep12Client
+        .getCustomer(customer.id, "sep-6", withdraw.id)!!
+        .fields
+        ?.filter { it.key != null && it.value?.optional == false }
+        ?.map { it.key!! }
+        .orEmpty()
+    val additionalCustomerRequest =
+      gson.fromJson(
+        gson.toJson(additionalRequiredFields.associateWith { customerInfo[it]!! }),
+        Sep12PutCustomerRequest::class.java,
+      )
+    sep12Client.putCustomer(additionalCustomerRequest)
+    Log.info("Submitted additional KYC info: $additionalRequiredFields")
+
+    waitStatus(withdraw.id, PENDING_USR_TRANSFER_START, sep6Client)
+
+    val withdrawTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction
+
+    val txHash =
+      transferFunds(
+        CLIENT_SMART_WALLET_ACCOUNT,
+        withdrawTxn.withdrawAnchorAccount,
+        Asset.create(USDC.id),
+        "1",
+        walletKeyPair.keyPair,
+      )
+    Log.info("Transfer complete: $txHash")
+
+    waitStatus(withdraw.id, COMPLETED, sep6Client)
+
+    val completedDepositTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id))
+    val transactionByStellarId: GetTransactionResponse =
+      sep6Client.getTransaction(
+        mapOf("stellar_transaction_id" to completedDepositTxn.transaction.stellarTransactionId)
+      )
+    assertEquals(completedDepositTxn.transaction.id, transactionByStellarId.transaction.id)
+  }
+
+  @Test
   fun `test typical withdraw-exchange without quote end-to-end flow`() = runBlocking {
     val memo = (50000..60000).random().toULong()
     val token = anchor.auth().authenticate(walletKeyPair, memoId = memo)
@@ -497,6 +568,82 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
     assertWalletReceivedCustomerStatuses(customer.id, expectedCustomerStatuses)
   }
 
+  @Test
+  fun `test withdraw-exchange to contract account end-to-end`() = runBlocking {
+    val webAuthDomain = toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT")
+    val homeDomain = "http://${URI.create(webAuthDomain).authority}"
+
+    val sep45Client =
+      Sep45Client(toml.getString("WEB_AUTH_FOR_CONTRACTS_ENDPOINT"), rpc, CLIENT_WALLET_SECRET)
+    val challenge =
+      sep45Client.getChallenge(
+        ChallengeRequest.builder()
+          .account(CLIENT_SMART_WALLET_ACCOUNT)
+          .homeDomain(homeDomain)
+          .build()
+      )
+    val token = sep45Client.validate(sep45Client.sign(challenge)).token
+    val sep12Client = Sep12Client(toml.getString("KYC_SERVER"), token)
+    val sep6Client = Sep6Client("${config.env["anchor.domain"]}/sep6", token)
+
+    val customerRequest =
+      gson.fromJson(
+        gson.toJson(basicInfoFields.associateWith { customerInfo[it]!! }),
+        Sep12PutCustomerRequest::class.java,
+      )
+    val customer = sep12Client.putCustomer(customerRequest)!!
+
+    val withdraw =
+      sep6Client.withdraw(
+        mapOf(
+          "destination_asset" to "iso4217:CAD",
+          "source_asset" to USDC.code,
+          "amount" to "1",
+          "type" to "bank_account",
+        ),
+        exchange = true,
+      )
+    Log.info("Withdrawal initiated: ${withdraw.id}")
+
+    val additionalRequiredFields =
+      sep12Client
+        .getCustomer(customer.id, "sep-6", withdraw.id)!!
+        .fields
+        ?.filter { it.key != null && it.value?.optional == false }
+        ?.map { it.key!! }
+        .orEmpty()
+    val additionalCustomerRequest =
+      gson.fromJson(
+        gson.toJson(additionalRequiredFields.associateWith { customerInfo[it]!! }),
+        Sep12PutCustomerRequest::class.java,
+      )
+    sep12Client.putCustomer(additionalCustomerRequest)
+    Log.info("Submitted additional KYC info: $additionalRequiredFields")
+
+    waitStatus(withdraw.id, PENDING_USR_TRANSFER_START, sep6Client)
+
+    val withdrawTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id)).transaction
+
+    val txHash =
+      transferFunds(
+        CLIENT_SMART_WALLET_ACCOUNT,
+        withdrawTxn.withdrawAnchorAccount,
+        Asset.create(USDC.id),
+        "1",
+        walletKeyPair.keyPair,
+      )
+    Log.info("Transfer complete: $txHash")
+
+    waitStatus(withdraw.id, COMPLETED, sep6Client)
+
+    val completedDepositTxn = sep6Client.getTransaction(mapOf("id" to withdraw.id))
+    val transactionByStellarId: GetTransactionResponse =
+      sep6Client.getTransaction(
+        mapOf("stellar_transaction_id" to completedDepositTxn.transaction.stellarTransactionId)
+      )
+    assertEquals(completedDepositTxn.transaction.id, transactionByStellarId.transaction.id)
+  }
+
   private suspend fun assertWalletReceivedStatuses(
     txnId: String,
     expected: List<SepTransactionStatus>,
@@ -541,5 +688,83 @@ open class Sep6End2EndTest : AbstractIntegrationTests(TestConfig()) {
       delay(1.seconds)
     }
     fail("Transaction status $status did not match expected status $expectedStatus")
+  }
+
+  private fun transferFunds(
+    source: String,
+    destination: String,
+    asset: Asset,
+    amount: String,
+    signer: KeyPair,
+  ): String {
+    val parameters =
+      mutableListOf(
+        // from=
+        SCVal.builder()
+          .discriminant(SCValType.SCV_ADDRESS)
+          .address(Scv.toAddress(source).address)
+          .build(),
+        // to=
+        SCVal.builder()
+          .discriminant(SCValType.SCV_ADDRESS)
+          .address(Scv.toAddress(destination).address)
+          .build(),
+        SCVal.builder()
+          .discriminant(SCValType.SCV_I128)
+          .i128(Scv.toInt128(BigInteger.valueOf(amount.toLong() * 10000000)).i128)
+          .build(),
+      )
+    val operation =
+      InvokeHostFunctionOperation.invokeContractFunctionOperationBuilder(
+          asset.getContractId(Network.TESTNET),
+          "transfer",
+          parameters,
+        )
+        .build()
+
+    var account = rpc.getAccount(walletKeyPair.keyPair.accountId)
+    val transaction =
+      TransactionBuilder(account, Network.TESTNET)
+        .addOperation(operation)
+        .setBaseFee(MIN_BASE_FEE)
+        .setTimeout(300)
+        .build()
+
+    val simulationResponse = rpc.simulateTransaction(transaction)
+    val signedAuthEntries = mutableListOf<SorobanAuthorizationEntry>()
+    simulationResponse.results.forEach {
+      it.auth.forEach { entryXdr ->
+        val entry = SorobanAuthorizationEntry.fromXdrBase64(entryXdr)
+        val validUntilLedgerSeq = simulationResponse.latestLedger + 10
+
+        val signedEntry = authorizeEntry(entry, signer, validUntilLedgerSeq, Network.TESTNET)
+        signedAuthEntries.add(signedEntry)
+      }
+    }
+
+    val signedOperation =
+      InvokeHostFunctionOperation.invokeContractFunctionOperationBuilder(
+          asset.getContractId(Network.TESTNET),
+          "transfer",
+          parameters,
+        )
+        .sourceAccount(walletKeyPair.keyPair.accountId)
+        .auth(signedAuthEntries)
+        .build()
+
+    account = rpc.getAccount(walletKeyPair.keyPair.accountId)
+    val authorizedTransaction =
+      TransactionBuilder(account, Network.TESTNET)
+        .addOperation(signedOperation)
+        .setBaseFee(Transaction.MIN_BASE_FEE)
+        .setTimeout(300)
+        .build()
+
+    val preparedTransaction = rpc.prepareTransaction(authorizedTransaction)
+    preparedTransaction.sign(signer)
+
+    val transactionResponse = rpc.sendTransaction(preparedTransaction)
+
+    return transactionResponse.hash
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -25,6 +25,9 @@ public interface JdbcSep6TransactionRepo
   JdbcSep6Transaction findOneByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
+  JdbcSep6Transaction findOneByWithdrawAnchorAccountAndFromAccountAndStatus(
+      String withdrawAnchorAccount, String fromAccount, String status);
+
   List<Sep6Transaction> findBySep10AccountAndRequestAssetCodeOrderByStartedAtDesc(
       String sep10Account, String requestAssetCode);
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionStore.java
@@ -128,4 +128,11 @@ public class JdbcSep6TransactionStore implements Sep6TransactionStore {
     return transactionRepo.findOneByWithdrawAnchorAccountAndMemoAndStatus(
         withdrawAnchorAccount, memo, status);
   }
+
+  @Override
+  public JdbcSep6Transaction findOneByWithdrawAnchorAccountAndFromAccountAndStatus(
+      String withdrawAnchorAccount, String fromAccount, String status) {
+    return transactionRepo.findOneByWithdrawAnchorAccountAndFromAccountAndStatus(
+        withdrawAnchorAccount, fromAccount, status);
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -46,11 +46,27 @@ public class PaymentOperationToEventListener implements PaymentListener {
 
   @Override
   public void onReceived(ObservedPayment payment) throws IOException {
-    // Check if payment is connected to a transaction
-    if (Objects.toString(payment.getTransactionHash(), "").isEmpty()
-        || Objects.toString(payment.getTransactionMemo(), "").isEmpty()) {
-      traceF("Ignore the payment {} is not connected to a transaction.", payment.getId());
-      return;
+    String memo = null;
+    String memoType;
+    if (!payment.getType().equals(ObservedPayment.Type.SAC_TRANSFER)) {
+      if (Objects.toString(payment.getTransactionHash(), "").isEmpty()
+          || Objects.toString(payment.getTransactionMemo(), "").isEmpty()) {
+        traceF("Ignore the payment {} is not connected to a transaction.", payment.getId());
+        return;
+      }
+
+      // Parse memo
+      memo = payment.getTransactionMemo();
+      memoType = payment.getTransactionMemoType();
+      if (memoType.equals(MemoHelper.memoTypeAsString(MemoType.MEMO_HASH))) {
+        try {
+          memo = MemoHelper.convertHexToBase64(payment.getTransactionMemo());
+        } catch (DecoderException ex) {
+          infoF(
+              "The memo type is \"hash\" but the memo string {} could not be parsed as such.",
+              memo);
+        }
+      }
     }
 
     // Check if the payment contains the expected asset type
@@ -59,18 +75,6 @@ public class PaymentOperationToEventListener implements PaymentListener {
       // Asset type does not match
       debugF("{} is not an issued asset.", payment.getAssetType());
       return;
-    }
-
-    // Parse memo
-    String memo = payment.getTransactionMemo();
-    String memoType = payment.getTransactionMemoType();
-    if (memoType.equals(MemoHelper.memoTypeAsString(MemoType.MEMO_HASH))) {
-      try {
-        memo = MemoHelper.convertHexToBase64(payment.getTransactionMemo());
-      } catch (DecoderException ex) {
-        infoF(
-            "The memo type is \"hash\" but the memo string {} could not be parsed as such.", memo);
-      }
     }
 
     // Find a transaction matching the memo, assumes transactions are unique to account+memo
@@ -115,9 +119,19 @@ public class PaymentOperationToEventListener implements PaymentListener {
     // Find a transaction matching the memo, assumes transactions are unique to account+memo
     JdbcSep6Transaction sep6Txn = null;
     try {
-      sep6Txn =
-          sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
-              payment.getTo(), memo, SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+      if (memo != null) {
+        sep6Txn =
+            sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(
+                payment.getTo(), memo, SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+      } else {
+        // SAC transfers do not include a memo so we need to find the transaction by the
+        // from_account
+        sep6Txn =
+            sep6TransactionStore.findOneByWithdrawAnchorAccountAndFromAccountAndStatus(
+                payment.getTo(),
+                payment.getFrom(),
+                SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+      }
     } catch (Exception ex) {
       errorEx(ex);
     }


### PR DESCRIPTION
### Description

This implements SEP-6 withdraw + withdraw exchange flows for contract accounts. The main change is to allow contract accounts as source and destination accounts for SEP-6 withdraw requests. The bulk of this PR is adding test code.

### Context

Contract account support

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

SEP-45 does not support memos so we cannot create a new customer every time the test is run. Therefore, we cannot assert on the intermediate PENDING_CUSTOMER_INFO_UPDATE status since a previous run may have already created a customer with enough KYC.

