### PR TITLE
Send sentry initialization message in debug level

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/configurator/SentryConfigAdapter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/configurator/SentryConfigAdapter.java
@@ -1,9 +1,11 @@
 package org.stellar.anchor.platform.configurator;
 
+import static io.sentry.Sentry.captureMessage;
 import static org.stellar.anchor.util.Log.*;
 import static org.stellar.anchor.util.StringHelper.*;
 
 import io.sentry.Sentry;
+import io.sentry.SentryLevel;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 
 public class SentryConfigAdapter extends SpringConfigAdapter {
@@ -30,6 +32,12 @@ public class SentryConfigAdapter extends SpringConfigAdapter {
           options.setTracesSampleRate(1.0);
           options.setEnableUncaughtExceptionHandler(true);
         });
+
+    captureMessage(
+        String.format(
+            "Sentry agent initialized. release:%s, environment: %s, debug: %s",
+            config.getString("sentry.release"), sentryEnv, config.getBoolean("sentry.debug")),
+        SentryLevel.DEBUG);
   }
 
   String getAuthToken() {


### PR DESCRIPTION
### Description

- Send sentry initialization message in debug level. (Log level not available)

### Context

- This is to indicate the sentry is activated instead of waiting for an exception to happen.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

