### PR TITLE
[Fix] Improve date error msg

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -95,17 +95,20 @@ public class Sep12Service {
 
     if (StringUtils.isNotEmpty(request.getBirthDate())) {
       if (!isValidISO8601Date(request.getBirthDate())) {
-        throw new SepValidationException("Invalid 'birth_date'");
+        throw new SepValidationException(
+            "Invalid 'birth_date'. Expected format: YYYY-MM-DD (e.g., 1987-12-11)");
       }
     }
     if (StringUtils.isNotEmpty(request.getIdIssueDate())) {
       if (!isValidISO8601Date(request.getIdIssueDate())) {
-        throw new SepValidationException("Invalid 'id_issue_date'");
+        throw new SepValidationException(
+            "Invalid 'id_issue_date'. Expected format: YYYY-MM-DD (e.g., 1987-12-11)");
       }
     }
     if (StringUtils.isNotEmpty(request.getIdExpirationDate())) {
       if (!isValidISO8601Date(request.getIdExpirationDate())) {
-        throw new SepValidationException("Invalid 'id_expiration_date'");
+        throw new SepValidationException(
+            "Invalid 'id_expiration_date'. Expected format: YYYY-MM-DD (e.g., 1987-12-11)");
       }
     }
 


### PR DESCRIPTION
### Description

Improve error msg to be more indicative.
When testing SEP-6 with demo wallet, the KYC step requires all dates to be in ISO8601 format. 

### Testing

- `./gradlew test`
