### PR TITLE
[PD][Fix] Add sep6 more info url in local values

### DIFF
--- a/helm-charts/sep-service/values.yaml
+++ b/helm-charts/sep-service/values.yaml
@@ -112,6 +112,8 @@ config:
 
   sep6:
     enabled: true
+    more_info_url:
+      base_url: http://localhost:3000/txn
 
   sep10:
     enabled: true


### PR DESCRIPTION
### Description

Missing in local is causing sep server pod crashing due to config validation failure

