### PR TITLE
Fix tag in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 # If LABEL is not provided set default value
 LABEL ?= $(shell git rev-parse --short HEAD)$(and $(shell git status -s),-dirty-$(shell id -u -n))
 # If TAG is not provided set default value
-TAG ?= stellar/stellar-disbursement-platform:$(LABEL)
+TAG ?= stellar/anchor-platform:$(LABEL)
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 BUILD_DATE := $(shell date -u +%FT%TZ)
 


### PR DESCRIPTION
### Description

This fixes the default `TAG` variable in the makefile.

### Context

The file was copied over from the SDP repo. I forgot to update it.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

