### PR TITLE
Enable event processing for callback API

### DIFF
--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -91,6 +91,10 @@ config:
   platform_api:
     base_url: http://anchor-platform-svc-platform:8085
 
+  event_processor:
+    callback_api_request:
+      enabled: true
+
   events:
     enabled: true
     queue:


### PR DESCRIPTION
### Description

This enables the event processor to send events to the business server in the local Kubernetes setup. SEP-6 would not work without event processing enabled.

### Context

This config was true by default in v2 but changed to false in v3. The helm chart values were never updated.

### Testing

- `./gradlew test`
- Tested that it works using the demo wallet.

### Documentation

N/A

### Known limitations

N/A

