### PR TITLE
[ANCHOR-977] Add LedgerTransferEvent to Stellar Observer

### DIFF
--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
@@ -6,11 +6,12 @@ import java.time.Instant;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
+import lombok.experimental.SuperBuilder;
 import org.stellar.sdk.xdr.Asset;
 import org.stellar.sdk.xdr.Memo;
 import org.stellar.sdk.xdr.OperationType;
 
-@Builder
+@SuperBuilder
 @Data
 public class LedgerTransaction {
   String hash;

--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerTransferEvent.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerTransferEvent.java
@@ -1,0 +1,25 @@
+package org.stellar.anchor.ledger;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@Builder
+public class LedgerTransferEvent {
+  SingleOpLedgerTransaction ledgerTransaction;
+
+  @SuperBuilder
+  @Getter
+  public static class SingleOpLedgerTransaction extends LedgerTransaction {
+    LedgerOperation operation;
+
+    @Override
+    public List<LedgerOperation> getOperations() {
+      throw new UnsupportedOperationException(
+          "SingleOpLedgerTransaction does not support getOperations()");
+    }
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/PaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/PaymentListener.java
@@ -2,8 +2,8 @@ package org.stellar.anchor.platform.observer;
 
 import java.io.IOException;
 import org.stellar.anchor.api.exception.AnchorException;
-import org.stellar.anchor.ledger.LedgerTransaction;
+import org.stellar.anchor.ledger.LedgerTransferEvent;
 
 public interface PaymentListener {
-  void onReceived(LedgerTransaction ledgerTransaction) throws AnchorException, IOException;
+  void onReceived(LedgerTransferEvent ledgerTransferEvent) throws AnchorException, IOException;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserver.java
@@ -172,13 +172,17 @@ public class StellarPaymentObserver implements HealthCheckable {
 
           @Override
           public void onFailure(Optional<Throwable> error, Optional<Integer> responseCode) {
-            // The SSEStreamer has internal errors. We will give up and let the container
-            // manager to restart.
-            errorEx("stellar payment observer stream error: ", error.orElse(null));
-            // Mark the observer unhealthy
-            setStatus(STREAM_ERROR);
+            handleFailure(error.orElse(null));
           }
         });
+  }
+
+  void handleFailure(Throwable error) {
+    // The SSEStreamer has internal errors. We will give up and let the container
+    // manager to restart.
+    errorEx("stellar payment observer stream error: ", error);
+    // Mark the observer unhealthy
+    setStatus(STREAM_ERROR);
   }
 
   void stopStream() {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserverTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/StellarPaymentObserverTest.kt
@@ -5,7 +5,6 @@ package org.stellar.anchor.platform.observer.stellar
 import com.google.gson.reflect.TypeToken
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import java.util.*
 import javax.net.ssl.SSLProtocolException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -47,7 +46,7 @@ class StellarPaymentObserverTest {
           stellarPaymentObserverConfig,
           null,
           paymentObservingAccountsManager,
-          paymentStreamerCursorStore
+          paymentStreamerCursorStore,
         )
       )
 
@@ -66,7 +65,7 @@ class StellarPaymentObserverTest {
         stellarPaymentObserverConfig,
         null,
         paymentObservingAccountsManager,
-        paymentStreamerCursorStore
+        paymentStreamerCursorStore,
       )
 
     // 2.1 If fetching from the network throws an error, we return `null`
@@ -155,12 +154,12 @@ class StellarPaymentObserverTest {
           stellarPaymentObserverConfig,
           null,
           paymentObservingAccountsManager,
-          paymentStreamerCursorStore
+          paymentStreamerCursorStore,
         )
       )
     every { observer.startSSEStream() } returns stream
     observer.start()
-    observer.handleFailure(Optional.of(SSLProtocolException("")))
+    observer.handleFailure(SSLProtocolException(""))
     assertEquals(ObserverStatus.STREAM_ERROR, observer.status)
 
     val checkResult = observer.check()


### PR DESCRIPTION
### Description

- Add `LedgerTransferEvent` class
- `SingleOpLedgerTransaction` is used to prevent same transfer operation processed more than once.
- Moved several helper functions from Horizon to StellarPaymentObserver.

### Context

- StellarRPC integration

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A
