### PR TITLE
[ANCHOR-632] Fix missing SENTRY_AUTH_TOKEN in event processor

### DIFF
--- a/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
+++ b/helm-charts/sep-service/templates/eventprocessor-deployment.yaml
@@ -78,6 +78,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.fullName }}-secrets
                   key: EVENTS_QUEUE_KAFKA_PASSWORD
+            - name: SENTRY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fullName }}-secrets
+                  key: SENTRY_AUTH_TOKEN
           resources:
             requests:
               memory: {{ .Values.services.eventProcessor.deployment.resources.requests.memory }}


### PR DESCRIPTION
### Description

Fix missing SENTRY_AUTH_TOKEN in event processor

### Context

- Bug fix

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

