### PR TITLE
[ANCHOR-914] Implement SEP-38 contract account support

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep38Config.java
@@ -4,5 +4,8 @@ package org.stellar.anchor.config;
 public interface Sep38Config {
   boolean isEnabled();
 
+  @Deprecated
   boolean isSep10Enforced();
+
+  boolean isAuthEnforced();
 }

--- a/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep38/Sep38Service.java
@@ -366,7 +366,7 @@ public class Sep38Service {
   private Pair<String, Pair<String, String>> validateToken(WebAuthJwt token)
       throws BadRequestException {
     if (token == null) {
-      throw new BadRequestException("missing sep10 jwt token");
+      throw new BadRequestException("missing web auth token");
     }
     String account, memo = null, memoType = null;
     if (!Objects.toString(token.getMuxedAccount(), "").isEmpty()) {
@@ -378,7 +378,7 @@ public class Sep38Service {
         memoType = "id";
       }
     } else {
-      throw new BadRequestException("sep10 token is malformed");
+      throw new BadRequestException("web auth token is malformed");
     }
     return Pair.of(account, Pair.of(memo, memoType));
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -100,7 +100,7 @@ public class SepBeans {
     registrationBean.addUrlPatterns("/sep31/transactions/*");
     registrationBean.addUrlPatterns("/sep38/quote");
     registrationBean.addUrlPatterns("/sep38/quote/*");
-    if (sep38Config.isSep10Enforced()) {
+    if (sep38Config.isSep10Enforced() || sep38Config.isAuthEnforced()) {
       registrationBean.addUrlPatterns("/sep38/info");
       registrationBean.addUrlPatterns("/sep38/price");
       registrationBean.addUrlPatterns("/sep38/prices");

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep38Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep38Config.java
@@ -2,12 +2,31 @@ package org.stellar.anchor.platform.config;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
 import org.stellar.anchor.config.Sep38Config;
 
 @Data
-public class PropertySep38Config implements Sep38Config {
+public class PropertySep38Config implements Sep38Config, Validator {
   boolean enabled;
 
   @SerializedName("sep10_enforced")
   boolean sep10Enforced;
+
+  @SerializedName("auth_enforced")
+  boolean authEnforced;
+
+  @Override
+  public boolean supports(Class<?> clazz) {
+    return Sep38Config.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(Object target, Errors errors) {
+    PropertySep38Config config = (PropertySep38Config) target;
+
+    if (config.isEnabled() && config.isAuthEnforced() != config.isSep10Enforced()) {
+      errors.reject("sep38-auth-enforced-mismatch", "Mismatched auth_enforced and sep10_enforced");
+    }
+  }
 }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -413,8 +413,10 @@ sep38:
   # Whether to enable SEP-38
   #
   enabled: false
-  # Whether to enforce SEP-10 authentication for SEP-38 /info, /price, /prices endpoints.
+  # (Deprecated) Whether to enforce SEP-10 authentication for SEP-38 /info, /price, /prices endpoints.
   sep10_enforced: false
+  # Whether to enforce SEP-10/SEP-45 authentication for SEP-38 /info, /price, /prices endpoints.
+  auth_enforced: false
 
 ######################
 # SEP-45 Configuration

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -102,6 +102,7 @@ sep31.enabled:
 sep31.payment_type:
 sep38.enabled:
 sep38.sep10_enforced:
+sep38.auth_enforced:
 sep45.enabled:
 sep45.web_auth_domain:
 sep45.web_auth_contract_id:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep38ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep38ConfigTest.kt
@@ -1,0 +1,41 @@
+package org.stellar.anchor.platform.config
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+
+class Sep38ConfigTest {
+  lateinit var config: PropertySep38Config
+  lateinit var errors: Errors
+
+  @BeforeEach
+  fun setup() {
+    config = PropertySep38Config()
+    config.enabled = true
+    config.sep10Enforced = true
+    config.authEnforced = true
+    errors = BindException(config, "config")
+  }
+
+  @Test
+  fun `test default sep38 config`() {
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @CsvSource("true,false", "false,true")
+  @ParameterizedTest
+  fun `test mismatched sep10Enforced and authEnforced`(
+    sep10Enforced: Boolean,
+    authEnforced: Boolean
+  ) {
+    config.sep10Enforced = sep10Enforced
+    config.authEnforced = authEnforced
+    config.validate(config, errors)
+    assertErrorCode(errors, "sep38-auth-enforced-mismatch")
+  }
+}


### PR DESCRIPTION
### Description

SEP-38 already supports contract accounts. This PR makes it explicit by adding tests.

### Context

Contract account support

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

