### PR TITLE
[PD] Fix ingress host key mismatch between local and kube

### DIFF
--- a/helm-charts/reference-server/templates/ingress.yaml
+++ b/helm-charts/reference-server/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    - host: {{ .Values.ingress.rules.host }}
       http:
         paths:
           - path: /

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -31,7 +31,8 @@ services:
           cpu: 1
 ingress:
   name: ingress-reference-server
-  host: reference-server.local
+  rules:
+    host: reference-server.local
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /

--- a/helm-charts/sep24-reference-ui/templates/ingress.yaml
+++ b/helm-charts/sep24-reference-ui/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    - host: {{ .Values.ingress.rules.host }}
       http:
         paths:
           - path: /

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -26,7 +26,8 @@ services:
           cpu: 1
 ingress:
   name: ingress-sep24-reference-ui
-  host: sep24-reference-ui.local
+  rules:
+    host: sep24-reference-ui.local
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /


### PR DESCRIPTION
### Description

Match the ingress host key between local and kube

### Context

Ingress host is defined with key `ingress.host` in local value file, and this is different from `ingress.rules.host` in Kube, resulting ingress host value might not be properly overwritten

### Testing

- Tested with minikube evrything works locallly.