### PR TITLE
[Chore] Bump version to `3.2.0-beta.1`

### DIFF
--- a/.github/workflows/on_release_created_or_updated.yml
+++ b/.github/workflows/on_release_created_or_updated.yml
@@ -58,7 +58,8 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           push: true
-          tags: stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }},stellar/anchor-platform:latest
+#          tags: stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }},stellar/anchor-platform:latest
+          tags: stellar/anchor-platform:${{ env.EXPECTED_RELEASE_TAG }} # TODO: remove when merged to develop
           file: Dockerfile
 
   complete:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "3.1.0"
+  version = "3.2.0-beta.1"
 
   tasks.jar {
     manifest {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v3.1.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.1.0)
+[![Docker](https://badgen.net/badge/Latest%20Release/v3.2.0-beta.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.2.0-beta.1)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=3.1.0
+version=3.2.0-beta.1


### PR DESCRIPTION
### Description

This bumps the version to `3.2.0-beta.1` and disables the Docker image publish with the latest tag.

### Context

Releasing a preview for testing the contract account features.

### Testing

- `./gradlew test`

### Documentation

Stellar docs to be updated

### Known limitations

N/A

