### PR TITLE
[Chore] Update SEP-45 contract version

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
@@ -36,10 +36,10 @@ public class Sep45Service {
   private static final String WEB_AUTH_VERIFY_FN = "web_auth_verify";
   private static final String KEY_ACCOUNT = "account";
   private static final String KEY_HOME_DOMAIN = "home_domain";
-  private static final String KEY_HOME_DOMAIN_ADDRESS = "home_domain_address";
   private static final String KEY_CLIENT_DOMAIN = "client_domain";
-  private static final String KEY_CLIENT_DOMAIN_ADDRESS = "client_domain_address";
+  private static final String KEY_CLIENT_DOMAIN_ACCOUNT = "client_domain_account";
   private static final String KEY_WEB_AUTH_DOMAIN = "web_auth_domain";
+  private static final String KEY_WEB_AUTH_DOMAIN_ACCOUNT = "web_auth_domain_account";
   private static final String KEY_NONCE = "nonce";
   private final AppConfig appConfig;
   private final SecretConfig secretConfig;
@@ -120,14 +120,14 @@ public class Sep45Service {
     argsMap.put(KEY_ACCOUNT, request.getAccount());
     argsMap.put(KEY_HOME_DOMAIN, request.getHomeDomain());
     argsMap.put(
-        KEY_HOME_DOMAIN_ADDRESS,
+        KEY_WEB_AUTH_DOMAIN_ACCOUNT,
         KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed()).getAccountId());
     argsMap.put(KEY_WEB_AUTH_DOMAIN, sep45Config.getWebAuthDomain());
     if (!isEmpty(request.getClientDomain())) {
       String clientDomainSigner =
           ClientDomainHelper.fetchSigningKeyFromClientDomain(request.getClientDomain(), false);
       argsMap.put(KEY_CLIENT_DOMAIN, request.getClientDomain());
-      argsMap.put(KEY_CLIENT_DOMAIN_ADDRESS, clientDomainSigner);
+      argsMap.put(KEY_CLIENT_DOMAIN_ACCOUNT, clientDomainSigner);
     }
 
     Nonce nonce = nonceManager.create(sep45Config.getAuthTimeout());
@@ -356,7 +356,7 @@ public class Sep45Service {
     }
 
     KeyPair keyPair = KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed());
-    if (!keyPair.getAccountId().equals(argsMap.get(KEY_HOME_DOMAIN_ADDRESS))) {
+    if (!keyPair.getAccountId().equals(argsMap.get(KEY_WEB_AUTH_DOMAIN_ACCOUNT))) {
       throw new BadRequestException("Invalid home domain address");
     }
 
@@ -367,7 +367,7 @@ public class Sep45Service {
     if (argsMap.containsKey(KEY_CLIENT_DOMAIN)) {
       String clientDomainSigner =
           ClientDomainHelper.fetchSigningKeyFromClientDomain(argsMap.get(KEY_CLIENT_DOMAIN), false);
-      if (!clientDomainSigner.equals(argsMap.get(KEY_CLIENT_DOMAIN_ADDRESS))) {
+      if (!clientDomainSigner.equals(argsMap.get(KEY_CLIENT_DOMAIN_ACCOUNT))) {
         throw new BadRequestException("Invalid client domain address");
       }
     }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt
@@ -153,7 +153,7 @@ class Sep45Tests : IntegrationTestBase(TestConfig()) {
   }
 
   @Test
-  fun testClientDomainVerification() {
+  fun testCliegikntDomainVerification() {
     val challenge =
       sep45Client.getChallenge(
         ChallengeRequest.builder()

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep45Tests.kt
@@ -153,7 +153,7 @@ class Sep45Tests : IntegrationTestBase(TestConfig()) {
   }
 
   @Test
-  fun testCliegikntDomainVerification() {
+  fun testClientDomainVerification() {
     val challenge =
       sep45Client.getChallenge(
         ChallengeRequest.builder()

--- a/soroban/README.md
+++ b/soroban/README.md
@@ -50,7 +50,7 @@ stellar contract deploy \
 
 ```bash
 # Install the account wasm on the network
-stellar contract install \
+stellar contract upload \
 --source ${MY_ACCOUNT} \
 --wasm target/wasm32-unknown-unknown/release/account.wasm \
 --network testnet
@@ -69,7 +69,7 @@ stellar contract invoke \
 
 ```bash
 # Install the account wasm on the network
-stellar contract install \
+stellar contract upload \
 --source ${MY_ACCOUNT} \
 --wasm target/wasm32-unknown-unknown/release/web_auth.wasm \
 --network testnet
@@ -77,7 +77,7 @@ stellar contract install \
 # Update the account contract with the new Wasm
 stellar contract invoke \
   --id ${CONTRACT_ID} \
-  --source alice \
+  --source ${MY_ACCOUNT} \
   --network testnet \
   -- \
   upgrade \

--- a/soroban/contracts/web-auth/src/lib.rs
+++ b/soroban/contracts/web-auth/src/lib.rs
@@ -1,8 +1,11 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, Map, String, Symbol,
+    contract, contracterror, contractimpl, contractmeta, contracttype, Address, BytesN, Env, Map, String, Symbol
 };
+
+contractmeta!(key="sep", val="45");
+contractmeta!(key="version", val="0.1.0");
 
 #[contract]
 pub struct WebAuthContract;
@@ -46,16 +49,16 @@ impl WebAuthContract {
             return Err(WebAuthError::MissingArgument);
         }
 
-        if let Some(home_domain_address) = args.get(Symbol::new(&env, "home_domain_address")) {
-            let home_domain_addr = Address::from_string(&home_domain_address);
-            home_domain_addr.require_auth();
+        if let Some(web_auth_domain_account) = args.get(Symbol::new(&env, "web_auth_domain_account")) {
+            let addr = Address::from_string(&web_auth_domain_account);
+            addr.require_auth();
         } else {
             return Err(WebAuthError::MissingArgument);
         }
 
-        if let Some(client_domain_address) = args.get(Symbol::new(&env, "client_domain_address")) {
-            let client_domain_addr = Address::from_string(&client_domain_address);
-            client_domain_addr.require_auth();
+        if let Some(client_domain_account) = args.get(Symbol::new(&env, "client_domain_account")) {
+            let addr = Address::from_string(&client_domain_account);
+            addr.require_auth();
         }
 
         Ok(())


### PR DESCRIPTION
### Description

This updates the argument names of the SEP-45 `web_auth_verify` function and adds `sep` and `version` to the contract meta.

### Context

It was renamed.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

