### PR TITLE
[CHORE] Bump version to 3.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "3.0.1"
+  version = "3.0.2"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v3.0.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.0.1)
+[![Docker](https://badgen.net/badge/Latest%20Release/v3.0.2/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.0.2)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=3.0.1
+version=3.0.2


### PR DESCRIPTION
For release 3.0.2

`stg` env is now available for test.