### PR TITLE
Use SEP-45 JWT secret for signing SEP-45 JWTs

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -42,6 +42,7 @@ public class JwtService {
 
   String sep6MoreInfoUrlJwtSecret;
   String sep10JwtSecret;
+  String sep45JwtSecret;
   String sep24InteractiveUrlJwtSecret;
   String sep24MoreInfoUrlJwtSecret;
   String callbackAuthSecret;
@@ -53,6 +54,7 @@ public class JwtService {
     this(
         secretConfig.getSep6MoreInfoUrlJwtSecret(),
         secretConfig.getSep10JwtSecretKey(),
+        secretConfig.getSep45JwtSecretKey(),
         secretConfig.getSep24InteractiveUrlJwtSecret(),
         secretConfig.getSep24MoreInfoUrlJwtSecret(),
         secretConfig.getCallbackAuthSecret(),
@@ -63,6 +65,7 @@ public class JwtService {
   public JwtService(
       String sep6MoreInfoUrlJwtSecret,
       String sep10JwtSecret,
+      String sep45JwtSecret,
       String sep24InteractiveUrlJwtSecret,
       String sep24MoreInfoUrlJwtSecret,
       String callbackAuthSecret,
@@ -70,6 +73,7 @@ public class JwtService {
       String custodyAuthSecret) {
     this.sep6MoreInfoUrlJwtSecret = sep6MoreInfoUrlJwtSecret;
     this.sep10JwtSecret = sep10JwtSecret;
+    this.sep45JwtSecret = sep45JwtSecret;
     this.sep24InteractiveUrlJwtSecret = sep24InteractiveUrlJwtSecret;
     this.sep24MoreInfoUrlJwtSecret = sep24MoreInfoUrlJwtSecret;
     this.callbackAuthSecret = callbackAuthSecret;
@@ -80,7 +84,7 @@ public class JwtService {
     Security.addProvider(new BouncyCastleProvider());
   }
 
-  public String encode(WebAuthJwt token) {
+  public <T extends WebAuthJwt> String encode(T token) {
     Instant timeExp = Instant.ofEpochSecond(token.getExp());
     Instant timeIat = Instant.ofEpochSecond(token.getIat());
 
@@ -101,7 +105,11 @@ public class JwtService {
       builder.claim(HOME_DOMAIN, token.getHomeDomain());
     }
 
-    return signJWT(builder, sep10JwtSecret);
+    if (token instanceof Sep45Jwt) {
+      return signJWT(builder, sep45JwtSecret);
+    } else {
+      return signJWT(builder, sep10JwtSecret);
+    }
   }
 
   public String encode(MoreInfoUrlJwt token) throws InvalidConfigException {
@@ -182,8 +190,10 @@ public class JwtService {
     String secret;
     if (cls.equals(Sep6MoreInfoUrlJwt.class)) {
       secret = sep6MoreInfoUrlJwtSecret;
-    } else if (cls.equals(WebAuthJwt.class)) {
+    } else if (cls.equals(Sep10Jwt.class)) {
       secret = sep10JwtSecret;
+    } else if (cls.equals(Sep45Jwt.class)) {
+      secret = sep45JwtSecret;
     } else if (cls.equals(Sep24InteractiveUrlJwt.class)) {
       secret = sep24InteractiveUrlJwtSecret;
     } else if (cls.equals(Sep24MoreInfoUrlJwt.class)) {
@@ -203,8 +213,10 @@ public class JwtService {
 
     if (cls.equals(Sep6MoreInfoUrlJwt.class)) {
       return (T) Sep6MoreInfoUrlJwt.class.getConstructor(Jwt.class).newInstance(jwt);
-    } else if (cls.equals(WebAuthJwt.class)) {
-      return (T) WebAuthJwt.class.getConstructor(Jwt.class).newInstance(jwt);
+    } else if (cls.equals(Sep10Jwt.class)) {
+      return (T) Sep10Jwt.class.getConstructor(Jwt.class).newInstance(jwt);
+    } else if (cls.equals(Sep45Jwt.class)) {
+      return (T) Sep45Jwt.class.getConstructor(Jwt.class).newInstance(jwt);
     } else if (cls.equals(Sep24InteractiveUrlJwt.class)) {
       return (T) Sep24InteractiveUrlJwt.class.getConstructor(Jwt.class).newInstance(jwt);
     } else if (cls.equals(Sep24MoreInfoUrlJwt.class)) {

--- a/core/src/main/java/org/stellar/anchor/auth/Sep10Jwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/Sep10Jwt.java
@@ -1,0 +1,38 @@
+package org.stellar.anchor.auth;
+
+import io.jsonwebtoken.Jwt;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Sep10Jwt extends WebAuthJwt {
+
+  public Sep10Jwt(Jwt jwt) {
+    super(jwt);
+  }
+
+  public Sep10Jwt(
+      String iss,
+      String sub,
+      long iat,
+      long exp,
+      String jti,
+      String clientDomain,
+      String homeDomain) {
+    super(iss, sub, iat, exp, jti, clientDomain, homeDomain);
+  }
+
+  public static Sep10Jwt of(
+      String iss,
+      String sub,
+      long iat,
+      long exp,
+      String jti,
+      String clientDomain,
+      String homeDomain) {
+    return new Sep10Jwt(iss, sub, iat, exp, jti, clientDomain, homeDomain);
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/auth/Sep45Jwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/Sep45Jwt.java
@@ -1,0 +1,51 @@
+package org.stellar.anchor.auth;
+
+import io.jsonwebtoken.Jwt;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Sep45Jwt extends WebAuthJwt {
+
+  public Sep45Jwt(Jwt jwt) {
+    super(jwt);
+  }
+
+  public Sep45Jwt(
+      String iss,
+      String sub,
+      long iat,
+      long exp,
+      String jti,
+      String clientDomain,
+      String homeDomain) {
+    super(iss, sub, iat, exp, jti, clientDomain, homeDomain);
+  }
+
+  public static Sep45Jwt of(
+      String iss,
+      String sub,
+      long iat,
+      long exp,
+      String jti,
+      String clientDomain,
+      String homeDomain) {
+    return new Sep45Jwt(iss, sub, iat, exp, jti, clientDomain, homeDomain);
+  }
+
+  @Override
+  public String getAccountMemo() {
+    throw new UnsupportedOperationException("SEP-45 does not support account memos");
+  }
+
+  @Override
+  public String getMuxedAccount() {
+    throw new UnsupportedOperationException("SEP-45 does not support muxed accounts");
+  }
+
+  @Override
+  public Long getMuxedAccountId() {
+    throw new UnsupportedOperationException("SEP-45 does not support muxed accounts");
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
@@ -14,7 +14,7 @@ import org.stellar.sdk.MuxedAccount;
 @Getter
 @Setter
 @NoArgsConstructor
-public class WebAuthJwt extends AbstractJwt {
+public abstract class WebAuthJwt extends AbstractJwt {
   @SerializedName(value = "client_domain")
   String clientDomain;
 
@@ -71,30 +71,6 @@ public class WebAuthJwt extends AbstractJwt {
     this.clientDomain = clientDomain;
     this.homeDomain = homeDomain;
     updateAccountAndMemo();
-  }
-
-  public static WebAuthJwt of(
-      String iss, String sub, long iat, long exp, String jti, String clientDomain) {
-    return new WebAuthJwt(iss, sub, iat, exp, jti, clientDomain, null);
-  }
-
-  public static WebAuthJwt of(
-      String iss,
-      String sub,
-      long iat,
-      long exp,
-      String jti,
-      String clientDomain,
-      String homeDomain) {
-    return new WebAuthJwt(iss, sub, iat, exp, jti, clientDomain, homeDomain);
-  }
-
-  public static WebAuthJwt of(String iss, long iat, long exp) {
-    WebAuthJwt token = new WebAuthJwt(iss, null, iat, 0, null, null, null);
-    token.iss = iss;
-    token.iat = iat;
-    token.exp = exp;
-    return token;
   }
 
   void updateAccountAndMemo() {

--- a/core/src/main/java/org/stellar/anchor/filter/WebAuthJwtFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/WebAuthJwtFilter.java
@@ -4,8 +4,9 @@ import static org.stellar.anchor.util.Log.*;
 
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.NonNull;
 import org.stellar.anchor.auth.JwtService;
+import org.stellar.anchor.auth.Sep10Jwt;
+import org.stellar.anchor.auth.Sep45Jwt;
 import org.stellar.anchor.auth.WebAuthJwt;
 
 public class WebAuthJwtFilter extends AbstractJwtFilter {
@@ -17,9 +18,16 @@ public class WebAuthJwtFilter extends AbstractJwtFilter {
   @Override
   public void check(String jwtCipher, HttpServletRequest request, ServletResponse servletResponse)
       throws Exception {
-    @NonNull WebAuthJwt token = jwtService.decode(jwtCipher, WebAuthJwt.class);
-    infoF("token created. account={} url={}", shorter(token.getAccount()), request.getRequestURL());
-    debugF("storing token to request {}:", request.getRequestURL(), token);
-    request.setAttribute(JWT_TOKEN, token);
+    WebAuthJwt token = null;
+    try {
+      token = jwtService.decode(jwtCipher, Sep10Jwt.class);
+    } catch (Exception ignored) {
+      token = jwtService.decode(jwtCipher, Sep45Jwt.class);
+    } finally {
+      infoF(
+          "token created. account={} url={}", shorter(token.getAccount()), request.getRequestURL());
+      debugF("storing token to request {}:", request.getRequestURL(), token);
+      request.setAttribute(JWT_TOKEN, token);
+    }
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -26,7 +26,7 @@ import org.stellar.anchor.api.sep.sep10.ChallengeResponse;
 import org.stellar.anchor.api.sep.sep10.ValidationRequest;
 import org.stellar.anchor.api.sep.sep10.ValidationResponse;
 import org.stellar.anchor.auth.JwtService;
-import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.SecretConfig;
@@ -531,8 +531,8 @@ public class Sep10Service implements ISep10Service {
       ChallengeTransaction challenge, String clientDomain, String homeDomain) {
     long issuedAt = challenge.getTransaction().getTimeBounds().getMinTime().longValue();
     Memo memo = challenge.getTransaction().getMemo();
-    WebAuthJwt webAuthJwt =
-        WebAuthJwt.of(
+    Sep10Jwt webAuthJwt =
+        Sep10Jwt.of(
             authUrl(),
             (memo == null || memo instanceof MemoNone)
                 ? challenge.getClientAccountId()

--- a/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
@@ -18,7 +18,7 @@ import org.stellar.anchor.api.sep.sep45.ChallengeResponse;
 import org.stellar.anchor.api.sep.sep45.ValidationRequest;
 import org.stellar.anchor.api.sep.sep45.ValidationResponse;
 import org.stellar.anchor.auth.JwtService;
-import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.auth.Sep45Jwt;
 import org.stellar.anchor.config.AppConfig;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.config.Sep45Config;
@@ -228,8 +228,8 @@ public class Sep45Service {
       throw new InternalServerErrorException("Unable to decode invocation");
     }
 
-    WebAuthJwt jwt =
-        WebAuthJwt.of(
+    Sep45Jwt jwt =
+        Sep45Jwt.of(
             homeDomain,
             account,
             issuedAt,

--- a/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/TestHelper.kt
@@ -2,6 +2,7 @@ package org.stellar.anchor
 
 import io.mockk.every
 import javax.crypto.SecretKey
+import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.WebAuthJwt
 import org.stellar.anchor.config.CustodySecretConfig
 import org.stellar.anchor.config.SecretConfig
@@ -21,7 +22,7 @@ class TestHelper {
       homeDomain: String = "test.stellar.org",
     ): WebAuthJwt {
       val issuedAt: Long = System.currentTimeMillis() / 1000L
-      return WebAuthJwt.of(
+      return Sep10Jwt.of(
         "$hostUrl/auth",
         if (accountMemo == null) account else "$account:$accountMemo",
         issuedAt,
@@ -48,6 +49,8 @@ fun SecretConfig.setupMock(block: (() -> Any)? = null) {
     "jwt_secret_sep_6_more_info_url_jwt_secret".also { KeyUtil.validateJWTSecret(it) }
   every { cfg.sep10JwtSecretKey } returns
     "jwt_secret_sep_10_secret_key_jwt_secret".also { KeyUtil.validateJWTSecret(it) }
+  every { cfg.sep45JwtSecretKey } returns
+    "jwt_secret_sep_45_secret_key_jwt_secret".also { KeyUtil.validateJWTSecret(it) }
   every { cfg.sep10SigningSeed } returns TEST_SIGNING_SEED.also { KeyUtil.validateJWTSecret(it) }
   every { cfg.sep24InteractiveUrlJwtSecret } returns
     "jwt_secret_sep_24_interactive_url_jwt_secret".also { KeyUtil.validateJWTSecret(it) }

--- a/core/src/test/kotlin/org/stellar/anchor/auth/WebAuthJwtTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/WebAuthJwtTest.kt
@@ -12,7 +12,7 @@ class WebAuthJwtTest {
 
   @Test
   fun `test token creation`() {
-    val token = WebAuthJwt.of("iss", TEST_ACCOUNT, issuedAt, expiresAt, "", TEST_CLIENT_DOMAIN)
+    val token = Sep10Jwt.of("iss", TEST_ACCOUNT, issuedAt, expiresAt, "", TEST_CLIENT_DOMAIN, null)
     assertNull(token.accountMemo)
     assertEquals(TEST_ACCOUNT, token.account)
 
@@ -23,13 +23,14 @@ class WebAuthJwtTest {
   fun `test the mapping of JWT fields`() {
     val accountMemo = "135689"
     val token =
-      WebAuthJwt.of(
+      Sep10Jwt.of(
         "iss",
         "$TEST_ACCOUNT:$accountMemo",
         issuedAt,
         expiresAt,
         "",
         TEST_CLIENT_DOMAIN,
+        null,
       )
     assertEquals(accountMemo, token.accountMemo)
     assertEquals(TEST_ACCOUNT, token.account)
@@ -40,7 +41,7 @@ class WebAuthJwtTest {
   @Test
   fun `test the mux account mapping`() {
     val muxedAccount = "MA3X53JGZ5SLT733GNKH3CVV7RKCL4DXWCIZG2Y24HA24L6XNEHSQAAAAAAETFQC2JGGC"
-    val token = WebAuthJwt.of("iss", muxedAccount, issuedAt, expiresAt, "", TEST_CLIENT_DOMAIN)
+    val token = Sep10Jwt.of("iss", muxedAccount, issuedAt, expiresAt, "", TEST_CLIENT_DOMAIN, null)
     assertEquals(muxedAccount, token.muxedAccount)
     assertEquals("GA3X53JGZ5SLT733GNKH3CVV7RKCL4DXWCIZG2Y24HA24L6XNEHSQXT4", token.account)
     assertEquals(1234567890, token.muxedAccountId)

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -48,7 +48,7 @@ import org.stellar.anchor.api.sep.sep10.ChallengeRequest
 import org.stellar.anchor.api.sep.sep10.ChallengeResponse
 import org.stellar.anchor.api.sep.sep10.ValidationRequest
 import org.stellar.anchor.auth.JwtService
-import org.stellar.anchor.auth.WebAuthJwt
+import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.config.AppConfig
 import org.stellar.anchor.config.CustodySecretConfig
@@ -386,7 +386,7 @@ internal class Sep10ServiceTest {
     every { horizon.server.accounts().account(ofType(String::class)) } returns accountResponse
 
     val response = sep10Service.validateChallenge(vr)
-    val jwt = jwtService.decode(response.token, WebAuthJwt::class.java)
+    val jwt = jwtService.decode(response.token, Sep10Jwt::class.java)
     assertEquals("${clientKeyPair.accountId}:$TEST_MEMO", jwt.sub)
   }
 
@@ -414,7 +414,7 @@ internal class Sep10ServiceTest {
 
     val validationResponse = sep10Service.validateChallenge(vr)
 
-    val token = jwtService.decode(validationResponse.token, WebAuthJwt::class.java)
+    val token = jwtService.decode(validationResponse.token, Sep10Jwt::class.java)
     assertEquals(token.clientDomain, TEST_CLIENT_DOMAIN)
     assertEquals(token.homeDomain, TEST_HOME_DOMAIN)
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -31,6 +31,7 @@ import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.apiclient.PlatformApiClient
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
+import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.WebAuthJwt
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.util.StringHelper.json
@@ -607,6 +608,6 @@ class Sep12ServiceTest {
   }
 
   private fun createJwtToken(subject: String): WebAuthJwt {
-    return WebAuthJwt.of("$TEST_HOST_URL/auth", subject, issuedAt, expiresAt, "", CLIENT_DOMAIN)
+    return Sep10Jwt.of("$TEST_HOST_URL/auth", subject, issuedAt, expiresAt, "", CLIENT_DOMAIN, null)
   }
 }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/e2etest/Sep24End2EndTests.kt
@@ -74,6 +74,7 @@ open class Sep24End2EndTests : AbstractIntegrationTests(TestConfig()) {
     JwtService(
       config.env["secret.sep6.more_info_url.jwt_secret"],
       config.env["secret.sep10.jwt_secret"]!!,
+      config.env["secret.sep45.jwt_secret"]!!,
       config.env["secret.sep24.interactive_url.jwt_secret"]!!,
       config.env["secret.sep24.more_info_url.jwt_secret"]!!,
       config.env["secret.callback_api.auth_secret"]!!,

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/CallbackApiTests.kt
@@ -53,6 +53,7 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
     JwtService(
       config.env["secret.sep6.more_info_url.jwt_secret"],
       config.env["secret.sep10.jwt_secret"]!!,
+      config.env["secret.sep45.jwt_secret"]!!,
       config.env["secret.sep24.interactive_url.jwt_secret"]!!,
       config.env["secret.sep24.more_info_url.jwt_secret"]!!,
       config.env["secret.callback_api.auth_secret"]!!,
@@ -65,7 +66,7 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
       "Authorization",
       platformToAnchorJwtService,
       JWT_EXPIRATION_MILLISECONDS,
-      CallbackAuthJwt::class.java
+      CallbackAuthJwt::class.java,
     )
 
   private val gson: Gson = GsonUtils.getInstance()
@@ -79,7 +80,7 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
       httpClient,
       authHelper,
       gson,
-      mockAssetService
+      mockAssetService,
     )
 
   @BeforeAll
@@ -89,7 +90,7 @@ class CallbackApiTests : AbstractIntegrationTests(TestConfig()) {
       listOf(
           AssetInfo.Schema.STELLAR,
           "USDC",
-          "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+          "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
         )
         .joinToString { ":" }
     usdc.significantDecimals = 4

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24Tests.kt
@@ -41,11 +41,12 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JwtService(
       config.env["secret.sep6.more_info_url.jwt_secret"],
       config.env["secret.sep10.jwt_secret"]!!,
+      config.env["secret.sep45.jwt_secret"]!!,
       config.env["secret.sep24.interactive_url.jwt_secret"]!!,
       config.env["secret.sep24.more_info_url.jwt_secret"]!!,
       config.env["secret.callback_api.auth_secret"]!!,
       config.env["secret.platform_api.auth_secret"]!!,
-      null
+      null,
     )
 
   private val platformApiClient =
@@ -75,11 +76,11 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
           IssuedAssetId("USDC", "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"),
           token,
           withdrawRequest,
-          "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4"
+          "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
         )
     printResponse(
       "POST /transactions/withdraw/interactive response:",
-      Json.encodeToString(response)
+      Json.encodeToString(response),
     )
     savedWithdrawTxn =
       anchor.sep24().getTransaction(response.id, token) as IncompleteWithdrawalTransaction
@@ -88,7 +89,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     assertEquals("INCOMPLETE", savedWithdrawTxn.status.name)
     assertEquals(
       "GAIUIZPHLIHQEMNJGSZKCEUWHAZVGUZDBDMO2JXNAJZZZVNSVHQCEWJ4",
-      savedWithdrawTxn.from?.address
+      savedWithdrawTxn.from?.address,
     )
 
     val requestLang = "es-AR"
@@ -97,7 +98,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
       jwtService
         .decode(
           UriComponentsBuilder.fromUriString(langTx.moreInfoUrl).build().queryParams["token"]!![0],
-          Sep24MoreInfoUrlJwt::class.java
+          Sep24MoreInfoUrlJwt::class.java,
         )
         .claims["data"]
     var lang = (claims as Map<String, String>)["lang"]
@@ -121,7 +122,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
         .deposit(
           IssuedAssetId(depositRequest["asset_code"]!!, depositRequest["asset_issuer"]!!),
           token,
-          depositRequest as HashMap<String, String>
+          depositRequest as HashMap<String, String>,
         )
     printResponse("POST /transactions/deposit/interactive response:", Json.encodeToString(response))
     savedDepositTxn =
@@ -132,7 +133,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     assertEquals("INCOMPLETE", savedDepositTxn.status.name)
     assertEquals(
       "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      savedDepositTxn.to?.address
+      savedDepositTxn.to?.address,
     )
     // check the returning Sep24InteractiveUrlJwt
     val params = UriComponentsBuilder.fromUriString(response.url).build().queryParams
@@ -199,7 +200,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
         .getTransactionBy(
           token,
           savedDepositTxn.id,
-          "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+          "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
         )
 
     val params = UriComponentsBuilder.fromUriString(txn.moreInfoUrl).build().queryParams
@@ -216,7 +217,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JSONAssert.assertEquals(
       expectedWithdrawTransactionResponse,
       json(actualWithdrawTxn),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
 
     val actualDepositTxn = platformApiClient.getTransaction(savedDepositTxn.id)
@@ -225,7 +226,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JSONAssert.assertEquals(
       expectedDepositTransactionResponse,
       json(actualDepositTxn),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 
@@ -244,7 +245,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JSONAssert.assertEquals(
       expectedAfterPatchWithdraw,
       json(afterPatchWithdraw),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
 
     var afterPatchDeposit = platformApiClient.getTransaction(savedDepositTxn.id)
@@ -252,7 +253,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JSONAssert.assertEquals(
       expectedAfterPatchDeposit,
       json(afterPatchDeposit),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
 
     // Test patch idempotency
@@ -261,7 +262,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JSONAssert.assertEquals(
       expectedAfterPatchWithdraw,
       json(afterPatchWithdraw),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
 
     afterPatchDeposit = platformApiClient.getTransaction(savedDepositTxn.id)
@@ -269,7 +270,7 @@ class Sep24Tests : AbstractIntegrationTests(TestConfig()) {
     JSONAssert.assertEquals(
       expectedAfterPatchDeposit,
       json(afterPatchDeposit),
-      JSONCompareMode.LENIENT
+      JSONCompareMode.LENIENT,
     )
   }
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.assertThrows
 import org.stellar.anchor.api.sep.sep45.ChallengeRequest
 import org.stellar.anchor.api.sep.sep45.ValidationRequest
 import org.stellar.anchor.auth.JwtService
-import org.stellar.anchor.auth.WebAuthJwt
+import org.stellar.anchor.auth.Sep45Jwt
 import org.stellar.anchor.client.Sep45Client
 import org.stellar.anchor.platform.AbstractIntegrationTests
 import org.stellar.anchor.platform.CLIENT_SMART_WALLET_ACCOUNT
@@ -34,6 +34,7 @@ class Sep45Tests : AbstractIntegrationTests(TestConfig()) {
     JwtService(
       config.env["secret.sep6.more_info_url.jwt_secret"],
       config.env["secret.sep10.jwt_secret"]!!,
+      config.env["secret.sep45.jwt_secret"]!!,
       config.env["secret.sep24.interactive_url.jwt_secret"]!!,
       config.env["secret.sep24.more_info_url.jwt_secret"]!!,
       config.env["secret.callback_api.auth_secret"]!!,
@@ -61,7 +62,7 @@ class Sep45Tests : AbstractIntegrationTests(TestConfig()) {
     val validationResponse = sep45Client.validate(validationRequest)
     Log.info("Validation response: ${GsonUtils.getInstance().toJson(validationResponse)}")
 
-    val jwt = jwtService.decode(validationResponse.token, WebAuthJwt::class.java)
+    val jwt = jwtService.decode(validationResponse.token, Sep45Jwt::class.java)
 
     assertEquals(homeDomain, jwt.homeDomain)
     assertEquals(CLIENT_SMART_WALLET_ACCOUNT, jwt.account)

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/AbstractAuthIntegrationTest.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/auth/AbstractAuthIntegrationTest.kt
@@ -29,9 +29,10 @@ abstract class AbstractAuthIntegrationTest {
         null,
         null,
         null,
+        null,
         PLATFORM_TO_ANCHOR_SECRET,
         ANCHOR_TO_PLATFORM_SECRET,
-        PLATFORM_TO_CUSTODY_SECRET
+        PLATFORM_TO_CUSTODY_SECRET,
       )
     private val jwtWrongKeyService =
       JwtService(
@@ -39,9 +40,10 @@ abstract class AbstractAuthIntegrationTest {
         null,
         null,
         null,
+        null,
         (PLATFORM_TO_ANCHOR_SECRET + "bad"),
         (ANCHOR_TO_PLATFORM_SECRET + "bad"),
-        (PLATFORM_TO_CUSTODY_SECRET + "bad")
+        (PLATFORM_TO_CUSTODY_SECRET + "bad"),
       )
 
     internal val platformJwtAuthHelper =


### PR DESCRIPTION
### Description

It's currently using the SEP-10 secret. This PR updates the encode/decode to use the SEP-45 secret instead.

### Context

Tech debt

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

