### PR TITLE
[ANCHOR-770] Implement SEP-24 withdraw for contract accounts

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -24,6 +24,9 @@ public interface JdbcSep24TransactionRepo
   JdbcSep24Transaction findOneByToAccountAndMemoAndStatus(
       String toAccount, String memo, String status);
 
+  JdbcSep24Transaction findOneByToAccountAndFromAccountAndStatus(
+      String toAccount, String fromAccount, String status);
+
   List<Sep24Transaction> findBySep10AccountAndRequestAssetCodeOrderByStartedAtDesc(
       String stellarAccount, String assetCode);
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -59,6 +59,14 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
     return optTxn.orElse(null);
   }
 
+  public JdbcSep24Transaction findOneByToAccountAndFromAccountAndStatus(
+      String toAccount, String fromAccount, String status) {
+    Optional<JdbcSep24Transaction> optTxn =
+        Optional.ofNullable(
+            txnRepo.findOneByToAccountAndFromAccountAndStatus(toAccount, fromAccount, status));
+    return optTxn.orElse(null);
+  }
+
   @Override
   public List<Sep24Transaction> findTransactions(
       String accountId, String accountMemo, GetTransactionsRequest tr)

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -100,9 +100,19 @@ public class PaymentOperationToEventListener implements PaymentListener {
     // Find a transaction matching the memo, assumes transactions are unique to account+memo
     JdbcSep24Transaction sep24Txn = null;
     try {
-      sep24Txn =
-          sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
-              payment.getTo(), memo, SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+      if (memo != null) {
+        sep24Txn =
+            sep24TransactionStore.findOneByToAccountAndMemoAndStatus(
+                payment.getTo(), memo, SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+      } else {
+        // SAC transfers do not include a memo so we need to find the transaction by the
+        // from_account
+        sep24Txn =
+            sep24TransactionStore.findOneByToAccountAndFromAccountAndStatus(
+                payment.getTo(),
+                payment.getFrom(),
+                SepTransactionStatus.PENDING_USR_TRANSFER_START.toString());
+      }
     } catch (Exception ex) {
       errorEx(ex);
     }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -481,6 +481,88 @@ class PaymentOperationToEventListenerTest {
         "credit_alphanum4,USD,GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
       ]
   )
+  fun `test SEP-24 onReceived with sufficient payment and no memo patches the transaction`(
+    assetType: String,
+    assetCode: String,
+    assetIssuer: String?,
+  ) {
+    val transferReceivedAt = Instant.now()
+    val transferReceivedAtStr = DateTimeFormatter.ISO_INSTANT.format(transferReceivedAt)
+    val asset = createAsset(assetType, assetCode, assetIssuer)
+
+    val p =
+      ObservedPayment.builder()
+        .transactionHash("1ad62e48724426be96cf2cdb65d5dacb8fac2e403e50bedb717bfc8eaf05af30")
+        .assetType(assetType)
+        .assetCode(assetCode)
+        .assetName(asset.toString())
+        .assetIssuer(assetIssuer)
+        .amount("10.0000000")
+        .sourceAccount("GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4")
+        .from("GAJKV32ZXP5QLYHPCMLTV5QCMNJR3W6ZKFP6HMDN67EM2ULDHHDGEZYO")
+        .to("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364")
+        .type(ObservedPayment.Type.SAC_TRANSFER)
+        .createdAt(transferReceivedAtStr)
+        .transactionEnvelope(
+          "AAAAAgAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAAAB9AAAACwAAAABAAAAAEAAAAAAAAAAAAAAABiMbeEAAAAAAAAABQAAAAAAAAAAAAAAADcXPrnCDi+IDcGSvu/HjP779qjBv6K9Sie8i3WDySaIgAAAAA8M2CAAAAAAAAAAAAAAAAAJXdMB+xylKwEPk1tOLU82vnDM0u15RsK6/HCKsY1O3MAAAAAPDNggAAAAAAAAAAAAAAAALn+JaJ9iXEcrPeRFqEMGo6WWFeOwW15H/vvCOuMqCsSAAAAADwzYIAAAAAAAAAAAAAAAADbWpHlX0LQjIjY0x8jWkclnQDK8jFmqhzCmB+1EusXwAAAAAA8M2CAAAAAAAAAAAAAAAAAmy3UTqTnhNzIg8TjCYiRh9l07ls0Hi5FTqelhfZ4KqAAAAAAPDNggAAAAAAAAAAAAAAAAIwiZIIbYJn7MbHrrM+Pg85c6Lcn0ZGLb8NIiXLEIPTnAAAAADwzYIAAAAAAAAAAAAAAAAAYEjPKA/6lDpr/w1Cfif2hK4GHeNODhw0kk4kgLrmPrQAAAAA8M2CAAAAAAAAAAAAAAAAASMrE32C3vL39cj84pIg2mt6OkeWBz5OSZn0eypcjS4IAAAAAPDNggAAAAAAAAAAAAAAAAIuxsI+2mSeh3RkrkcpQ8bMqE7nXUmdvgwyJS/dBThIPAAAAADwzYIAAAAAAAAAAAAAAAACuZxdjR/GXaymdc9y5WFzz2A8Yk5hhgzBZsQ9R0/BmZwAAAAA8M2CAAAAAAAAAAAAAAAAAAtWBvyq0ToNovhQHSLeQYu7UzuqbVrm0i3d1TjRm7WEAAAAAPDNggAAAAAAAAAAAAAAAANtrzNON0u1IEGKmVsm80/Av+BKip0ioeS/4E+Ejs9YPAAAAADwzYIAAAAAAAAAAAAAAAAD+ejNcgNcKjR/ihUx1ikhdz5zmhzvRET3LGd7oOiBlTwAAAAA8M2CAAAAAAAAAAAAAAAAASXG3P6KJjS6e0dzirbso8vRvZKo6zETUsEv7OSP8XekAAAAAPDNggAAAAAAAAAAAAAAAAC5orVpxxvGEB8ISTho2YdOPZJrd7UBj1Bt8TOjLOiEKAAAAADwzYIAAAAAAAAAAAAAAAAAOQR7AqdGyIIMuFLw9JQWtHqsUJD94kHum7SJS9PXkOwAAAAA8M2CAAAAAAAAAAAAAAAAAIosijRx7xSP/+GA6eAjGeV9wJtKDySP+OJr90euE1yQAAAAAPDNggAAAAAAAAAAAAAAAAKlHXWQvwNPeT4Pp1oJDiOpcKwS3d9sho+ha+6pyFwFqAAAAADwzYIAAAAAAAAAAAAAAAABjCjnoL8+FEP0LByZA9PfMLwU1uAX4Cb13rVs83e1UZAAAAAA8M2CAAAAAAAAAAAAAAAAAokhNCZNGq9uAkfKTNoNGr5XmmMoY5poQEmp8OVbit7IAAAAAPDNggAAAAAAAAAABhlbgnAAAAEBa9csgF5/0wxrYM6oVsbM4Yd+/3uVIplS6iLmPOS4xf8oLQLtjKKKIIKmg9Gc/yYm3icZyU7icy9hGjcujenMN"
+        )
+        .id("755914248193")
+        .build()
+
+    val sep24TxMock = JdbcSep24Transaction()
+    sep24TxMock.id = "ceaa7677-a5a7-434e-b02a-8e0801b3e7bd"
+    sep24TxMock.requestAssetCode = assetCode
+    sep24TxMock.requestAssetIssuer = assetIssuer
+    sep24TxMock.amountIn = "10.0000000"
+    sep24TxMock.kind = PlatformTransactionData.Kind.WITHDRAWAL.kind
+
+    val sep24TxnCopy = gson.fromJson(gson.toJson(sep24TxMock), JdbcSep24Transaction::class.java)
+    every {
+      sep24TransactionStore.findOneByToAccountAndFromAccountAndStatus(
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
+        "GAJKV32ZXP5QLYHPCMLTV5QCMNJR3W6ZKFP6HMDN67EM2ULDHHDGEZYO",
+        any(),
+      )
+    } returns sep24TxnCopy
+
+    val txnIdCapture = slot<String>()
+    val stellarTxnIdCapture = slot<String>()
+    val amountCapture = slot<String>()
+    val messageCapture = slot<String>()
+
+    every { rpcConfig.customMessages.incomingPaymentReceived } returns "payment received"
+    every {
+      platformApiClient.notifyOnchainFundsReceived(
+        capture(txnIdCapture),
+        capture(stellarTxnIdCapture),
+        capture(amountCapture),
+        capture(messageCapture),
+      )
+    } just Runs
+
+    paymentOperationToEventListener.onReceived(p)
+    verify(exactly = 1) {
+      sep24TransactionStore.findOneByToAccountAndFromAccountAndStatus(
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
+        "GAJKV32ZXP5QLYHPCMLTV5QCMNJR3W6ZKFP6HMDN67EM2ULDHHDGEZYO",
+        "pending_user_transfer_start",
+      )
+    }
+
+    assertEquals(sep24TxMock.id, txnIdCapture.captured)
+    assertEquals(p.transactionHash, stellarTxnIdCapture.captured)
+    assertEquals(p.amount, amountCapture.captured)
+    assertEquals("payment received", messageCapture.captured)
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+    value =
+      [
+        "native,native,",
+        "credit_alphanum4,USD,GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
+      ]
+  )
   fun `test SEP-6 onReceived with sufficient payment patches the transaction`(
     assetType: String,
     assetCode: String,

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -43,6 +43,9 @@ class PaymentOperationToEventListenerTest {
     every { sep24TransactionStore.findOneByToAccountAndMemoAndStatus(any(), any(), any()) } returns
       null
     every {
+      sep24TransactionStore.findOneByToAccountAndFromAccountAndStatus(any(), any(), any())
+    } returns null
+    every {
       sep6TransactionStore.findOneByWithdrawAnchorAccountAndMemoAndStatus(any(), any(), any())
     } returns null
     every {


### PR DESCRIPTION
### Description

This implements SEP-24 withdraw flows for contract accounts. The bulk of this PR is adding test code.

### Context

Contract account support

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

