### PR TITLE
[ANCHOR-1018] Rename fee_details column and bump version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "3.0.3"
+  version = "3.0.4"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v3.0.3/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.0.3)
+[![Docker](https://badgen.net/badge/Latest%20Release/v3.0.4/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.0.4)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSepTransaction.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSepTransaction.java
@@ -55,8 +55,8 @@ public abstract class JdbcSepTransaction {
   @Column(name = "amount_fee_asset")
   String amountFeeAsset;
 
-  @SerializedName("fee_details")
-  @Column(name = "fee_details")
+  @SerializedName("fee_details_list")
+  @Column(name = "fee_details_list")
   @JdbcTypeCode(SqlTypes.JSON)
   List<FeeDescription> feeDetailsList;
 

--- a/platform/src/main/resources/db/migration/V21__sep6_24_31_rename_column.sql
+++ b/platform/src/main/resources/db/migration/V21__sep6_24_31_rename_column.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sep6_transaction RENAME COLUMN fee_details TO fee_details_list;
+ALTER TABLE sep24_transaction RENAME COLUMN fee_details TO fee_details_list;
+ALTER TABLE sep31_transaction RENAME COLUMN fee_details TO fee_details_list;
+

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=3.0.3
+version=3.0.4


### PR DESCRIPTION
#### What's Changed
Rename db column `fee_details `to `fee_details_list`.
Bump to 3.0.4 for patch release

#### Context
The database stored `feeDetailsList` (a list) under serialized name "fee_details", while sep24 transactionResponse expected a`FeeDetails` (a object) at the same key "fee_details". This caused Gson to fail with `Expected BEGIN_OBJECT but was BEGIN_ARRAY` at [here](https://github.com/stellar/anchor-platform/blob/develop/core/src/main/java/org/stellar/anchor/sep24/Sep24Helper.java#L122). 

#### WHY it didn't work
By default, Gson uses the JSON structure to map fields, not getter/setter methods. Even though `getFeeDetails` been implemented to help construct the object, Gson will still look for a nested `fee_details` object in the JSON.

However in our system the error (expect object but found array) was somehow silent.
