### PR TITLE
[ANCHOR-1049] Fix NPE when the `max_amount` is not set in assets.yaml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "3.1.0"
+  version = "3.1.1"
 
   tasks.jar {
     manifest {

--- a/core/src/main/java/org/stellar/anchor/util/AssetValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetValidator.java
@@ -169,7 +169,7 @@ public class AssetValidator {
                 assetId, receiveInfo.getMinAmount()));
       }
 
-      if (receiveInfo.getMaxAmount() <= 0) {
+      if (receiveInfo.getMaxAmount() != null && receiveInfo.getMaxAmount() <= 0) {
         errors.add(
             format(
                 "Asset %s: SEP-31 receive 'max_amount' must be positive (current value: %s).",

--- a/core/src/main/resources/config/anchor-asset-default-values.yaml
+++ b/core/src/main/resources/config/anchor-asset-default-values.yaml
@@ -32,7 +32,7 @@ items:
         # The minimum amount that the user can deposit.
         min_amount: 0
         # The maximum amount that the user can deposit.
-        max_amount:
+        max_amount: 999999999
         # The list of the methods that the user can use to deposit the asset.
         # Example:
         #   - SEPA
@@ -45,7 +45,7 @@ items:
         # The minimum amount that the user can withdraw.
         min_amount: 0
         # The maximum amount that the user can withdraw.
-        max_amount: 1000
+        max_amount: 999999999
         # The list of the methods that the anchor supports for the withdrawal of the asset.
         # Example:
         #   - bank_account
@@ -63,7 +63,7 @@ items:
         # The minimum amount that the user can deposit.
         min_amount: 0
         # The maximum amount that the user can deposit.
-        max_amount:
+        max_amount: 999999999
         # The list of the methods that the user can use to deposit the asset.
         # Example:
         #   - SEPA
@@ -77,7 +77,7 @@ items:
         # the minimum amount that the user can withdraw.
         min_amount: 0
         # the maximum amount that the user can withdraw.
-        max_amount:
+        max_amount: 999999999
         # the list of the methods that the anchor supports for the withdrawal of the asset.
         # Example:
         #   - bank_account
@@ -96,7 +96,7 @@ items:
       receive:
         # the maximum amount that the user can receive.
         min_amount: 0
-        max_amount: 1000
+        max_amount: 999999999
         # The list of methods supported by the anchor to receive assets.
         # Example:
         #   - SEPA
@@ -112,7 +112,7 @@ items:
       # Example:
       #  - iso4217:USD
       #  - iso4217:CAD
-      exchangeable_assets:
+      exchangeable_assets: []
 
   #
   # Fiat (ISO4217) assets
@@ -126,7 +126,7 @@ items:
       receive:
         # the maximum amount that the user can receive.
         min_amount: 0
-        max_amount:
+        max_amount: 999999999
         methods: []
       # `true` if the asset supports quotesinforesponse.java.
       quotes_supported: true
@@ -146,7 +146,7 @@ items:
       # Example:
       #   - US
       #   - CA
-      country_codes:
+      country_codes: []
 
       # An array of objects describing the methods a client can use to sell/deliver funds to the anchor.
       # Refer to: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#get-info

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v3.1.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.1.0)
+[![Docker](https://badgen.net/badge/Latest%20Release/v3.1.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.1.1)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=3.1.0
+version=3.1.1


### PR DESCRIPTION
### Description

If the following attributes are not set in the `assets.yaml`, NPE is thrown:

- `sep6.deposit.max_amount`
- `sep6.withdraw.max_amount`
- `sep24.deposit.max_amount`
- `sep24.withdraw.max_amount`
- `sep31.receive.max_amount`

### Context

- Bug fix

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

