### PR TITLE
[ANCHOR-955] Add SEP-45 config validation

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -73,9 +73,8 @@ public class SepBeans {
 
   @Bean
   @ConfigurationProperties(prefix = "sep45")
-  Sep45Config sep45Config(
-      AppConfig appConfig, SecretConfig secretConfig, ClientService clientService) {
-    return new PropertySep45Config(appConfig, clientService, secretConfig);
+  Sep45Config sep45Config(AppConfig appConfig, SecretConfig secretConfig) {
+    return new PropertySep45Config(appConfig, secretConfig);
   }
 
   /**

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySecretConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySecretConfig.java
@@ -1,9 +1,16 @@
 package org.stellar.anchor.platform.config;
 
+import static org.stellar.anchor.util.StringHelper.isEmpty;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.platform.configurator.SecretManager;
+import org.stellar.anchor.util.KeyUtil;
+import org.stellar.sdk.KeyPair;
 
-public class PropertySecretConfig implements SecretConfig {
+public class PropertySecretConfig implements SecretConfig, Validator {
 
   public static final String SECRET_SEP_6_MORE_INFO_URL_JWT_SECRET =
       "secret.sep6.more_info_url.jwt_secret";
@@ -86,5 +93,28 @@ public class PropertySecretConfig implements SecretConfig {
   @Override
   public String getEventsQueueKafkaPassword() {
     return SecretManager.getInstance().get(SECRET_EVENTS_QUEUE_KAFKA_PASSWORD);
+  }
+
+  @Override
+  public boolean supports(@NotNull Class<?> clazz) {
+    return PropertySecretConfig.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(@NotNull Object target, @NotNull Errors errors) {
+    PropertySecretConfig config = (PropertySecretConfig) target;
+
+    if (!isEmpty(config.getSep45JwtSecretKey())) {
+      KeyUtil.rejectWeakJWTSecret(config.getSep45JwtSecretKey(), errors, "secret.sep45.jwt_secret");
+    }
+
+    if (!isEmpty(config.getSep45SimulatingSigningSeed())) {
+      try {
+        KeyPair.fromSecretSeed(config.getSep45SimulatingSigningSeed());
+      } catch (Throwable ex) {
+        errors.reject(
+            "sep45-simulating-seed-invalid", "The secret.sep45.simulating_seed is not valid.");
+      }
+    }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java
@@ -1,36 +1,34 @@
 package org.stellar.anchor.platform.config;
 
 import static org.stellar.anchor.util.StringHelper.isEmpty;
+import static org.stellar.anchor.util.StringHelper.isNotEmpty;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Data;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
-import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.config.Sep45Config;
-import org.stellar.anchor.util.KeyUtil;
+import org.stellar.anchor.util.NetUtil;
+import org.stellar.sdk.Address;
+import org.stellar.sdk.scval.Scv;
 
-// TODO(philip): Improve configuration validation
 @Data
 public class PropertySep45Config implements Sep45Config, Validator {
   private Boolean enabled;
   private String webAuthDomain;
   private String webAuthContractId;
   private List<String> homeDomains;
-  private Integer jwtTimeout =
-      86400; // TODO: this is hardcoded in SEP-10 as well, it should configurable
+  private Integer jwtTimeout;
+  private Integer authTimeout;
   private AppConfig appConfig;
-  private ClientService clientService;
   private SecretConfig secretConfig;
 
-  public PropertySep45Config(
-      AppConfig appConfig, ClientService clientService, SecretConfig secretConfig) {
+  public PropertySep45Config(AppConfig appConfig, SecretConfig secretConfig) {
     this.appConfig = appConfig;
-    this.clientService = clientService;
     this.secretConfig = secretConfig;
   }
 
@@ -55,9 +53,15 @@ public class PropertySep45Config implements Sep45Config, Validator {
       return;
     }
 
+    if (isEmpty(appConfig.getRpcUrl())) {
+      errors.reject(
+          "stellar-network-rpc-url-empty",
+          "The stellar_network.rpc_url is not defined. It is required for SEP-45.");
+    }
+
     if (isEmpty(secretConfig.getSep45SimulatingSigningSeed())) {
       errors.reject(
-          "sep45-simulating-signing-seed-empty",
+          "sep45-simulating-seed-empty",
           "Please set the secret.sep45.simulating_signing_seed or SECRET_SEP45_SIMULATING_SIGNING_SEED environment variable");
     }
 
@@ -67,13 +71,56 @@ public class PropertySep45Config implements Sep45Config, Validator {
           "Please set the secret.sep45.jwt_secret or SECRET_SEP45_JWT_SECRET environment variable");
     }
 
-    KeyUtil.rejectWeakJWTSecret(
-        secretConfig.getSep45JwtSecretKey(), errors, "secret.sep45.jwt_secret");
-
     if (homeDomains == null || homeDomains.isEmpty()) {
       errors.reject(
           "sep45-home-domains-empty",
           "Please set the sep45.home_domains or SEP45_HOME_DOMAINS environment variable");
+    } else {
+      for (String domain : homeDomains) {
+        if (!NetUtil.isServerPortValid(domain, false)) {
+          errors.rejectValue(
+              "homeDomain",
+              "sep45-home-domain-invalid",
+              "The sep45.home_domain does not have valid format.");
+        }
+      }
+    }
+
+    if (isEmpty(webAuthContractId)) {
+      errors.reject(
+          "sep45-web-auth-contract-id-empty",
+          "Please set the sep45.web_auth_contract_id or SEP45_WEB_AUTH_CONTRACT_ID environment variable");
+    } else {
+      try {
+        Address.fromSCAddress(Scv.fromAddress(Scv.toAddress(webAuthContractId)).toSCAddress());
+      } catch (RuntimeException ex) {
+        errors.reject(
+            "sep45-web-auth-contract-id-invalid",
+            "The sep45.web_auth_contract_id does not have valid format.");
+      }
+    }
+
+    if (isNotEmpty(webAuthDomain)) {
+      if (!NetUtil.isServerPortValid(webAuthDomain, false)) {
+        errors.reject(
+            "sep45-home-domain-invalid", "The sep45.home_domain does not have valid format.");
+      }
+    } else if (homeDomains != null
+        && !homeDomains.isEmpty()
+        && (homeDomains.size() > 1 || homeDomains.get(0).contains("*"))) {
+      errors.rejectValue(
+          "sep45-web-auth-domain-empty",
+          "The sep45.web_auth_domain is required for multiple home domains.");
+    }
+
+    if (jwtTimeout <= 0) {
+      errors.rejectValue(
+          "sep45-jwt-timeout-invalid", "The sep45.jwt_timeout must be greater than 0");
+    }
+
+    if (authTimeout <= 0) {
+      errors.rejectValue(
+          "sep45-auth-timeout-invalid", "The sep45.auth_timeout must be greater than 0");
     }
   }
 }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -417,13 +417,46 @@ sep38:
   sep10_enforced: false
 
 ######################
-# SEP-45 Configuration (TODO(philip): to be updated)
+# SEP-45 Configuration
 ######################
 sep45:
+  # Whether to enable SEP-45
+  # If `enabled` is set to True, the following two secrets must be set via the environment
+  # variables and `stellar_network.rpc_url` must be set.
+  # `secret.sep45_jwt_secret`: The JWT encryption key.
+  # `secret.sep45_simulating_signing_seed`: The private key for signing transactions for simulation.
+  #
   enabled: false
+  # The `web_auth_domain` property of SEP-45. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md
+  # The `web_auth_domain` is optional and will be set to the value of the `home_domains` if "home_domains" can only be translated to one domain.
+  # 1) web_auth_domain is optional:
+  #    Ex: home_domains: ap.stellar.org
+  # 2) web_auth_domain is required:
+  #    Ex: home_domains: ap.stellar.org, sdp.stellar.org
+  #    Ex: home_domains: *.sdp.stellar.org
+  #
   web_auth_domain:
+  # The contract address of a SEP-45 web auth contract. https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md#web-authentication-contract
+  # This is the contract the server will use to authenticate the client and is required.
+  #
   web_auth_contract_id:
+  # The `home_domains` property of SEP-45. This is a list of domains and/or wildcard patterns that the client can use to authenticate.
+  # https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0045.md
+  # Please also set web_auth_domain if you have more than one home domain in this list.
+  # The following lists are examples:
+  # Ex: home_domains: [ap.stellar.org, *.sdp.stellar.org]
+  # Ex: home_domains: ap.stellar.org, *.sdp.stellar.org
+  #
   home_domains: localhost:8080
+  # Set the authentication challenge transaction timeout in seconds. An expired signed transaction will be rejected.
+  # This is the timeout period the client must finish the authentication process. (ie: sign and respond the challenge
+  # transaction).
+  #
+  auth_timeout: 900
+  # Set the timeout in seconds of the authenticated JSON Web Token. An expired JWT will be rejected.
+  # This is the timeout period after the client has authenticated.
+  #
+  jwt_timeout: 86400
 
 ######################
 ## Custody Server configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -106,6 +106,8 @@ sep45.enabled:
 sep45.web_auth_domain:
 sep45.web_auth_contract_id:
 sep45.home_domains:
+sep45.jwt_timeout:
+sep45.auth_timeout:
 sep6.deposit_info_generator_type:
 sep6.enabled:
 sep6.more_info_url.base_url:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/SecretConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/SecretConfigTest.kt
@@ -1,0 +1,67 @@
+package org.stellar.anchor.platform.config
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+import org.stellar.anchor.platform.configurator.SecretManager
+
+class SecretConfigTest {
+  lateinit var config: PropertySecretConfig
+  lateinit var errors: Errors
+  private lateinit var secretManager: SecretManager
+
+  @BeforeEach
+  fun setup() {
+    secretManager = mockk<SecretManager>()
+    mockkStatic(SecretManager::class)
+    every { secretManager.get(any()) } returns null
+    every { SecretManager.getInstance() } returns secretManager
+
+    config = PropertySecretConfig()
+    errors = BindException(config, "config")
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `test weak sep45 jwt secret`() {
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_45_JWT_SECRET) } returns "simple"
+    config.validate(config, errors)
+    assertEquals("hmac-weak-secret", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test valid sep45 jwt secret`() {
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_45_JWT_SECRET) } returns
+      "6a627a7fb025e2c5db643267523a1c801c1178bed30331a2606fe93f4dd9aa7b"
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test bad sep45 simulating seed`() {
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_45_SIMULATING_SIGNING_SEED) } returns
+      "GBAD"
+    config.validate(config, errors)
+    assertEquals("sep45-simulating-seed-invalid", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test valid sep45 simulating seed`() {
+    every { secretManager.get(PropertySecretConfig.SECRET_SEP_45_SIMULATING_SIGNING_SEED) } returns
+      "SDRNY2YXLOGYNN5Z4QNUUH325KVOXOT2HV2XUVIK24AKNBTODZC26C3G"
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep45ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep45ConfigTest.kt
@@ -1,0 +1,108 @@
+package org.stellar.anchor.platform.config
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+import org.stellar.anchor.config.AppConfig
+import org.stellar.anchor.platform.utils.setupMock
+
+class Sep45ConfigTest {
+  lateinit var config: PropertySep45Config
+  lateinit var errors: Errors
+  private lateinit var secretConfig: PropertySecretConfig
+  private lateinit var appConfig: AppConfig
+
+  @BeforeEach
+  fun setup() {
+    secretConfig = mockk()
+    appConfig = mockk()
+
+    every { appConfig.rpcUrl } returns "https://soroban-testnet.stellar.org"
+    every { secretConfig.sep45JwtSecretKey } returns "some_jwt_secret"
+    every { secretConfig.sep45SimulatingSigningSeed } returns "some_signing_seed"
+
+    config = PropertySep45Config(appConfig, secretConfig)
+    config.enabled = true
+    config.webAuthDomain = "stellar.org"
+    config.webAuthContractId = "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX"
+    config.homeDomains = listOf("stellar.org")
+    config.jwtTimeout = 86400
+    config.authTimeout = 900
+    errors = BindException(config, "config")
+    secretConfig.setupMock()
+  }
+
+  @Test
+  fun `test default sep45 config`() {
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["stellar.org", "localhost", "127.0.0.1:80"])
+  fun `test valid home domains`(value: String) {
+    config.webAuthDomain = value
+    config.homeDomains = listOf(value)
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test missing rpc url`() {
+    every { appConfig.rpcUrl } returns null
+    config.validate(config, errors)
+    assertEquals("stellar-network-rpc-url-empty", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test missing sep45 simulating seed`() {
+    every { secretConfig.sep45SimulatingSigningSeed } returns null
+    config.validate(config, errors)
+    assertEquals("sep45-simulating-seed-empty", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test missing sep45 jwt secret key`() {
+    every { secretConfig.sep45JwtSecretKey } returns null
+    config.validate(config, errors)
+    assertEquals("sep45-jwt-secret-empty", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test missing sep45 web auth contract id`() {
+    config.webAuthContractId = null
+    config.validate(config, errors)
+    assertEquals("sep45-web-auth-contract-id-empty", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test invalid sep45 web auth contract id`() {
+    config.webAuthContractId = "CAAABAD"
+    config.validate(config, errors)
+    assertEquals("sep45-web-auth-contract-id-invalid", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test if web_auth_domain is not set, default to the domain of the host_url`() {
+    config.webAuthDomain = null
+    config.homeDomains = listOf("www.stellar.org")
+    config.postConstruct()
+    Assertions.assertEquals("www.stellar.org", config.webAuthDomain)
+  }
+
+  @Test
+  fun `test if web_auth_domain is set, it is not default to the domain of the host_url`() {
+    config.webAuthDomain = "localhost:8080"
+    config.homeDomains = listOf("www.stellar.org")
+    config.postConstruct()
+    Assertions.assertEquals("localhost:8080", config.webAuthDomain)
+  }
+}


### PR DESCRIPTION
### Description

This PR adds SEP-45 configuration validation. I decided to do the secret validation in the secret config implementation. I think it's the best place to implement it. Dependent configs, like SEP-45, should just check that the relevant properties are set. We should refactor the rest of the configuration to follow the same pattern.

### Context

It's currently missing.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

