### PR TITLE
[PD] Add allowedHost to helm charts

### DIFF
--- a/helm-charts/sep24-reference-ui/templates/deployment.yaml
+++ b/helm-charts/sep24-reference-ui/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: BUSINESS_SERVER_ENDPOINT
               value: {{ .Values.config.businessServerEndpoint }}
+            - name: ALLOWED_HOST
+              value: {{ .Values.config.allowedHost }}
           resources:
             requests:
               memory: {{ .Values.services.ui.deployment.resources.requests.memory }}

--- a/helm-charts/sep24-reference-ui/values.yaml
+++ b/helm-charts/sep24-reference-ui/values.yaml
@@ -8,6 +8,7 @@ container:
 
 config:
   businessServerEndpoint: "http://localhost:8091"
+  allowedHost: "localhost"
 
 services:
   ui:


### PR DESCRIPTION
### Description

The following step of [[PD] Add allowed host env var](https://github.com/stellar/sep24-reference-ui/pull/14)
Next step would be update kube repo with `allowedHost=<ingressHost>`

### Testing

Tested with minikube and env var was properly populated


