### PR TITLE
[ANCHOR-1018] Fix sep24 txn fields were not populated into response

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java
@@ -21,13 +21,24 @@ public class Sep24Helper {
 
   static void setSharedTransactionResponseFields(TransactionResponse txnR, Sep24Transaction txn) {
     txnR.setId(txn.getTransactionId());
+    if (txn.getAmountIn() != null) txnR.setAmountIn(txn.getAmountIn());
+    if (txn.getAmountInAsset() != null) txnR.setAmountInAsset(txn.getAmountInAsset());
+    if (txn.getAmountOut() != null) txnR.setAmountOut(txn.getAmountOut());
+    if (txn.getAmountOutAsset() != null) txnR.setAmountOutAsset(txn.getAmountOutAsset());
     if (txn.getFromAccount() != null) txnR.setFrom(txn.getFromAccount());
     if (txn.getToAccount() != null) txnR.setTo(txn.getToAccount());
     if (txn.getStartedAt() != null) txnR.setStartedAt(txn.getStartedAt());
     if (txn.getCompletedAt() != null) txnR.setCompletedAt(txn.getCompletedAt());
+    if (txn.getFeeDetails() != null) txnR.setFeeDetails(txn.getFeeDetails());
     if (txn.getQuoteId() != null) txnR.setQuoteId(txn.getQuoteId());
     if (txn.getUserActionRequiredBy() != null)
       txnR.setUserActionRequiredBy(txn.getUserActionRequiredBy());
+    if (txn.getStellarTransactionId() != null)
+      txnR.setStellarTransactionId(txn.getStellarTransactionId());
+    if (txn.getExternalTransactionId() != null)
+      txnR.setExternalTransactionId(txn.getExternalTransactionId());
+    if (txn.getMessage() != null) txnR.setMessage(txn.getMessage());
+    if (txn.getRefunded() != null) txnR.setRefunded(txn.getRefunded());
   }
 
   static TransactionResponse updateRefundInfo(

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTestHelper.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTestHelper.kt
@@ -7,6 +7,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_ASSET_ISSUER_ACCOUNT_ID
 import org.stellar.anchor.TestConstants.Companion.TEST_OFFCHAIN_ASSET
 import org.stellar.anchor.TestConstants.Companion.TEST_QUOTE_ID
+import org.stellar.anchor.api.shared.FeeDescription
 
 fun createTestTransactionRequest(quoteID: String? = null): MutableMap<String, String> {
   val request =
@@ -44,7 +45,12 @@ fun createTestTransaction(kind: String): Sep24Transaction {
   txn.clientDomain = TestConstants.TEST_CLIENT_DOMAIN
   txn.protocol = "sep24"
   txn.amountIn = "321.4"
-  txn.amountOut = "321.4"
+  txn.amountInAsset = TEST_OFFCHAIN_ASSET
+  txn.amountOut = "320.4"
+  txn.amountOutAsset = TEST_ASSET
+  txn.amountFee = "1"
+  txn.amountFeeAsset = TEST_OFFCHAIN_ASSET
+  txn.feeDetailsList = listOf(FeeDescription("service_fee", "1"))
 
   return txn
 }
@@ -67,7 +73,9 @@ fun createTestTransactions(kind: String): MutableList<Sep24Transaction> {
   txn.clientDomain = TestConstants.TEST_CLIENT_DOMAIN
   txn.protocol = "sep24"
   txn.amountIn = "321.4"
-  txn.amountOut = "321.4"
+  txn.amountOut = "320.4"
+  txn.amountFee = "1"
+  txn.feeDetailsList = listOf(FeeDescription("service_fee", "1"))
   txn.quoteId = TEST_QUOTE_ID
   txns.add(txn)
 
@@ -86,7 +94,9 @@ fun createTestTransactions(kind: String): MutableList<Sep24Transaction> {
   txn.clientDomain = TestConstants.TEST_CLIENT_DOMAIN
   txn.protocol = "sep24"
   txn.amountIn = "456.7"
-  txn.amountOut = "456.7"
+  txn.amountOut = "455.7"
+  txn.amountFee = "1"
+  txn.feeDetailsList = listOf(FeeDescription("service_fee", "1"))
   txn.quoteId = TEST_QUOTE_ID
   txns.add(txn)
 


### PR DESCRIPTION
The `setSharedTransactionResponseFields` only have partial of the shared fields included, resulting rest of the fields missing in get transaction response