### PR TITLE
[PD] use call.request.queryParameters

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/Sep24TestRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/Sep24TestRoute.kt
@@ -24,11 +24,13 @@ fun Route.testSep24(
 ) {
   route("/sep24/interactive") {
     get {
-      log.info { "Called /sep24/interactive with parameters ${call.parameters}" }
+      log.info {
+        "Called /sep24/interactive with parameters ${call.request.queryParameters.entries()}"
+      }
 
       val token =
         JwtDecoder.decode(
-          call.parameters["token"]
+          call.request.queryParameters["token"]
             ?: throw ClientException("Missing token parameter in the request"),
           jwtKey,
         )


### PR DESCRIPTION
### Description

use `call.request.queryParameters` to properly fetch url query params following the `?`

### Context

When testing with Sep24TestRoute on kubernetes, reference server throws below error
```
16:39:37.446 INFO  - o.s.r.s.Sep24TestRoute - Called /sep24/interactive with parameters Parameters [transaction_id=[1ff8fcca-a5ca-4d2a-b883-723f8abe3b01]]
16:39:37.449 ERROR - o.s.r.ReferenceServer - Unexpected exception
org.stellar.reference.ClientException: Missing token parameter in the request
```
The potential cause could be proxy, encoding,  middlewares or as simple as this PR. 

### Testing

- `./gradlew test`
- Printed out in local that params were correctly parsed.

