### PR TITLE
[PD] Remove configmap annotation

### DIFF
--- a/helm-charts/sep24-reference-ui/templates/ingress.yaml
+++ b/helm-charts/sep24-reference-ui/templates/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ .Values.ingress.name }}
   namespace: {{ .Values.namespace }}
   annotations:
-    {{- $annotations := dict "nginx.ingress.kubernetes.io/custom-headers" (printf "%s/%s-configmap" .Values.namespace .Values.ingress.name) }}
     {{- if .Values.ingress.annotations }}
       {{- $annotations = merge $annotations .Values.ingress.annotations }}
     {{- end }}


### PR DESCRIPTION
### Description

configmap has been removed for sep24-reference-ui, thus removing corresponding annotation
`nginx.ingress.kubernetes.io/custom-headers: anchor-platform-dev/sep24-reference-ui-configmap`

