### PR TITLE
[ANCHOR-789] Update SEP-12 to explicitly support contract accounts

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -223,7 +223,7 @@ public class Sep12Service {
       return;
     }
 
-    // SEP-12 says: If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this
+    // SEP-12 says: If a memo is present in the decoded JWT's `sub` value, it must match this
     // parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests
     // must match the 64-bit integer subaccount ID of the muxed account. See the Shared Account's
     // section for more information.
@@ -249,7 +249,7 @@ public class Sep12Service {
     }
     String memoTypeId = MemoHelper.memoTypeAsString(MemoType.MEMO_ID);
     String memoType = Objects.toString(requestBase.getMemoType(), memoTypeId);
-    // SEP-12 says: If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter
+    // SEP-12 says: If a memo is present in the decoded JWT's `sub` value, this parameter
     // (memoType) can be ignored:
     if (token.getAccountMemo() != null || token.getMuxedAccountId() != null) {
       memoType = MemoHelper.memoTypeAsString(MemoType.MEMO_ID);

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -16,11 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.skyscreamer.jsonassert.JSONAssert
-import org.stellar.anchor.api.callback.CustomerIntegration
-import org.stellar.anchor.api.callback.GetCustomerRequest
-import org.stellar.anchor.api.callback.GetCustomerResponse
-import org.stellar.anchor.api.callback.PutCustomerRequest
-import org.stellar.anchor.api.callback.PutCustomerResponse
+import org.stellar.anchor.api.callback.*
 import org.stellar.anchor.api.event.AnchorEvent
 import org.stellar.anchor.api.exception.*
 import org.stellar.anchor.api.platform.GetTransactionResponse
@@ -42,6 +38,8 @@ import org.stellar.anchor.util.StringHelper.json
 class Sep12ServiceTest {
   companion object {
     private const val TEST_ACCOUNT = "GBFZNZTFSI6TWLVAID7VOLCIFX2PMUOS2X7U6H4TNK4PAPSHPWMMUIZG"
+    private const val TEST_CONTRACT_ACCOUNT =
+      "CCAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX"
     private const val TEST_MEMO = "123456"
     private const val TEST_MUXED_ACCOUNT =
       "MBFZNZTFSI6TWLVAID7VOLCIFX2PMUOS2X7U6H4TNK4PAPSHPWMMUAAAAAAAAAPCIA2IM"
@@ -115,6 +113,37 @@ class Sep12ServiceTest {
     sep12Service = Sep12Service(customerIntegration, platformApiClient, eventService)
   }
 
+  @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])
+  @ParameterizedTest
+  fun `test get for all account types succeed`(account: String) {
+    val jwtToken = createJwtToken(account)
+    val request =
+      Sep12GetCustomerRequest.builder()
+        .memo(if (account == TEST_MUXED_ACCOUNT) TEST_MEMO else null)
+        .build()
+    assertDoesNotThrow { sep12Service.getCustomer(jwtToken, request) }
+  }
+
+  @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])
+  @ParameterizedTest
+  fun `test put for all account types succeed`(account: String) {
+    val jwtToken = createJwtToken(account)
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .memo(if (account == TEST_MUXED_ACCOUNT) TEST_MEMO else null)
+        .build()
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+  }
+
+  @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])
+  @ParameterizedTest
+  fun `test delete for all account types succeed`(account: String) {
+    val jwtToken = createJwtToken(account)
+    val memo = if (account == TEST_MUXED_ACCOUNT) TEST_MEMO else null
+    val memoType = if (account == TEST_MUXED_ACCOUNT) "id" else null
+    assertDoesNotThrow { sep12Service.deleteCustomer(jwtToken, account, memo, memoType) }
+  }
+
   @Test
   fun `test validate request and token accounts`() {
     val mockRequestBase = mockk<Sep12CustomerRequestBase>(relaxed = true)
@@ -144,6 +173,11 @@ class Sep12ServiceTest {
     // request account succeeds when the same as token's base account when using "account:memo"
     jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
     every { mockRequestBase.account } returns TEST_ACCOUNT
+    assertDoesNotThrow { sep12Service.validateRequestAndTokenAccounts(mockRequestBase, jwtToken) }
+
+    // request account succeeds for contract accounts
+    jwtToken = createJwtToken(TEST_CONTRACT_ACCOUNT)
+    every { mockRequestBase.account } returns TEST_CONTRACT_ACCOUNT
     assertDoesNotThrow { sep12Service.validateRequestAndTokenAccounts(mockRequestBase, jwtToken) }
   }
 


### PR DESCRIPTION
### Description

SEP-12 already supports contract accounts since it passes the `account` field from the `WebAuthJwt` directly into the customer callback without checking its type. This PR just adds some unit tests to explicitly test that passing a contract account to all endpoints does not throw exceptions. The SEP-6 end-to-end tests further test that the endpoint works as expected. 

### Context

Contract account support

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

