### PR TITLE
[PD] Add reference server root route

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/Sep24TestRoute.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/sep24/Sep24TestRoute.kt
@@ -22,6 +22,7 @@ fun Route.testSep24(
   withdrawalService: WithdrawalService,
   jwtKey: String,
 ) {
+  route("/") { get { call.respondText("Reference server is running ...") } }
   route("/sep24/interactive") {
     get {
       log.info { "Called /sep24/interactive with parameters ${call.parameters}" }


### PR DESCRIPTION
### Description

Reference server is unavailable on k8s. Adding a root route for test and debug 

### Testing
<img width="654" alt="Screenshot 2025-02-25 at 6 56 18 PM" src="https://github.com/user-attachments/assets/e156137a-79e8-4ab8-a33f-2b7783430eee" />

