### PR TITLE
Fix contract address using a salt on deploy

### DIFF
--- a/soroban/README.md
+++ b/soroban/README.md
@@ -31,15 +31,17 @@ stellar contract deploy \
 --wasm target/wasm32-unknown-unknown/release/account.wasm \
 --source-account ${MY_ACCOUNT} \
 --network testnet \
+--salt 616e63686f722d706c6174666f726d \
 -- \
 --admin ${MY_ACCOUNT}
 --signer ${MY_ACCOUNT_PUBLIC_KEY_BYTES} # you can get this by calling KeyPair#rawPublicKey using the JS SDK
 
 # Deploy the web auth contract
 stellar contract deploy \
---wasm target/wasm32-unknown-unknown/release/web-auth.wasm \
+--wasm target/wasm32-unknown-unknown/release/web_auth.wasm \
 --source-account ${MY_ACCOUNT} \
 --network testnet \
+--salt 616e63686f722d706c6174666f726d \
 -- \
 --admin ${MY_ACCOUNT}
 ```


### PR DESCRIPTION
### Description

This adds the salt parameter to the contract deploy instructions so that the contract addresses stay the same between Testnet resets. The salt used is just the hash hex of "anchor-platform".

### Context

We don't want to update the code when there is a testnet reset.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

