### PR TITLE
Clean up all instances of `Sep10Jwt`

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -133,14 +133,14 @@ public class Sep10Service implements ISep10Service {
 
     if (account == null) {
       // The account does not exist from Horizon, using the client's master key to verify.
-      return ValidationResponse.of(generateSep10Jwt(challenge, clientDomain, homeDomain));
+      return ValidationResponse.of(generateWebAuthJwt(challenge, clientDomain, homeDomain));
     }
     // Since the account exists, we should check the signers and the client domain
     validateChallengeRequest(request, account, clientDomain);
     // increment counter
     incrementValidationRequestValidatedCounter();
     // Generate the JWT token
-    return ValidationResponse.of(generateSep10Jwt(challenge, clientDomain, homeDomain));
+    return ValidationResponse.of(generateWebAuthJwt(challenge, clientDomain, homeDomain));
   }
 
   @Override
@@ -527,10 +527,11 @@ public class Sep10Service implements ISep10Service {
     return challenge;
   }
 
-  String generateSep10Jwt(ChallengeTransaction challenge, String clientDomain, String homeDomain) {
+  String generateWebAuthJwt(
+      ChallengeTransaction challenge, String clientDomain, String homeDomain) {
     long issuedAt = challenge.getTransaction().getTimeBounds().getMinTime().longValue();
     Memo memo = challenge.getTransaction().getMemo();
-    WebAuthJwt sep10Jwt =
+    WebAuthJwt webAuthJwt =
         WebAuthJwt.of(
             authUrl(),
             (memo == null || memo instanceof MemoNone)
@@ -541,8 +542,8 @@ public class Sep10Service implements ISep10Service {
             challenge.getTransaction().hashHex(),
             clientDomain,
             homeDomain);
-    debug("jwtToken:", sep10Jwt);
-    return jwtService.encode(sep10Jwt);
+    debug("jwtToken:", webAuthJwt);
+    return jwtService.encode(webAuthJwt);
   }
 
   private String authUrl() {

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -126,25 +126,25 @@ public class Sep12Service {
     return Sep12PutCustomerResponse.builder().id(updatedCustomer.getId()).build();
   }
 
-  public void deleteCustomer(WebAuthJwt sep10Jwt, String account, String memo, String memoType)
+  public void deleteCustomer(WebAuthJwt token, String account, String memo, String memoType)
       throws AnchorException {
     boolean isAccountAuthenticated =
-        Stream.of(sep10Jwt.getAccount(), sep10Jwt.getMuxedAccount())
+        Stream.of(token.getAccount(), token.getMuxedAccount())
             .filter(Objects::nonNull)
             .anyMatch(tokenAccount -> Objects.equals(tokenAccount, account));
 
     boolean isMemoMissingAuthentication = false;
-    String muxedAccountId = Objects.toString(sep10Jwt.getMuxedAccountId(), null);
+    String muxedAccountId = Objects.toString(token.getMuxedAccountId(), null);
     if (muxedAccountId != null) {
-      if (!Objects.equals(sep10Jwt.getMuxedAccount(), account)) {
+      if (!Objects.equals(token.getMuxedAccount(), account)) {
         isMemoMissingAuthentication = !Objects.equals(muxedAccountId, memo);
       }
-    } else if (sep10Jwt.getAccountMemo() != null) {
-      isMemoMissingAuthentication = !Objects.equals(sep10Jwt.getAccountMemo(), memo);
+    } else if (token.getAccountMemo() != null) {
+      isMemoMissingAuthentication = !Objects.equals(token.getAccountMemo(), memo);
     }
 
     if (!isAccountAuthenticated || isMemoMissingAuthentication) {
-      infoF("Requester ({}) not authorized to delete account ({})", sep10Jwt.getAccount(), account);
+      infoF("Requester ({}) not authorized to delete account ({})", token.getAccount(), account);
       throw new SepNotAuthorizedException(
           String.format("Not authorized to delete account [%s] with memo [%s]", account, memo));
     }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -100,10 +100,10 @@ public class Sep31Service {
 
   @Transactional(rollbackOn = {AnchorException.class, RuntimeException.class})
   public Sep31PostTransactionResponse postTransaction(
-      WebAuthJwt sep10Jwt, Sep31PostTransactionRequest request) throws AnchorException {
+      WebAuthJwt webAuthJwt, Sep31PostTransactionRequest request) throws AnchorException {
     Context.reset();
     Context.get().setRequest(request);
-    Context.get().setSep10Jwt(sep10Jwt);
+    Context.get().setWebAuthJwt(webAuthJwt);
 
     StellarAssetInfo assetInfo =
         (StellarAssetInfo) assetService.getAsset(request.getAssetCode(), request.getAssetIssuer());
@@ -139,7 +139,8 @@ public class Sep31Service {
      */
     if (request.getFields() == null) {
       infoF(
-          "POST /transaction with id ({}) cannot have empty `fields`", sep10Jwt.getTransactionId());
+          "POST /transaction with id ({}) cannot have empty `fields`",
+          webAuthJwt.getTransactionId());
       throw new BadRequestException("'fields' field cannot be empty");
     }
     Context.get().setTransactionFields(request.getFields().getTransaction());
@@ -154,8 +155,9 @@ public class Sep31Service {
     // Get the creator's stellarId
     StellarId creatorStellarId =
         StellarId.builder()
-            .account(Objects.requireNonNullElse(sep10Jwt.getMuxedAccount(), sep10Jwt.getAccount()))
-            .memo(sep10Jwt.getAccountMemo())
+            .account(
+                Objects.requireNonNullElse(webAuthJwt.getMuxedAccount(), webAuthJwt.getAccount()))
+            .memo(webAuthJwt.getAccountMemo())
             .build();
 
     Sep38Quote quote = Context.get().getQuote();
@@ -184,7 +186,7 @@ public class Sep31Service {
             .externalTransactionId(null)
             .requiredInfoMessage(null)
             .quoteId(request.getQuoteId())
-            .clientDomain(sep10Jwt.getClientDomain())
+            .clientDomain(webAuthJwt.getClientDomain())
             .clientName(getClientName())
             .requiredInfoUpdates(null)
             .fields(request.getFields().getTransaction())
@@ -519,7 +521,7 @@ public class Sep31Service {
   }
 
   String getClientName() throws BadRequestException {
-    return getClientName(Context.get().getSep10Jwt().getAccount());
+    return getClientName(Context.get().getWebAuthJwt().getAccount());
   }
 
   String getClientName(String account) throws BadRequestException {
@@ -590,7 +592,7 @@ public class Sep31Service {
     private Sep31Transaction transaction;
     private Sep31PostTransactionRequest request;
     private Sep38Quote quote;
-    private WebAuthJwt sep10Jwt;
+    private WebAuthJwt webAuthJwt;
     private Amount fee;
     private AssetInfo asset;
     private Map<String, String> transactionFields;

--- a/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
@@ -13,7 +13,7 @@ class TestHelper {
     const val TEST_ACCOUNT = "GBJDSMTMG4YBP27ZILV665XBISBBNRP62YB7WZA2IQX2HIPK7ABLF4C2"
     const val TEST_MEMO = "123456"
 
-    fun createSep10Jwt(
+    fun createWebAuthJwt(
       account: String = TEST_ACCOUNT,
       accountMemo: String? = null,
       hostUrl: String = "",

--- a/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
@@ -37,25 +37,25 @@ internal class JwtServiceTest {
   }
 
   @Test
-  fun `test apply Sep10Jwt encoding and decoding and make sure the original values are not changed`() {
+  fun `test apply WebAuthJwt encoding and decoding and make sure the original values are not changed`() {
     val jwtService = JwtService(secretConfig, custodySecretConfig)
     val token =
       WebAuthJwt.of(TEST_ISS, TEST_SUB, TEST_IAT, TEST_EXP, TEST_JTI, TEST_CLIENT_DOMAIN)
         as WebAuthJwt
     val cipher = jwtService.encode(token)
-    val sep10Jwt = jwtService.decode(cipher, WebAuthJwt::class.java)
+    val webAuthJwt = jwtService.decode(cipher, WebAuthJwt::class.java)
 
-    assertEquals(sep10Jwt.iss, token.iss)
-    assertEquals(sep10Jwt.sub, token.sub)
-    assertEquals(sep10Jwt.iat, token.iat)
-    assertEquals(sep10Jwt.exp, token.exp)
-    assertEquals(sep10Jwt.jti, token.jti)
-    assertEquals(sep10Jwt.clientDomain, token.clientDomain)
-    assertEquals(sep10Jwt.account, token.sub)
-    assertEquals(sep10Jwt.transactionId, token.jti)
-    assertEquals(sep10Jwt.issuer, token.iss)
-    assertEquals(sep10Jwt.issuedAt, token.iat)
-    assertEquals(sep10Jwt.expiresAt, token.exp)
+    assertEquals(webAuthJwt.iss, token.iss)
+    assertEquals(webAuthJwt.sub, token.sub)
+    assertEquals(webAuthJwt.iat, token.iat)
+    assertEquals(webAuthJwt.exp, token.exp)
+    assertEquals(webAuthJwt.jti, token.jti)
+    assertEquals(webAuthJwt.clientDomain, token.clientDomain)
+    assertEquals(webAuthJwt.account, token.sub)
+    assertEquals(webAuthJwt.transactionId, token.jti)
+    assertEquals(webAuthJwt.issuer, token.iss)
+    assertEquals(webAuthJwt.issuedAt, token.iat)
+    assertEquals(webAuthJwt.expiresAt, token.exp)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/filter/WebAuthJwtFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/WebAuthJwtFilterTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.stellar.anchor.TestHelper.Companion.createSep10Jwt
+import org.stellar.anchor.TestHelper.Companion.createWebAuthJwt
 import org.stellar.anchor.auth.AbstractJwt
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.WebAuthJwt
@@ -159,7 +159,7 @@ internal class WebAuthJwtFilterTest {
     val slot = slot<WebAuthJwt>()
     every { request.setAttribute(JWT_TOKEN, capture(slot)) } answers {}
 
-    val jwtToken = jwtService.encode(createSep10Jwt(PUBLIC_KEY, null, "stellar.org"))
+    val jwtToken = jwtService.encode(createWebAuthJwt(PUBLIC_KEY, null, "stellar.org"))
     every { request.getHeader("Authorization") } returns "Bearer $jwtToken"
     webAuthJwtFilter.doFilter(request, response, mockFilterChain)
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -190,7 +190,7 @@ internal class Sep24ServiceTest {
 
     every { txnStore.save(capture(slotTxn)) } returns null
 
-    val response = sep24Service.withdraw(createTestSep10JwtToken(), createTestTransactionRequest())
+    val response = sep24Service.withdraw(createTestWebAuthJwt(), createTestTransactionRequest())
 
     verify(exactly = 1) { txnStore.save(any()) }
 
@@ -238,7 +238,7 @@ internal class Sep24ServiceTest {
     every { txnStore.save(capture(slotTxn)) } returns null
 
     val response =
-      sep24Service.withdraw(createTestSep10JwtWithMemo(), createTestTransactionRequest())
+      sep24Service.withdraw(createTestWebAuthJwtWithMemo(), createTestTransactionRequest())
     val params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
     val tokenStrings = params.filter { pair -> pair.name.equals("token") }
     assertEquals(tokenStrings.size, 1)
@@ -268,7 +268,7 @@ internal class Sep24ServiceTest {
     every { txnStore.save(capture(slotTxn)) } returns null
     every { sep38QuoteStore.findByQuoteId(any()) } returns withdrawQuote
     sep24Service.withdraw(
-      createTestSep10JwtWithMemo(),
+      createTestWebAuthJwtWithMemo(),
       createTestTransactionRequest(withdrawQuote.id),
     )
     assertEquals(withdrawQuote.id, slotTxn.captured.quoteId)
@@ -281,7 +281,7 @@ internal class Sep24ServiceTest {
     val deadline = 100L
     every { txnStore.save(capture(slotTxn)) } returns null
     every { sep24Config.initialUserDeadlineSeconds } returns deadline
-    sep24Service.withdraw(createTestSep10JwtWithMemo(), createTestTransactionRequest())
+    sep24Service.withdraw(createTestWebAuthJwtWithMemo(), createTestTransactionRequest())
     val dbDeadline = slotTxn.captured.userActionRequiredBy.epochSecond
     val expectedDeadline = Instant.now().plusSeconds(deadline).epochSecond
     Assertions.assertTrue(
@@ -300,7 +300,7 @@ internal class Sep24ServiceTest {
       sep24Service.withdraw(null, createTestTransactionRequest())
     }
 
-    assertThrows<SepValidationException> { sep24Service.withdraw(createTestSep10JwtToken(), null) }
+    assertThrows<SepValidationException> { sep24Service.withdraw(createTestWebAuthJwt(), null) }
   }
 
   @Test
@@ -308,44 +308,44 @@ internal class Sep24ServiceTest {
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request.remove("asset_code")
-      sep24Service.withdraw(createTestSep10JwtToken(), request)
+      sep24Service.withdraw(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["account"] = "G1234"
-      sep24Service.withdraw(createTestSep10JwtToken(), request)
+      sep24Service.withdraw(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["asset_code"] = "USDC_NA"
-      sep24Service.withdraw(createTestSep10JwtToken(), request)
+      sep24Service.withdraw(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["amount"] = "0"
-      sep24Service.withdraw(createTestSep10JwtToken(), request)
+      sep24Service.withdraw(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["amount"] = "10001"
-      sep24Service.withdraw(createTestSep10JwtToken(), request)
+      sep24Service.withdraw(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["account"] = "G1234"
-      val token = createTestSep10JwtToken()
+      val token = createTestWebAuthJwt()
       token.sub = "G1234"
       sep24Service.withdraw(token, request)
     }
 
     assertThrows<BadRequestException> {
       val request = createTestTransactionRequest("bad-quote-id")
-      val token = createTestSep10JwtToken()
+      val token = createTestWebAuthJwt()
       every { sep38QuoteStore.findByQuoteId(any()) } returns null
       sep24Service.withdraw(token, request)
     }
@@ -364,7 +364,7 @@ internal class Sep24ServiceTest {
 
     val request = createTestTransactionRequest()
     request["claimable_balance_supported"] = claimableBalanceSupported
-    val response = sep24Service.deposit(createTestSep10JwtToken(), request)
+    val response = sep24Service.deposit(createTestWebAuthJwt(), request)
 
     verify(exactly = 1) { txnStore.save(any()) }
 
@@ -393,7 +393,7 @@ internal class Sep24ServiceTest {
     every { txnStore.save(capture(slotTxn)) } returns null
 
     val response =
-      sep24Service.deposit(createTestSep10JwtWithMemo(), createTestTransactionRequest())
+      sep24Service.deposit(createTestWebAuthJwtWithMemo(), createTestTransactionRequest())
     val params = URLEncodedUtils.parse(URI(response.url), Charset.forName("UTF-8"))
     val tokenStrings = params.filter { pair -> pair.name.equals("token") }
     assertEquals(tokenStrings.size, 1)
@@ -422,7 +422,7 @@ internal class Sep24ServiceTest {
     every { txnStore.save(capture(slotTxn)) } returns null
     every { sep38QuoteStore.findByQuoteId(any()) } returns depositQuote
     sep24Service.deposit(
-      createTestSep10JwtWithMemo(),
+      createTestWebAuthJwtWithMemo(),
       createTestTransactionRequest(depositQuote.id),
     )
     assertEquals(depositQuote.id, slotTxn.captured.quoteId)
@@ -435,7 +435,7 @@ internal class Sep24ServiceTest {
     val deadline = 100L
     every { txnStore.save(capture(slotTxn)) } returns null
     every { sep24Config.initialUserDeadlineSeconds } returns deadline
-    sep24Service.deposit(createTestSep10JwtWithMemo(), createTestTransactionRequest())
+    sep24Service.deposit(createTestWebAuthJwtWithMemo(), createTestTransactionRequest())
     val dbDeadline = slotTxn.captured.userActionRequiredBy.epochSecond
     val expectedDeadline = Instant.now().plusSeconds(deadline).epochSecond
     Assertions.assertTrue(
@@ -454,7 +454,7 @@ internal class Sep24ServiceTest {
       sep24Service.deposit(null, createTestTransactionRequest())
     }
 
-    assertThrows<SepValidationException> { sep24Service.deposit(createTestSep10JwtToken(), null) }
+    assertThrows<SepValidationException> { sep24Service.deposit(createTestWebAuthJwt(), null) }
   }
 
   @Test
@@ -464,9 +464,7 @@ internal class Sep24ServiceTest {
     request["account"] = unknownAccount
 
     val ex =
-      assertThrows<SepValidationException> {
-        sep24Service.deposit(createTestSep10JwtToken(), request)
-      }
+      assertThrows<SepValidationException> { sep24Service.deposit(createTestWebAuthJwt(), request) }
     assertEquals(Sep24Service.ERR_TOKEN_ACCOUNT_MISMATCH, ex.message)
   }
 
@@ -489,7 +487,7 @@ internal class Sep24ServiceTest {
     val request = createTestTransactionRequest()
     request["account"] = whitelistedAccount
 
-    val response = sep24Service.deposit(createTestSep10JwtToken(), request)
+    val response = sep24Service.deposit(createTestWebAuthJwt(), request)
 
     verify(exactly = 1) { txnStore.save(any()) }
 
@@ -511,44 +509,44 @@ internal class Sep24ServiceTest {
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request.remove("asset_code")
-      sep24Service.deposit(createTestSep10JwtToken(), request)
+      sep24Service.deposit(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["account"] = "G1234"
-      sep24Service.deposit(createTestSep10JwtToken(), request)
+      sep24Service.deposit(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["asset_code"] = "USDC_NA"
-      sep24Service.deposit(createTestSep10JwtToken(), request)
+      sep24Service.deposit(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["amount"] = "0"
-      sep24Service.deposit(createTestSep10JwtToken(), request)
+      sep24Service.deposit(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["amount"] = "10001"
-      sep24Service.deposit(createTestSep10JwtToken(), request)
+      sep24Service.deposit(createTestWebAuthJwt(), request)
     }
 
     assertThrows<SepValidationException> {
       val request = createTestTransactionRequest()
       request["account"] = "G1234"
-      val token = createTestSep10JwtToken()
+      val token = createTestWebAuthJwt()
       token.sub = "G1234"
       sep24Service.deposit(token, request)
     }
 
     assertThrows<BadRequestException> {
       val request = createTestTransactionRequest("bad-quote-id")
-      val token = createTestSep10JwtToken()
+      val token = createTestWebAuthJwt()
       every { sep38QuoteStore.findByQuoteId(any()) } returns null
       sep24Service.deposit(token, request)
     }
@@ -561,7 +559,7 @@ internal class Sep24ServiceTest {
       createTestTransactions(kind)
     val gtr =
       GetTransactionsRequest.of(TEST_ASSET, kind, 10, "2021-12-20T19:30:58+00:00", "1", "en-US")
-    val response = sep24Service.findTransactions(createTestSep10JwtToken(), gtr)
+    val response = sep24Service.findTransactions(createTestWebAuthJwt(), gtr)
 
     assertEquals(response.transactions.size, 2)
     assertEquals(response.transactions[0].id, TEST_TRANSACTION_ID_0)
@@ -589,7 +587,7 @@ internal class Sep24ServiceTest {
       createTestTransactions("deposit")
     val gtr =
       GetTransactionsRequest.of(assetCode, "deposit", 10, "2021-12-20T19:30:58+00:00", "1", "en-US")
-    val response = sep24Service.findTransactions(createTestSep10JwtToken(), gtr)
+    val response = sep24Service.findTransactions(createTestWebAuthJwt(), gtr)
 
     assertEquals(response.transactions.size, 2)
   }
@@ -613,7 +611,7 @@ internal class Sep24ServiceTest {
           "1",
           "en-US",
         )
-      sep24Service.findTransactions(createTestSep10JwtToken(), gtr)
+      sep24Service.findTransactions(createTestWebAuthJwt(), gtr)
     }
   }
 
@@ -623,7 +621,7 @@ internal class Sep24ServiceTest {
     every { txnStore.findByTransactionId(any()) } returns createTestTransaction(kind)
 
     var gtr = GetTransactionRequest(TEST_TRANSACTION_ID_0, null, null, "en-US")
-    val response = sep24Service.findTransaction(createTestSep10JwtToken(), gtr)
+    val response = sep24Service.findTransaction(createTestWebAuthJwt(), gtr)
 
     assertEquals(TEST_TRANSACTION_ID_0, response.transaction.id)
     assertEquals("incomplete", response.transaction.status)
@@ -635,14 +633,14 @@ internal class Sep24ServiceTest {
     // test with stellar transaction_id
     every { txnStore.findByStellarTransactionId(any()) } returns createTestTransaction("deposit")
     gtr = GetTransactionRequest(null, TEST_TRANSACTION_ID_0, null, "en-US")
-    sep24Service.findTransaction(createTestSep10JwtToken(), gtr)
+    sep24Service.findTransaction(createTestWebAuthJwt(), gtr)
 
     verify(exactly = 1) { txnStore.findByStellarTransactionId(TEST_TRANSACTION_ID_0) }
 
     // test with external transaction_id
     every { txnStore.findByExternalTransactionId(any()) } returns createTestTransaction("deposit")
     gtr = GetTransactionRequest(null, null, TEST_TRANSACTION_ID_0, "en-US")
-    sep24Service.findTransaction(createTestSep10JwtToken(), gtr)
+    sep24Service.findTransaction(createTestWebAuthJwt(), gtr)
 
     verify(exactly = 1) { txnStore.findByExternalTransactionId(TEST_TRANSACTION_ID_0) }
   }
@@ -656,18 +654,18 @@ internal class Sep24ServiceTest {
     }
 
     assertThrows<SepValidationException> {
-      sep24Service.findTransaction(createTestSep10JwtToken(), null)
+      sep24Service.findTransaction(createTestWebAuthJwt(), null)
     }
 
     assertThrows<SepValidationException> {
       val gtr = GetTransactionRequest(null, null, null, "en-US")
-      sep24Service.findTransaction(createTestSep10JwtToken(), gtr)
+      sep24Service.findTransaction(createTestWebAuthJwt(), gtr)
     }
 
     every { txnStore.findByTransactionId(any()) } returns null
     assertThrows<SepNotFoundException> {
       val gtr = GetTransactionRequest(TEST_TRANSACTION_ID_0, null, null, "en-US")
-      sep24Service.findTransaction(createTestSep10JwtToken(), gtr)
+      sep24Service.findTransaction(createTestWebAuthJwt(), gtr)
     }
 
     val badTxn = createTestTransaction(kind)
@@ -676,7 +674,7 @@ internal class Sep24ServiceTest {
 
     assertThrows<SepException> {
       val gtr = GetTransactionRequest(TEST_TRANSACTION_ID_0, null, null, "en-US")
-      sep24Service.findTransaction(createTestSep10JwtToken(), gtr)
+      sep24Service.findTransaction(createTestWebAuthJwt(), gtr)
     }
   }
 
@@ -711,16 +709,21 @@ internal class Sep24ServiceTest {
 
     val request = createTestTransactionRequest()
     request["lang"] = "en"
-    val response = sep24Service.withdraw(createTestSep10JwtToken(), request)
+    val response = sep24Service.withdraw(createTestWebAuthJwt(), request)
     assertTrue(response.url.indexOf("lang=en") != -1)
   }
 
-  private fun createTestSep10JwtToken(): WebAuthJwt {
-    return TestHelper.createSep10Jwt(TEST_ACCOUNT, null, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
+  private fun createTestWebAuthJwt(): WebAuthJwt {
+    return TestHelper.createWebAuthJwt(TEST_ACCOUNT, null, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
   }
 
-  private fun createTestSep10JwtWithMemo(): WebAuthJwt {
-    return TestHelper.createSep10Jwt(TEST_ACCOUNT, TEST_MEMO, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
+  private fun createTestWebAuthJwtWithMemo(): WebAuthJwt {
+    return TestHelper.createWebAuthJwt(
+      TEST_ACCOUNT,
+      TEST_MEMO,
+      TEST_HOME_DOMAIN,
+      TEST_CLIENT_DOMAIN,
+    )
   }
 
   private fun createTestInteractiveJwt(accountMemo: String?): Sep24InteractiveUrlJwt {

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -324,9 +324,7 @@ class Sep31ServiceTest {
   @Test
   fun `test quotes supported and required validation`() {
     val ex: AnchorException = assertThrows {
-      DefaultAssetService.fromJsonResource(
-        "test_assets.json.quotes_required_but_not_supported",
-      )
+      DefaultAssetService.fromJsonResource("test_assets.json.quotes_required_but_not_supported")
     }
     assertInstanceOf(InvalidConfigException::class.java, ex)
     assertEquals(
@@ -476,7 +474,7 @@ class Sep31ServiceTest {
 
   @Test
   fun `test POST transaction failures`() {
-    val jwtToken = TestHelper.createSep10Jwt()
+    val jwtToken = TestHelper.createWebAuthJwt()
 
     // missing asset code
     val postTxRequest = Sep31PostTransactionRequest()
@@ -617,7 +615,7 @@ class Sep31ServiceTest {
           "receiver_account_number" to "1",
           "type" to "1",
           "receiver_routing_number" to "SWIFT",
-        ),
+        )
       )
 
     // Make sure we can get the sender and receiver customers
@@ -651,7 +649,7 @@ class Sep31ServiceTest {
       }
 
     // POST transaction
-    val jwtToken = TestHelper.createSep10Jwt(accountMemo = TestHelper.TEST_MEMO)
+    val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
     var gotResponse: Sep31PostTransactionResponse? = null
     assertDoesNotThrow { gotResponse = sep31Service.postTransaction(jwtToken, postTxRequest) }
 
@@ -718,7 +716,7 @@ class Sep31ServiceTest {
           "receiver_account_number" to "1",
           "type" to "1",
           "receiver_routing_number" to "SWIFT",
-        ),
+        )
       )
 
     // Make sure we can get the sender and receiver customers
@@ -727,7 +725,7 @@ class Sep31ServiceTest {
     every { customerIntegration.getCustomer(any()) } returns mockCustomer
 
     // POST transaction
-    val jwtToken = TestHelper.createSep10Jwt()
+    val jwtToken = TestHelper.createWebAuthJwt()
     val ex: AnchorException = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("quotes_required is set to true; quote id cannot be empty", ex.message)
@@ -745,9 +743,7 @@ class Sep31ServiceTest {
       }
 
     val assetServiceQuotesNotSupported: AssetService =
-      DefaultAssetService.fromJsonResource(
-        "test_assets.json.quotes_not_supported",
-      )
+      DefaultAssetService.fromJsonResource("test_assets.json.quotes_not_supported")
     sep31Service =
       Sep31Service(
         appConfig,
@@ -758,7 +754,7 @@ class Sep31ServiceTest {
         clientService,
         assetServiceQuotesNotSupported,
         rateIntegration,
-        eventService
+        eventService,
       )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
@@ -776,7 +772,7 @@ class Sep31ServiceTest {
           "receiver_account_number" to "1",
           "type" to "1",
           "receiver_routing_number" to "SWIFT",
-        ),
+        )
       )
 
     // Provide fee response.
@@ -789,7 +785,7 @@ class Sep31ServiceTest {
     every { customerIntegration.getCustomer(any()) } returns mockCustomer
 
     // POST transaction
-    val jwtToken = TestHelper.createSep10Jwt()
+    val jwtToken = TestHelper.createWebAuthJwt()
     var gotResponse: Sep31PostTransactionResponse? = null
     assertDoesNotThrow { gotResponse = sep31Service.postTransaction(jwtToken, postTxRequest) }
 
@@ -842,9 +838,9 @@ class Sep31ServiceTest {
 
   @Test
   fun `Test update fee ok`() {
-    val jwtToken = TestHelper.createSep10Jwt()
+    val jwtToken = TestHelper.createWebAuthJwt()
     Context.get().request = request
-    Context.get().sep10Jwt = jwtToken
+    Context.get().webAuthJwt = jwtToken
 
     // With quote
     Context.get().quote = quote
@@ -861,7 +857,7 @@ class Sep31ServiceTest {
           .fee(
             FeeDetails(
               "10",
-              "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+              "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
             )
           )
           .build()
@@ -883,9 +879,9 @@ class Sep31ServiceTest {
 
   @Test
   fun `test update fee failure`() {
-    val jwtToken = TestHelper.createSep10Jwt()
+    val jwtToken = TestHelper.createWebAuthJwt()
     Context.get().request = request
-    Context.get().sep10Jwt = jwtToken
+    Context.get().webAuthJwt = jwtToken
 
     // With quote
     Context.get().quote = quote

--- a/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep38/Sep38ServiceTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode.STRICT
-import org.stellar.anchor.TestHelper.Companion.createSep10Jwt
+import org.stellar.anchor.TestHelper.Companion.createWebAuthJwt
 import org.stellar.anchor.api.asset.Sep38Info
 import org.stellar.anchor.api.callback.GetRateRequest
 import org.stellar.anchor.api.callback.GetRateRequest.Type.FIRM
@@ -592,7 +592,7 @@ class Sep38ServiceTest {
         sep38Service.assetService,
         mockRateIntegration,
         mockQuoteStore,
-        eventService
+        eventService,
       )
 
     // empty token
@@ -601,13 +601,13 @@ class Sep38ServiceTest {
     assertEquals("missing sep10 jwt token", ex.message)
 
     // malformed token
-    var token = createSep10Jwt("")
+    var token = createWebAuthJwt("")
     ex = assertThrows { sep38Service.postQuote(token, Sep38PostQuoteRequest.builder().build()) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sep10 token is malformed", ex.message)
 
     // empty sell_asset
-    token = createSep10Jwt()
+    token = createWebAuthJwt()
     ex = assertThrows { sep38Service.postQuote(token, Sep38PostQuoteRequest.builder().build()) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sell_asset cannot be empty", ex.message)
@@ -616,7 +616,7 @@ class Sep38ServiceTest {
     ex = assertThrows {
       sep38Service.postQuote(
         token,
-        Sep38PostQuoteRequest.builder().sellAssetName("foo:bar").build()
+        Sep38PostQuoteRequest.builder().sellAssetName("foo:bar").build(),
       )
     }
     assertInstanceOf(NotFoundException::class.java, ex)
@@ -633,7 +633,7 @@ class Sep38ServiceTest {
     ex = assertThrows {
       sep38Service.postQuote(
         token,
-        Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName("foo:bar").build()
+        Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName("foo:bar").build(),
       )
     }
     assertInstanceOf(NotFoundException::class.java, ex)
@@ -643,7 +643,7 @@ class Sep38ServiceTest {
     ex = assertThrows {
       sep38Service.postQuote(
         token,
-        Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName(stellarUSDC).build()
+        Sep38PostQuoteRequest.builder().sellAssetName(fiatUSD).buyAssetName(stellarUSDC).build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -658,7 +658,7 @@ class Sep38ServiceTest {
           .sellAmount("100")
           .buyAssetName(stellarUSDC)
           .buyAmount("100")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -672,7 +672,7 @@ class Sep38ServiceTest {
           .sellAssetName(fiatUSD)
           .sellAmount("foo")
           .buyAssetName(stellarUSDC)
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -686,7 +686,7 @@ class Sep38ServiceTest {
           .sellAssetName(fiatUSD)
           .sellAmount("-0.01")
           .buyAssetName(stellarUSDC)
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -700,7 +700,7 @@ class Sep38ServiceTest {
           .sellAssetName(fiatUSD)
           .sellAmount("0")
           .buyAssetName(stellarUSDC)
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -714,7 +714,7 @@ class Sep38ServiceTest {
           .sellAssetName(fiatUSD)
           .buyAssetName(stellarUSDC)
           .buyAmount("bar")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -728,7 +728,7 @@ class Sep38ServiceTest {
           .sellAssetName(fiatUSD)
           .buyAssetName(stellarUSDC)
           .buyAmount("-0.02")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -742,7 +742,7 @@ class Sep38ServiceTest {
           .sellAssetName(fiatUSD)
           .buyAssetName(stellarUSDC)
           .buyAmount("0")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -757,7 +757,7 @@ class Sep38ServiceTest {
           .sellAmount("1.23")
           .sellDeliveryMethod("FOO")
           .buyAssetName(stellarUSDC)
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -773,7 +773,7 @@ class Sep38ServiceTest {
           .sellDeliveryMethod("WIRE")
           .buyAssetName(stellarUSDC)
           .buyDeliveryMethod("BAR")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -789,7 +789,7 @@ class Sep38ServiceTest {
           .sellDeliveryMethod("WIRE")
           .buyAssetName(stellarUSDC)
           .countryCode("BR")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -806,7 +806,7 @@ class Sep38ServiceTest {
           .buyAssetName(stellarUSDC)
           .countryCode("US")
           .expireAfter("2022-04-18T23:33:24.629719Z")
-          .build()
+          .build(),
       )
     }
     assertInstanceOf(BadRequestException::class.java, ex)
@@ -843,7 +843,7 @@ class Sep38ServiceTest {
         sep38Service.assetService,
         mockRateIntegration,
         mockQuoteStore,
-        eventService
+        eventService,
       )
 
     val slotQuote = slot<Sep38Quote>()
@@ -854,7 +854,7 @@ class Sep38ServiceTest {
     every { eventSession.publish(capture(slotEvent)) } just Runs
 
     // test happy path with the minimum parameters using sellAmount
-    val token = createSep10Jwt()
+    val token = createWebAuthJwt()
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
@@ -865,7 +865,7 @@ class Sep38ServiceTest {
             .sellAssetName(fiatUSD)
             .sellAmount("103")
             .buyAssetName(stellarUSDC)
-            .build()
+            .build(),
         )
     }
     val wantResponse =
@@ -953,7 +953,7 @@ class Sep38ServiceTest {
     every { eventSession.publish(capture(slotEvent)) } just Runs
 
     // test happy path with the minimum parameters using sellAmount
-    val token = createSep10Jwt()
+    val token = createWebAuthJwt()
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
@@ -964,7 +964,7 @@ class Sep38ServiceTest {
             .sellAssetName(fiatUSD)
             .buyAssetName(stellarUSDC)
             .buyAmount("100")
-            .build()
+            .build(),
         )
     }
     val wantResponse =
@@ -1040,7 +1040,7 @@ class Sep38ServiceTest {
         sep38Service.assetService,
         mockRateIntegration,
         mockQuoteStore,
-        eventService
+        eventService,
       )
 
     val slotQuote = slot<Sep38Quote>()
@@ -1051,7 +1051,7 @@ class Sep38ServiceTest {
     every { eventSession.publish(capture(slotEvent)) } just Runs
 
     // test happy path with the minimum parameters using sellAmount
-    val token = createSep10Jwt()
+    val token = createWebAuthJwt()
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
@@ -1065,7 +1065,7 @@ class Sep38ServiceTest {
             .buyAssetName(stellarUSDC)
             .countryCode("US")
             .expireAfter(now.toString())
-            .build()
+            .build(),
         )
     }
     val wantResponse =
@@ -1144,7 +1144,7 @@ class Sep38ServiceTest {
         sep38Service.assetService,
         mockRateIntegration,
         mockQuoteStore,
-        eventService
+        eventService,
       )
 
     val slotQuote = slot<Sep38Quote>()
@@ -1155,7 +1155,7 @@ class Sep38ServiceTest {
     every { eventSession.publish(capture(slotEvent)) } just Runs
 
     // test happy path with the minimum parameters using sellAmount
-    val token = createSep10Jwt()
+    val token = createWebAuthJwt()
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
@@ -1169,7 +1169,7 @@ class Sep38ServiceTest {
             .buyAmount("100")
             .countryCode("US")
             .expireAfter(now.toString())
-            .build()
+            .build(),
         )
     }
     val wantResponse =
@@ -1256,7 +1256,7 @@ class Sep38ServiceTest {
         sep38Service.assetService,
         mockRateIntegration,
         mockQuoteStore,
-        eventService
+        eventService,
       )
 
     val slotQuote = slot<Sep38Quote>()
@@ -1267,7 +1267,7 @@ class Sep38ServiceTest {
     every { eventSession.publish(capture(slotEvent)) } just Runs
 
     // test happy path with the minimum parameters using sellAmount
-    val token = createSep10Jwt()
+    val token = createWebAuthJwt()
     var gotResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow {
       gotResponse =
@@ -1281,7 +1281,7 @@ class Sep38ServiceTest {
             .buyAmount(requestBuyAmount)
             .countryCode("US")
             .expireAfter(now.toString())
-            .build()
+            .build(),
         )
     }
     val wantResponse =
@@ -1359,13 +1359,13 @@ class Sep38ServiceTest {
     assertEquals("missing sep10 jwt token", ex.message)
 
     // malformed token
-    var token = createSep10Jwt("")
+    var token = createWebAuthJwt("")
     ex = assertThrows { sep38Service.getQuote(token, null) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("sep10 token is malformed", ex.message)
 
     // empty quote id
-    token = createSep10Jwt()
+    token = createWebAuthJwt()
     ex = assertThrows { sep38Service.getQuote(token, null) }
     assertInstanceOf(BadRequestException::class.java, ex)
     assertEquals("quote id cannot be empty", ex.message)
@@ -1457,7 +1457,7 @@ class Sep38ServiceTest {
     every { mockQuoteStore.findByQuoteId(capture(slotQuoteId)) } returns mockQuote
 
     // execute request
-    val token = createSep10Jwt()
+    val token = createWebAuthJwt()
     var gotQuoteResponse: Sep38QuoteResponse? = null
     assertDoesNotThrow { gotQuoteResponse = sep38Service.getQuote(token, "123") }
 
@@ -1488,7 +1488,7 @@ class Sep38ServiceTest {
     every { mockRateIntegration.getRate(capture(slotGetRateRequest)) } returns
       GetRateResponse.indicativePrice("1", "100", "100", mockSellAssetFee(fiatUSD))
 
-    val token = createSep10Jwt(PUBLIC_KEY)
+    val token = createWebAuthJwt(PUBLIC_KEY)
     val getPriceRequest =
       Sep38GetPriceRequest.builder()
         .sellAssetName(fiatUSD)

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/ExchangeAmountsCalculatorTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/ExchangeAmountsCalculatorTest.kt
@@ -22,7 +22,7 @@ import org.stellar.anchor.sep6.ExchangeAmountsCalculator.Amounts
 
 class ExchangeAmountsCalculatorTest {
   companion object {
-    val token = TestHelper.createSep10Jwt(TEST_ACCOUNT, TestConstants.TEST_MEMO)
+    val token = TestHelper.createWebAuthJwt(TEST_ACCOUNT, TestConstants.TEST_MEMO)
   }
 
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
@@ -64,7 +64,7 @@ class ExchangeAmountsCalculatorTest {
         .amountOutAsset("iso4217:USD")
         .feeDetails(FeeDetails("2", "iso4217:USD"))
         .build(),
-      result
+      result,
     )
   }
 
@@ -112,7 +112,7 @@ class ExchangeAmountsCalculatorTest {
         quoteId,
         assetService.getAsset("USDC"),
         assetService.getAsset("JPYC"),
-        "100"
+        "100",
       )
     }
   }

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -7,7 +7,6 @@ import java.time.Instant
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -43,7 +42,7 @@ import org.stellar.anchor.util.GsonUtils
 class Sep6ServiceTest {
   companion object {
     val gson: Gson = GsonUtils.getInstance()
-    val token = TestHelper.createSep10Jwt(TEST_ACCOUNT, TEST_MEMO)
+    val token = TestHelper.createWebAuthJwt(TEST_ACCOUNT, TEST_MEMO)
   }
 
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
@@ -93,7 +92,7 @@ class Sep6ServiceTest {
     val infoResponse = sep6Service.info
     assertEquals(
       gson.fromJson(Sep6ServiceTestData.infoJson, InfoResponse::class.java),
-      infoResponse
+      infoResponse,
     )
   }
 
@@ -139,7 +138,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositTxnJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -147,17 +146,17 @@ class Sep6ServiceTest {
     val expectedDeadline = Instant.now().plusSeconds(deadline).epochSecond
     Assertions.assertTrue(
       dbDeadline >= expectedDeadline - 2,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
     Assertions.assertTrue(
       dbDeadline <= expectedDeadline,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
 
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositTxnEventJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -168,7 +167,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -194,7 +193,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositTxnJsonWithoutAmountOrType,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -202,7 +201,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositTxnEventWithoutAmountOrTypeJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -213,7 +212,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -399,7 +398,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositExchangeTxnJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -407,17 +406,17 @@ class Sep6ServiceTest {
     val expectedDeadline = Instant.now().plusSeconds(deadline).epochSecond
     Assertions.assertTrue(
       dbDeadline >= expectedDeadline - 2,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
     Assertions.assertTrue(
       dbDeadline <= expectedDeadline,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
 
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositExchangeTxnEventJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -428,7 +427,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -477,7 +476,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositExchangeTxnWithoutQuoteJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -485,7 +484,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositExchangeTxnEventWithoutQuoteJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -496,7 +495,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.depositResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -695,7 +694,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawTxnJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -703,17 +702,17 @@ class Sep6ServiceTest {
     val expectedDeadline = Instant.now().plusSeconds(deadline).epochSecond
     Assertions.assertTrue(
       dbDeadline >= expectedDeadline - 2,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
     Assertions.assertTrue(
       dbDeadline <= expectedDeadline,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
 
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawTxnEventJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -725,7 +724,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -782,7 +781,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawTxnWithoutAmountOrTypeJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -790,7 +789,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawTxnEventWithoutAmountOrTypeJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -802,7 +801,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -984,7 +983,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawExchangeTxnJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -992,7 +991,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawExchangeTxnEventJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -1004,7 +1003,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -1055,7 +1054,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawExchangeTxnWithoutQuoteJson,
       gson.toJson(slotTxn.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotTxn.captured.id.isNotEmpty())
     assertNotNull(slotTxn.captured.startedAt)
@@ -1063,17 +1062,17 @@ class Sep6ServiceTest {
     val expectedDeadline = Instant.now().plusSeconds(deadline).epochSecond
     Assertions.assertTrue(
       dbDeadline >= expectedDeadline - 2,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
     Assertions.assertTrue(
       dbDeadline <= expectedDeadline,
-      "Expected $expectedDeadline got $dbDeadline}"
+      "Expected $expectedDeadline got $dbDeadline}",
     )
 
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawExchangeTxnWithoutQuoteEventJson,
       gson.toJson(slotEvent.captured),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
     assert(slotEvent.captured.id.isNotEmpty())
     assert(slotEvent.captured.transaction.id.isNotEmpty())
@@ -1085,7 +1084,7 @@ class Sep6ServiceTest {
     JSONAssert.assertEquals(
       Sep6ServiceTestData.withdrawResJson,
       gson.toJson(response),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -1273,7 +1272,7 @@ class Sep6ServiceTest {
     val request = GetTransactionRequest.builder().id(depositTxn.id).lang("en-US").build()
     every { txnStore.findByTransactionId(depositTxn.id) } returns depositTxn
 
-    sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
 
     verify { txnStore.findByTransactionId(depositTxn.id) }
   }
@@ -1289,7 +1288,7 @@ class Sep6ServiceTest {
     every { txnStore.findByStellarTransactionId(depositTxn.stellarTransactionId) } returns
       depositTxn
 
-    sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
 
     verify { txnStore.findByStellarTransactionId(depositTxn.stellarTransactionId) }
   }
@@ -1305,7 +1304,7 @@ class Sep6ServiceTest {
     every { txnStore.findByExternalTransactionId(depositTxn.externalTransactionId) } returns
       depositTxn
 
-    sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
 
     verify { txnStore.findByExternalTransactionId(depositTxn.externalTransactionId) }
   }
@@ -1315,7 +1314,7 @@ class Sep6ServiceTest {
     val request = GetTransactionRequest.builder().lang("en-US").build()
 
     assertThrows<SepValidationException> {
-      sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+      sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
     }
     verify { txnStore wasNot Called }
   }
@@ -1327,7 +1326,7 @@ class Sep6ServiceTest {
     every { txnStore.findByTransactionId(any()) } returns null
 
     assertThrows<NotFoundException> {
-      sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+      sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
     }
 
     verify { txnStore.findByTransactionId(any()) }
@@ -1340,7 +1339,7 @@ class Sep6ServiceTest {
     every { txnStore.findByTransactionId(depositTxn.id) } returns depositTxn
 
     assertThrows<NotFoundException> {
-      sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+      sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
     }
 
     verify { txnStore.findByTransactionId(depositTxn.id) }
@@ -1353,7 +1352,7 @@ class Sep6ServiceTest {
     every { txnStore.findByTransactionId(depositTxn.id) } returns depositTxn
 
     assertThrows<NotFoundException> {
-      sep6Service.findTransaction(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+      sep6Service.findTransaction(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
     }
 
     verify { txnStore.findByTransactionId(depositTxn.id) }
@@ -1373,7 +1372,7 @@ class Sep6ServiceTest {
         .build()
 
     assertThrows<SepNotAuthorizedException> {
-      sep6Service.findTransactions(TestHelper.createSep10Jwt("other-account"), request)
+      sep6Service.findTransactions(TestHelper.createWebAuthJwt("other-account"), request)
     }
     verify { txnStore wasNot Called }
   }
@@ -1392,7 +1391,7 @@ class Sep6ServiceTest {
         .build()
 
     assertThrows<SepValidationException> {
-      sep6Service.findTransactions(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+      sep6Service.findTransactions(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
     }
     verify { txnStore wasNot Called }
   }
@@ -1411,7 +1410,7 @@ class Sep6ServiceTest {
         .pagingId("1")
         .lang("en-US")
         .build()
-    val response = sep6Service.findTransactions(TestHelper.createSep10Jwt(TEST_ACCOUNT), request)
+    val response = sep6Service.findTransactions(TestHelper.createWebAuthJwt(TEST_ACCOUNT), request)
 
     verify(exactly = 1) { txnStore.findTransactions(TEST_ACCOUNT, null, request) }
 
@@ -1420,7 +1419,7 @@ class Sep6ServiceTest {
 
   private fun createDepositTxn(
     sep10Account: String,
-    sep10AccountMemo: String? = null
+    sep10AccountMemo: String? = null,
   ): Sep6Transaction {
     val txn = PojoSep6Transaction()
 

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientFinderTest.kt
@@ -22,7 +22,7 @@ import org.stellar.anchor.sep6.ExchangeAmountsCalculatorTest
 
 class ClientFinderTest {
   companion object {
-    val token = TestHelper.createSep10Jwt(TEST_ACCOUNT, TEST_MEMO)
+    val token = TestHelper.createWebAuthJwt(TEST_ACCOUNT, TEST_MEMO)
     private val custodialClient =
       CustodialClient.builder()
         .name("referenceCustodial")

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep12Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep12Controller.java
@@ -55,7 +55,7 @@ public class Sep12Controller {
         memoType,
         transactionId,
         lang);
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
     Sep12GetCustomerRequest getCustomerRequest =
         Sep12GetCustomerRequest.builder()
             .type(type)
@@ -67,7 +67,7 @@ public class Sep12Controller {
             .lang(lang)
             .build();
 
-    return sep12Service.getCustomer(sep10Jwt, getCustomerRequest);
+    return sep12Service.getCustomer(webAuthJwt, getCustomerRequest);
   }
 
   @SneakyThrows
@@ -81,8 +81,8 @@ public class Sep12Controller {
   public Sep12PutCustomerResponse putCustomer(
       HttpServletRequest request, @RequestBody Sep12PutCustomerRequest putCustomerRequest) {
     debug("PUT /customer details:", putCustomerRequest);
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
-    return sep12Service.putCustomer(sep10Jwt, putCustomerRequest);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
+    return sep12Service.putCustomer(webAuthJwt, putCustomerRequest);
   }
 
   @SneakyThrows
@@ -118,8 +118,8 @@ public class Sep12Controller {
       }
     }
 
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
-    return sep12Service.putCustomer(sep10Jwt, putCustomerRequest);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
+    return sep12Service.putCustomer(webAuthJwt, putCustomerRequest);
   }
 
   @SneakyThrows
@@ -134,7 +134,7 @@ public class Sep12Controller {
       HttpServletRequest request,
       @PathVariable String account,
       @RequestBody(required = false) Sep12DeleteCustomerRequest body) {
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
     String memo = body != null ? body.getMemo() : null;
     String memoType = body != null ? body.getMemoType() : null;
     debugF(
@@ -142,7 +142,7 @@ public class Sep12Controller {
         request.getRequestURI(),
         account,
         body);
-    sep12Service.deleteCustomer(sep10Jwt, account, memo, memoType);
+    sep12Service.deleteCustomer(webAuthJwt, account, memo, memoType);
   }
 
   @SneakyThrows
@@ -158,8 +158,8 @@ public class Sep12Controller {
       @PathVariable String account,
       @RequestParam(required = false) String memo,
       @RequestParam(required = false, name = "memo_type") String memoType) {
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
     debugF("DELETE /customer requestURI={} account={}", request.getRequestURI(), account);
-    sep12Service.deleteCustomer(sep10Jwt, account, memo, memoType);
+    sep12Service.deleteCustomer(webAuthJwt, account, memo, memoType);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep24Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep24Controller.java
@@ -49,7 +49,7 @@ public class Sep24Controller {
       HttpServletRequest request, @RequestBody HashMap<String, String> requestData)
       throws AnchorException, MalformedURLException, URISyntaxException {
     debug("/deposit", requestData);
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     InteractiveTransactionResponse itr = sep24Service.deposit(token, requestData);
     info("interactive redirection:", itr);
     return itr;
@@ -81,7 +81,7 @@ public class Sep24Controller {
       HttpServletRequest request, @RequestBody HashMap<String, String> requestData)
       throws AnchorException, MalformedURLException, URISyntaxException {
     debug("/withdraw", requestData);
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     InteractiveTransactionResponse itr = sep24Service.withdraw(token, requestData);
     info("interactive redirection:", itr);
     return itr;
@@ -113,7 +113,7 @@ public class Sep24Controller {
       HttpServletRequest request, @RequestBody GetTransactionsRequest tr)
       throws SepException, MalformedURLException, URISyntaxException {
     debug("/transactions", tr);
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     return sep24Service.findTransactions(token, tr);
   }
 
@@ -154,7 +154,7 @@ public class Sep24Controller {
       HttpServletRequest request, @RequestBody(required = false) GetTransactionRequest tr)
       throws SepException, IOException, URISyntaxException {
     debug("/transaction", tr);
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
 
     return sep24Service.findTransaction(token, tr);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
@@ -47,9 +47,9 @@ public class Sep31Controller {
   public Sep31PostTransactionResponse postTransaction(
       HttpServletRequest servletRequest, @RequestBody Sep31PostTransactionRequest request)
       throws AnchorException {
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(servletRequest);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(servletRequest);
     debugF("POST /transactions request={}", request);
-    return sep31Service.postTransaction(sep10Jwt, request);
+    return sep31Service.postTransaction(webAuthJwt, request);
   }
 
   @CrossOrigin(origins = "*")

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep38Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep38Controller.java
@@ -77,13 +77,13 @@ public class Sep38Controller {
     debugF("GET /price params={}", params);
     Sep38GetPriceRequest getPriceRequest =
         gson.fromJson(gson.toJson(params), Sep38GetPriceRequest.class);
-    WebAuthJwt sep10Jwt;
+    WebAuthJwt webAuthJwt;
     try {
-      sep10Jwt = Sep10Helper.getSep10Token(request);
+      webAuthJwt = WebAuthJwtHelper.getToken(request);
     } catch (SepValidationException svex) {
-      sep10Jwt = null;
+      webAuthJwt = null;
     }
-    return sep38Service.getPrice(sep10Jwt, getPriceRequest);
+    return sep38Service.getPrice(webAuthJwt, getPriceRequest);
   }
 
   @SneakyThrows
@@ -96,9 +96,9 @@ public class Sep38Controller {
       method = {RequestMethod.POST})
   public Sep38QuoteResponse postQuote(
       HttpServletRequest request, @RequestBody Sep38PostQuoteRequest postQuoteRequest) {
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
     debugF("POSTS /quote request={}", postQuoteRequest);
-    return sep38Service.postQuote(sep10Jwt, postQuoteRequest);
+    return sep38Service.postQuote(webAuthJwt, postQuoteRequest);
   }
 
   @SneakyThrows
@@ -110,9 +110,9 @@ public class Sep38Controller {
       method = {RequestMethod.GET})
   public Sep38QuoteResponse getQuote(
       HttpServletRequest request, @PathVariable(name = "quote_id") String quoteId) {
-    WebAuthJwt sep10Jwt = Sep10Helper.getSep10Token(request);
+    WebAuthJwt webAuthJwt = WebAuthJwtHelper.getToken(request);
     debugF("GET /quote id={}", quoteId);
-    return sep38Service.getQuote(sep10Jwt, quoteId);
+    return sep38Service.getQuote(webAuthJwt, quoteId);
   }
 
   @ExceptionHandler(RestClientException.class)

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -58,7 +58,7 @@ public class Sep6Controller {
           Boolean claimableBalancesSupported)
       throws AnchorException {
     debugF("GET /deposit");
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     StartDepositRequest startDepositRequest =
         StartDepositRequest.builder()
             .assetCode(assetCode)
@@ -100,7 +100,7 @@ public class Sep6Controller {
           Boolean claimableBalancesSupported)
       throws AnchorException {
     debugF("GET /deposit-exchange");
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     StartDepositExchangeRequest startDepositExchangeRequest =
         StartDepositExchangeRequest.builder()
             .destinationAsset(destinationAsset)
@@ -135,7 +135,7 @@ public class Sep6Controller {
       @RequestParam(value = "refundMemoType", required = false) String refundMemoType)
       throws AnchorException {
     debugF("GET /withdraw");
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     StartWithdrawRequest startWithdrawRequest =
         StartWithdrawRequest.builder()
             .assetCode(assetCode)
@@ -167,7 +167,7 @@ public class Sep6Controller {
       @RequestParam(value = "refund_memo_type", required = false) String refundMemoType)
       throws AnchorException {
     debugF("GET /withdraw-exchange");
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     StartWithdrawExchangeRequest startWithdrawExchangeRequest =
         StartWithdrawExchangeRequest.builder()
             .sourceAsset(sourceAsset)
@@ -206,7 +206,7 @@ public class Sep6Controller {
         pagingId,
         noOlderThan,
         lang);
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     GetTransactionsRequest getTransactionsRequest =
         GetTransactionsRequest.builder()
             .assetCode(assetCode)
@@ -239,7 +239,7 @@ public class Sep6Controller {
         stellarTransactionId,
         externalTransactionId,
         lang);
-    WebAuthJwt token = Sep10Helper.getSep10Token(request);
+    WebAuthJwt token = WebAuthJwtHelper.getToken(request);
     GetTransactionRequest getTransactionRequest =
         GetTransactionRequest.builder()
             .id(id)

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/WebAuthJwtHelper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/WebAuthJwtHelper.java
@@ -6,12 +6,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.stellar.anchor.api.exception.SepValidationException;
 import org.stellar.anchor.auth.WebAuthJwt;
 
-public class Sep10Helper {
-  public static WebAuthJwt getSep10Token(HttpServletRequest request) throws SepValidationException {
+public class WebAuthJwtHelper {
+  public static WebAuthJwt getToken(HttpServletRequest request) throws SepValidationException {
     WebAuthJwt token = (WebAuthJwt) request.getAttribute(JWT_TOKEN);
     if (token == null) {
       throw new SepValidationException(
-          "missing sep10 jwt token. Make sure the sep10 filter is invoked before the controller");
+          "missing web auth jwt token. Make sure the web auth jwt filter is invoked before the controller");
     }
     return token;
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -46,7 +46,7 @@ class SimpleInteractiveUrlConstructorTest {
   @MockK(relaxed = true) private lateinit var custodySecretConfig: CustodySecretConfig
   @MockK(relaxed = true) private lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) private lateinit var testAsset: AssetInfo
-  @MockK(relaxed = true) private lateinit var sep10Jwt: WebAuthJwt
+  @MockK(relaxed = true) private lateinit var webAuthJwt: WebAuthJwt
 
   private lateinit var jwtService: JwtService
   private lateinit var sep24Config: PropertySep24Config
@@ -61,7 +61,7 @@ class SimpleInteractiveUrlConstructorTest {
     clientService = DefaultClientService.fromYamlResourceFile("test_clients.yaml")
     every { testAsset.id } returns
       "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
-    every { sep10Jwt.homeDomain } returns TEST_HOME_DOMAIN
+    every { webAuthJwt.homeDomain } returns TEST_HOME_DOMAIN
 
     jwtService = JwtService(secretConfig, custodySecretConfig)
     sep24Config = gson.fromJson(SEP24_CONFIG_JSON_1, PropertySep24Config::class.java)
@@ -87,7 +87,12 @@ class SimpleInteractiveUrlConstructorTest {
 
     var jwt =
       parseJwtFromUrl(
-        constructor.construct(testTxn, testRequest as HashMap<String, String>?, testAsset, sep10Jwt)
+        constructor.construct(
+          testTxn,
+          testRequest as HashMap<String, String>?,
+          testAsset,
+          webAuthJwt
+        )
       )
     testJwt(jwt)
     var claims = jwt.claims
@@ -99,7 +104,7 @@ class SimpleInteractiveUrlConstructorTest {
     // Unknown client domain
     testTxn.sep10AccountMemo = null
     testTxn.clientDomain = "unknown.com"
-    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, sep10Jwt))
+    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, webAuthJwt))
     claims = jwt.claims
     testJwt(jwt)
     assertEquals("GBLGJA4TUN5XOGTV6WO2BWYUI2OZR5GYQ5PDPCRMQ5XEPJOYWB2X4CJO", jwt.sub)
@@ -111,7 +116,7 @@ class SimpleInteractiveUrlConstructorTest {
     testTxn.sep10Account = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     testTxn.sep10AccountMemo = "1234"
     testTxn.clientDomain = null
-    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, sep10Jwt))
+    jwt = parseJwtFromUrl(constructor.construct(testTxn, testRequest, testAsset, webAuthJwt))
     claims = jwt.claims
     testJwt(jwt)
     assertEquals("GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP:1234", jwt.sub)
@@ -135,9 +140,9 @@ class SimpleInteractiveUrlConstructorTest {
         jwtService,
       )
     sep24Config.kycFieldsForwarding.isEnabled = true
-    every { sep10Jwt.account }.returns("test_account")
-    every { sep10Jwt.accountMemo }.returns("123")
-    constructor.construct(txn, request as HashMap<String, String>?, testAsset, sep10Jwt)
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns("123")
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
     assertEquals(capturedPutCustomerRequest.captured.firstName, request.get("first_name"))
     assertEquals(capturedPutCustomerRequest.captured.lastName, request.get("last_name"))
@@ -159,7 +164,7 @@ class SimpleInteractiveUrlConstructorTest {
         jwtService,
       )
     sep24Config.kycFieldsForwarding.isEnabled = false
-    constructor.construct(txn, request as HashMap<String, String>?, testAsset, sep10Jwt)
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     verify(exactly = 0) { customerIntegration.putCustomer(any()) }
   }
 


### PR DESCRIPTION
### Description

This renames all instances of `Sep10Jwt` to `WebAuthJwt`.

### Context

The class was renamed to be generic to SEP-10 and SEP-45 so the variable names should also change.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

