### PR TITLE
[ANCHOR-1054] Handle contract payment events in the StellarRpcPaymentObserver and tests.

### DIFF
--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerClientHelper.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerClientHelper.java
@@ -6,6 +6,7 @@ import static org.stellar.anchor.util.Log.*;
 import static org.stellar.sdk.xdr.HostFunctionType.HOST_FUNCTION_TYPE_INVOKE_CONTRACT;
 import static org.stellar.sdk.xdr.OperationType.*;
 
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +53,7 @@ public class LedgerClientHelper {
                 LedgerPaymentOperation.builder()
                     .id(operationId)
                     .asset(payment.getAsset())
-                    .amount(payment.getAmount().getInt64())
+                    .amount(BigInteger.valueOf(payment.getAmount().getInt64()))
                     .from(sourceAccount)
                     .sourceAccount(sourceAccount)
                     .to(
@@ -98,7 +99,7 @@ public class LedgerClientHelper {
                 LedgerPathPaymentOperation.builder()
                     .id(operationId)
                     .asset(asset)
-                    .amount(amount)
+                    .amount(BigInteger.valueOf(amount))
                     .from(sourceAccount)
                     .to(toAddress)
                     .sourceAccount(sourceAccount)
@@ -126,7 +127,7 @@ public class LedgerClientHelper {
                     .contractId(contractId)
                     .hostFunction("transfer")
                     .id(operationId)
-                    .amount(amount.getI128().getLo().getUint64().getNumber().longValue())
+                    .amount(amount.getI128().getLo().getUint64().getNumber())
                     .from(getAddressOrContractId(from.getAddress()))
                     .to(getAddressOrContractId(to.getAddress()))
                     .sourceAccount(sourceAccount)

--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerClientHelper.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerClientHelper.java
@@ -3,10 +3,8 @@ package org.stellar.anchor.ledger;
 import static java.lang.Thread.sleep;
 import static org.stellar.anchor.ledger.LedgerTransaction.*;
 import static org.stellar.anchor.util.Log.*;
-import static org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.*;
 import static org.stellar.sdk.xdr.HostFunctionType.HOST_FUNCTION_TYPE_INVOKE_CONTRACT;
 import static org.stellar.sdk.xdr.OperationType.*;
-import static org.stellar.sdk.xdr.SignerKeyType.*;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -125,7 +123,7 @@ public class LedgerClientHelper {
             .type(INVOKE_HOST_FUNCTION)
             .invokeHostFunctionOperation(
                 LedgerInvokeHostFunctionOperation.builder()
-                    .stellarAssetContractId(contractId)
+                    .contractId(contractId)
                     .hostFunction("transfer")
                     .id(operationId)
                     .amount(amount.getI128().getLo().getUint64().getNumber().longValue())

--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.ledger;
 
 import static org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.*;
 
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 import lombok.Builder;
@@ -43,7 +44,7 @@ public class LedgerTransaction {
     String getTo();
 
     // The amount is in the smallest unit of the asset as in 10^-7.
-    Long getAmount();
+    BigInteger getAmount();
 
     Asset getAsset();
 
@@ -56,7 +57,7 @@ public class LedgerTransaction {
     String id;
     String from;
     String to;
-    Long amount;
+    BigInteger amount;
     Asset asset;
     String sourceAccount;
   }
@@ -67,7 +68,7 @@ public class LedgerTransaction {
     String id;
     String from;
     String to;
-    Long amount;
+    BigInteger amount;
     Asset asset;
     String sourceAccount;
   }
@@ -81,7 +82,7 @@ public class LedgerTransaction {
     String id;
     String from;
     String to;
-    Long amount;
+    BigInteger amount;
     Asset asset;
     String sourceAccount;
 

--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
@@ -32,6 +32,7 @@ public class LedgerTransaction {
     OperationType type;
     LedgerPaymentOperation paymentOperation;
     LedgerPathPaymentOperation pathPaymentOperation;
+    LedgerInvokeHostFunctionOperation invokeHostFunctionOperation;
   }
 
   public interface LedgerPayment {
@@ -68,6 +69,32 @@ public class LedgerTransaction {
     Long amount;
     Asset asset;
     String sourceAccount;
+  }
+
+  @Builder
+  @Data
+  public static class LedgerInvokeHostFunctionOperation implements LedgerPayment {
+    String stellarAssetContractId;
+    String hostFunction;
+
+    String id;
+    String from;
+    String to;
+    Long amount;
+    Asset asset;
+    String sourceAccount;
+
+    public Asset getAsset() {
+      if (asset == null) {
+        if (stellarAssetContractId != null) {
+          // The SAC to Asset conversion requires a network call to the ledger. This should be
+          // converted before using the operation.
+          throw new IllegalStateException(
+              "Please convert stellarAssetContractId to Asset before calling getAsset()");
+        }
+      }
+      return asset;
+    }
   }
 
   @Builder

--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
@@ -42,6 +42,7 @@ public class LedgerTransaction {
 
     String getTo();
 
+    // The amount is in the smallest unit of the asset as in 10^-7.
     Long getAmount();
 
     Asset getAsset();

--- a/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/LedgerTransaction.java
@@ -74,7 +74,7 @@ public class LedgerTransaction {
   @Builder
   @Data
   public static class LedgerInvokeHostFunctionOperation implements LedgerPayment {
-    String stellarAssetContractId;
+    String contractId;
     String hostFunction;
 
     String id;
@@ -86,7 +86,7 @@ public class LedgerTransaction {
 
     public Asset getAsset() {
       if (asset == null) {
-        if (stellarAssetContractId != null) {
+        if (contractId != null) {
           // The SAC to Asset conversion requires a network call to the ledger. This should be
           // converted before using the operation.
           throw new IllegalStateException(

--- a/core/src/main/java/org/stellar/anchor/ledger/PaymentTransferEvent.java
+++ b/core/src/main/java/org/stellar/anchor/ledger/PaymentTransferEvent.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.ledger;
 
+import java.math.BigInteger;
 import lombok.Builder;
 import lombok.Data;
 
@@ -25,7 +26,7 @@ public class PaymentTransferEvent {
   String sep11Asset;
 
   /** The XDR amount of the payment transfer. */
-  Long amount;
+  BigInteger amount;
 
   /** The transaction hash of the payment transfer. */
   String txHash;

--- a/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetHelper.java
@@ -4,6 +4,7 @@ import static java.math.RoundingMode.DOWN;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Currency;
 import org.stellar.anchor.api.asset.AssetInfo;
 import org.stellar.anchor.api.asset.DepositWithdrawInfo;
@@ -171,6 +172,20 @@ public class AssetHelper {
   public static String fromXdrAmount(Long amount) {
     // The rounding mode is set to DOWN because the XDR_SCALE_FACTOR is also 7 digits.
     return BigDecimal.valueOf(amount).divide(XDR_SCALE_FACTOR, 7, DOWN).toPlainString();
+  }
+
+  /**
+   * Converts an amount in XDR format to a string representation.
+   *
+   * @param amount the amount in XDR format
+   * @return the string representation of the amount
+   */
+  public static String fromXdrAmount(BigInteger amount) {
+    if (amount == null) {
+      return null;
+    }
+    // The rounding mode is set to DOWN because the XDR_SCALE_FACTOR is also 7 digits.
+    return new BigDecimal(amount).divide(XDR_SCALE_FACTOR, 7, DOWN).toPlainString();
   }
 
   /**

--- a/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
@@ -3,9 +3,7 @@ package org.stellar.anchor.ledger
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.stellar.anchor.util.GsonUtils
-import org.stellar.sdk.responses.SubmitTransactionAsyncResponse.TransactionStatus
 import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.SendTransactionStatus.*
 import org.stellar.sdk.xdr.*
 import org.stellar.sdk.xdr.CryptoKeyType.KEY_TYPE_ED25519
@@ -15,40 +13,6 @@ import org.stellar.sdk.xdr.OperationType.PATH_PAYMENT_STRICT_RECEIVE
 import org.stellar.sdk.xdr.SignerKeyType.*
 
 internal class LedgerClientHelperTest {
-  @Test
-  fun `test getKeyTypeDiscriminant with valid types`() {
-    assertEquals(
-      SIGNER_KEY_TYPE_ED25519,
-      LedgerClientHelper.getKeyTypeDiscriminant("ed25519_public_key"),
-    )
-    assertEquals(
-      SIGNER_KEY_TYPE_PRE_AUTH_TX,
-      LedgerClientHelper.getKeyTypeDiscriminant("preauth_tx"),
-    )
-    assertEquals(SIGNER_KEY_TYPE_HASH_X, LedgerClientHelper.getKeyTypeDiscriminant("sha256_hash"))
-    assertEquals(
-      SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD,
-      LedgerClientHelper.getKeyTypeDiscriminant("ed25519_signed_payload"),
-    )
-  }
-
-  @Test
-  fun `test getKeyTypeDiscriminant with invalid type`() {
-    val exception =
-      assertThrows<IllegalArgumentException> {
-        LedgerClientHelper.getKeyTypeDiscriminant("invalid_type")
-      }
-    assertEquals("Invalid signer key type: invalid_type", exception.message)
-  }
-
-  @Test
-  fun `test convert() with transaction status`() {
-    assertEquals(PENDING, LedgerClientHelper.convert(TransactionStatus.PENDING))
-    assertEquals(ERROR, LedgerClientHelper.convert(TransactionStatus.ERROR))
-    assertEquals(DUPLICATE, LedgerClientHelper.convert(TransactionStatus.DUPLICATE))
-    assertEquals(TRY_AGAIN_LATER, LedgerClientHelper.convert(TransactionStatus.TRY_AGAIN_LATER))
-  }
-
   @Test
   fun `test convert() with payment transaction`() {
     val operation = GsonUtils.getInstance().fromJson(testPaymentOpJson, Operation::class.java)
@@ -242,7 +206,7 @@ internal class LedgerClientHelperTest {
   }
 }
 
-private val testPaymentOpJson =
+private const val testPaymentOpJson =
   """
 {
    "body":{
@@ -265,7 +229,7 @@ private val testPaymentOpJson =
 }
 """
 
-private val testPathPaymentOpJson =
+private const val testPathPaymentOpJson =
   """
 {
    "body":{
@@ -294,7 +258,8 @@ private val testPathPaymentOpJson =
 }
 """
 
-private val testUnhandledOpJson = """
+private const val testUnhandledOpJson =
+  """
 {
    "body":{
       "discriminant":"CREATE_ACCOUNT"

--- a/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/ledger/LedgerClientHelperTest.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.ledger
 
+import java.math.BigInteger
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -35,7 +36,7 @@ internal class LedgerClientHelperTest {
       "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
       ledgerOperation.paymentOperation.to,
     )
-    assertEquals(1230L, ledgerOperation.paymentOperation.amount)
+    assertEquals(BigInteger.valueOf(1230L), ledgerOperation.paymentOperation.amount)
     assertEquals(
       "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
       ledgerOperation.paymentOperation.sourceAccount,
@@ -64,7 +65,7 @@ internal class LedgerClientHelperTest {
       "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
       ledgerOperation.pathPaymentOperation.to,
     )
-    assertEquals(1230L, ledgerOperation.pathPaymentOperation.amount)
+    assertEquals(BigInteger.valueOf(1230L), ledgerOperation.pathPaymentOperation.amount)
     assertEquals(
       "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
       ledgerOperation.pathPaymentOperation.sourceAccount,

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/AbstractIntegrationTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/AbstractIntegrationTests.kt
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform
 import io.ktor.client.plugins.*
 import io.ktor.http.*
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.time.Instant
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -55,6 +56,7 @@ abstract class AbstractIntegrationTests(val config: TestConfig) {
     const val TEST_PAYMENT_DEST_ACCOUNT = "GBDYDBJKQBJK4GY4V7FAONSFF2IBJSKNTBYJ65F5KCGBY2BIGPGGLJOH"
     const val TEST_PAYMENT_ASSET_CIRCLE_USDC =
       "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+
     // custody deposit address
     const val CUSTODY_DEST_ACCOUNT = "GC6X2ANA2OS3O2ESHUV6X44NH6J46EP2EO2JB7563Y7DYOIXFKHMHJ5O"
   }
@@ -138,7 +140,7 @@ abstract class AbstractIntegrationTests(val config: TestConfig) {
             .id(op.getId().toString())
             .from(op.from)
             .to(op.to)
-            .amount(AssetHelper.toXdrAmount(op.amount))
+            .amount(BigInteger.valueOf(AssetHelper.toXdrAmount(op.amount)))
             .asset(op.asset.toXdr())
             .sourceAccount(op.getSourceAccount())
             .build()
@@ -151,7 +153,7 @@ abstract class AbstractIntegrationTests(val config: TestConfig) {
             .id(op.getId().toString())
             .from(op.from)
             .to(op.to)
-            .amount(AssetHelper.toXdrAmount(op.amount))
+            .amount(BigInteger.valueOf(AssetHelper.toXdrAmount(op.amount)))
             .asset(op.asset.toXdr())
             .sourceAccount(op.getSourceAccount())
             .build()

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -138,7 +138,7 @@ class PaymentObserverTests {
     assertEquals(1, toEvent?.size)
     assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
     assertEquals(walletContractId, toEvent!![0].to)
-    assertEquals(AssetHelper.toXdrAmount("0.0000002"), fromEvent[0].amount)
+    assertEquals(BigInteger.valueOf(AssetHelper.toXdrAmount("0.0000002")), fromEvent[0].amount)
     assertEquals(Asset.createNativeAsset().toString(), fromEvent[0].sep11Asset)
     assertEquals(fromEvent, toEvent)
 
@@ -163,7 +163,7 @@ class PaymentObserverTests {
     assertEquals(1, toEvent2?.size)
     assertEquals(walletContractId, fromEvent2!![0].from)
     assertEquals(fromKeyPair.accountId, toEvent2!![0].to)
-    assertEquals(AssetHelper.toXdrAmount("0.0000001"), fromEvent2[0].amount)
+    assertEquals(BigInteger.valueOf(AssetHelper.toXdrAmount("0.0000001")), fromEvent2[0].amount)
     assertEquals(fromEvent2, toEvent2)
   }
 
@@ -300,7 +300,10 @@ class PaymentObserverTests {
     assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
     assertEquals(toKeyPair.accountId, fromEvent[0].to)
     val paymentOperation: PaymentOperation = txn.operations[0] as PaymentOperation
-    assertEquals(AssetHelper.toXdrAmount(paymentOperation.amount.toString()), fromEvent[0].amount)
+    assertEquals(
+      BigInteger.valueOf(AssetHelper.toXdrAmount(paymentOperation.amount.toString())),
+      fromEvent[0].amount
+    )
     assertEquals(
       AssetHelper.getSep11AssetName(paymentOperation.asset.toXdr()),
       fromEvent[0].sep11Asset,
@@ -320,7 +323,7 @@ class PaymentObserverTests {
     val paymentOperation: PathPaymentStrictSendOperation =
       txn.operations[0] as PathPaymentStrictSendOperation
     assertEquals(
-      AssetHelper.toXdrAmount(paymentOperation.sendAmount.toString()),
+      BigInteger.valueOf(AssetHelper.toXdrAmount(paymentOperation.sendAmount.toString())),
       fromEvent[0].amount,
     )
     assertEquals(

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -61,7 +61,7 @@ class PaymentObserverTests {
       fromKeyPair2 = createAndFundAccount()
       toKeyPair2 = createAndFundAccount()
       walletContractId =
-        createContractWithWasmId(
+        createContractWithWasmIdAndGetContractId(
           stellarRpc,
           Network.TESTNET,
           "a4f2bbf00e661546a2db6de1922dc638ee94e0b52c48adb051dad42329e866fb",
@@ -452,7 +452,7 @@ internal fun createAndFundAccount(): KeyPair {
   return keyPair
 }
 
-internal fun createContractWithWasmIdAndGetHash(
+internal fun createContractWithWasmIdAndGetContractId(
   sorobanServer: SorobanServer,
   network: Network,
   wasmId: String,

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -60,11 +60,13 @@ class PaymentObserverTests {
       toKeyPair = createAndFundAccount()
       fromKeyPair2 = createAndFundAccount()
       toKeyPair2 = createAndFundAccount()
+      // the wasmId is the wasm hash of the contract under soroban/contracts/account.
+      val wasmId = "a4f2bbf00e661546a2db6de1922dc638ee94e0b52c48adb051dad42329e866fb"
       walletContractId =
         createContractWithWasmIdAndGetContractId(
           stellarRpc,
           Network.TESTNET,
-          "a4f2bbf00e661546a2db6de1922dc638ee94e0b52c48adb051dad42329e866fb",
+          wasmId,
           fromKeyPair,
           listOf(Scv.toAddress(fromKeyPair.accountId), Scv.toBytes(fromKeyPair.publicKey)),
         )

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/PaymentObserverTests.kt
@@ -52,18 +52,10 @@ class PaymentObserverTests {
     @JvmStatic
     @BeforeAll
     fun start() {
-      fromKeyPair =
-        KeyPair.fromSecretSeed("SD4XJTFKVTCUC7XOHJLUC7YZHOCZRKOTQ3OAR7VAUKOUCKPGPNC25ZXB")
-      toKeyPair = KeyPair.fromSecretSeed("SAB7GZ6KN2YLJ2NM52JYM4OWXY55AVG54LPYUEVUZGIPUY2PUVFN6OJB")
-      fromKeyPair2 =
-        KeyPair.fromSecretSeed("SAJPASKHPZAMLY27IQBTBYB45G7D62QNXUV3WE5NP42YCVHSC7EMWGDQ")
-      toKeyPair2 =
-        KeyPair.fromSecretSeed("SBRU7TKRPRM2EQC3KLAWNLNKIJ6HTEQVIJ4AQQJCUQJX725NN3M6BWKF")
-
-      //      fromKeyPair = createAndFundAccount()
-      //      toKeyPair = createAndFundAccount()
-      //      fromKeyPair2 = createAndFundAccount()
-      //      toKeyPair2 = createAndFundAccount()
+      fromKeyPair = createAndFundAccount()
+      toKeyPair = createAndFundAccount()
+      fromKeyPair2 = createAndFundAccount()
+      toKeyPair2 = createAndFundAccount()
 
       keyMap.add(fromKeyPair.accountId)
       keyMap.add(toKeyPair.accountId)
@@ -257,25 +249,6 @@ class PaymentObserverTests {
     return rpc.sendTransaction(preparedTransaction)
   }
 
-  //
-  //  private fun assertEventsSacPayment(
-  //    txn: Transaction,
-  //    fromEvent: List<PaymentTransferEvent>?,
-  //    toEvent: List<PaymentTransferEvent>?,
-  //  ) {
-  //    assertEquals(1, fromEvent?.size)
-  //    assertEquals(1, toEvent?.size)
-  //    assertEquals(fromKeyPair.accountId, fromEvent!![0].from)
-  //    assertEquals(toKeyPair.accountId, fromEvent[0].to)
-  //    val invokeHostFunctionOp: InvokeHostFunctionOperation =
-  //      txn.operations[0] as InvokeHostFunctionOperation
-  //    assertEquals(
-  //      AssetHelper.toXdrAmount(invokeHostFunctionOp. .parameters[2].i128.toString()),
-  //      fromEvent[0].amount,
-  //    )
-  //    assertEquals(fromEvent, toEvent)
-  //  }
-  //
   private fun assertEventsPayment(
     txn: Transaction,
     fromEvent: List<PaymentTransferEvent>?,

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListener.java
@@ -180,7 +180,7 @@ public class DefaultPaymentListener implements PaymentListener {
             AnchorMetrics.PAYMENT_RECEIVED.toString(),
             "asset",
             getSep11AssetName(ledgerPayment.getAsset()))
-        .increment(ledgerPayment.getAmount());
+        .increment(ledgerPayment.getAmount().doubleValue());
   }
 
   void handleSep24Transaction(
@@ -217,7 +217,7 @@ public class DefaultPaymentListener implements PaymentListener {
             AnchorMetrics.PAYMENT_RECEIVED.toString(),
             "asset",
             getSep11AssetName(ledgerPayment.getAsset()))
-        .increment(ledgerPayment.getAmount());
+        .increment(ledgerPayment.getAmount().doubleValue());
   }
 
   void handleSep6Transaction(
@@ -256,7 +256,7 @@ public class DefaultPaymentListener implements PaymentListener {
             AnchorMetrics.PAYMENT_RECEIVED.toString(),
             "asset",
             getSep11AssetName(ledgerPayment.getAsset()))
-        .increment(ledgerPayment.getAmount());
+        .increment(ledgerPayment.getAmount().doubleValue());
   }
 
   boolean validate(LedgerTransaction ledgerTransaction, LedgerPayment ledgerPayment) {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/HorizonPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/HorizonPaymentObserver.java
@@ -10,6 +10,7 @@ import static org.stellar.anchor.util.Log.warnF;
 import static org.stellar.anchor.util.ReflectionUtil.getField;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 
+import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -231,7 +232,7 @@ public class HorizonPaymentObserver extends AbstractPaymentObserver {
             .from(paymentOp.getFrom())
             .to(paymentOp.getTo())
             .sep11Asset(AssetHelper.getSep11AssetName(paymentOp.getAsset().toXdr()))
-            .amount(AssetHelper.toXdrAmount(paymentOp.getAmount()))
+            .amount(BigInteger.valueOf(AssetHelper.toXdrAmount(paymentOp.getAmount())))
             .operationId(String.valueOf(operation.getId()))
             .txHash(paymentOp.getTransactionHash())
             .ledgerTransaction(horizon.getTransaction(operation.getTransactionHash()))
@@ -247,7 +248,7 @@ public class HorizonPaymentObserver extends AbstractPaymentObserver {
             .from(pathPaymentOp.getFrom())
             .to(pathPaymentOp.getTo())
             .sep11Asset(AssetHelper.getSep11AssetName(pathPaymentOp.getAsset().toXdr()))
-            .amount(AssetHelper.toXdrAmount(pathPaymentOp.getAmount()))
+            .amount(BigInteger.valueOf(AssetHelper.toXdrAmount(pathPaymentOp.getAmount())))
             .operationId(String.valueOf(operation.getId()))
             .txHash(pathPaymentOp.getTransactionHash())
             .ledgerTransaction(horizon.getTransaction(operation.getTransactionHash()))

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
@@ -3,5 +3,7 @@ package org.stellar.anchor.platform.observer.stellar;
 import org.stellar.sdk.xdr.Asset;
 
 public class SacToAssetMapper {
-  public static Asset map(String sac) {}
+  public static Asset map(String sac) {
+    return null;
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.platform.observer.stellar;
 
+import static org.stellar.sdk.xdr.ContractExecutableType.CONTRACT_EXECUTABLE_STELLAR_ASSET;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,15 +74,15 @@ public class SacToAssetMapper {
             .getVal()
             .getInstance();
 
-    return switch (contractInstance.getExecutable().getDiscriminant()) {
-      case CONTRACT_EXECUTABLE_STELLAR_ASSET ->
-          Scv.fromMap(
-                  SCVal.builder()
-                      .discriminant(SCValType.SCV_MAP)
-                      .map(contractInstance.getStorage())
-                      .build())
-              .get(Scv.toSymbol("METADATA"));
-      default -> null;
-    };
+    if (contractInstance.getExecutable().getDiscriminant() == CONTRACT_EXECUTABLE_STELLAR_ASSET) {
+      return Scv.fromMap(
+              SCVal.builder()
+                  .discriminant(SCValType.SCV_MAP)
+                  .map(contractInstance.getStorage())
+                  .build())
+          .get(Scv.toSymbol("METADATA"));
+    } else {
+      return null;
+    }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
@@ -25,7 +25,7 @@ public class SacToAssetMapper {
    * @param sac the Stellar Asset Contract ID
    * @return the corresponding Asset object
    */
-  public Asset getAssetFromSac(String sac) throws IOException {
+  public Asset getAssetFromSac(String sac) {
     if (sacToAssetMap.containsKey(sac)) {
       return sacToAssetMap.get(sac);
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
@@ -30,8 +30,13 @@ public class SacToAssetMapper {
       return sacToAssetMap.get(sac);
     }
 
-    SCVal metadata = fetchSacMetadata(sac);
-    if (metadata == null) {
+    SCVal metadata;
+    try {
+      metadata = fetchSacMetadata(sac);
+      if (metadata == null) {
+        return null;
+      }
+    } catch (IOException e) {
       return null;
     }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/SacToAssetMapper.java
@@ -1,0 +1,7 @@
+package org.stellar.anchor.platform.observer.stellar;
+
+import org.stellar.sdk.xdr.Asset;
+
+public class SacToAssetMapper {
+  public static Asset map(String sac) {}
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import lombok.Getter;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.LedgerException;
 import org.stellar.anchor.api.platform.HealthCheckResult;
@@ -32,8 +33,8 @@ import org.stellar.sdk.responses.sorobanrpc.GetTransactionsResponse;
 import org.stellar.sdk.xdr.OperationType;
 
 public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
-  final StellarRpc stellarRpc;
-  final SorobanServer sorobanServer;
+  @Getter final StellarRpc stellarRpc;
+  @Getter final SorobanServer sorobanServer;
 
   public StellarRpcPaymentObserver(
       String rpcUrl,
@@ -195,6 +196,10 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
                 .operationId(pathPaymentOp.getId())
                 .ledgerTransaction(ledgerTxn)
                 .build();
+          }
+          case INVOKE_HOST_FUNCTION -> {
+            LedgerTransaction.LedgerInvokeHostFunctionOperation invokeOp =
+                op.getInvokeHostFunctionOperation();
           }
           default -> null;
         };

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -214,8 +214,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
           case INVOKE_HOST_FUNCTION -> {
             LedgerTransaction.LedgerInvokeHostFunctionOperation invokeOp =
                 op.getInvokeHostFunctionOperation();
-            invokeOp.setAsset(
-                sacToAssetMapper.getAssetFromSac(invokeOp.getStellarAssetContractId()));
+            invokeOp.setAsset(sacToAssetMapper.getAssetFromSac(invokeOp.getContractId()));
             yield PaymentTransferEvent.builder()
                 .from(invokeOp.getFrom())
                 .to(invokeOp.getTo())

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/fireblocks/FireblocksEventServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/fireblocks/FireblocksEventServiceTest.kt
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.custody.fireblocks
 
 import io.mockk.*
+import java.math.BigInteger
 import java.security.Signature
 import java.util.*
 import kotlin.test.assertEquals
@@ -473,7 +474,7 @@ class FireblocksEventServiceTest {
             .id("12345")
             .from("testFrom")
             .to("testTo")
-            .amount(150000000)
+            .amount(BigInteger.valueOf(150000000))
             .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
             .sourceAccount("testSourceAccount")
             .build()
@@ -491,7 +492,7 @@ class FireblocksEventServiceTest {
             .id("12345")
             .from("testFrom")
             .to("testTo")
-            .amount(150000000)
+            .amount(BigInteger.valueOf(150000000))
             .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
             .sourceAccount("testSourceAccount")
             .build()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/DefaultPaymentListenerTest.kt
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.observer.stellar
 
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
@@ -258,7 +259,7 @@ class DefaultPaymentListenerTest {
                 LedgerTransaction.LedgerPaymentOperation.builder()
                   .id(testTOID.toInt64().toString())
                   .asset(testAssetFoo.toXdr())
-                  .amount(1)
+                  .amount(BigInteger.valueOf(1))
                   .sourceAccount("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5")
                   .to("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364")
                   .build()
@@ -271,7 +272,7 @@ class DefaultPaymentListenerTest {
     return PaymentTransferEvent.builder()
       .from("GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5")
       .to("GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364")
-      .amount(1)
+      .amount(BigInteger.valueOf(1))
       .txHash("1ad62e48724426be96cf2cdb65d5dacb8fac2e403e50bedb717bfc8eaf05af30")
       .operationId(testTOID.toInt64().toString())
       .ledgerTransaction(ledgerTransaction)

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsReceivedHandlerTest.kt
@@ -4,6 +4,7 @@ import com.google.gson.reflect.TypeToken
 import io.micrometer.core.instrument.Counter
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import java.math.BigInteger
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -90,7 +91,7 @@ class NotifyOnchainFundsReceivedHandlerTest {
               .paymentOperation(
                 LedgerPaymentOperation.builder()
                   .id("12345")
-                  .amount(150000000)
+                  .amount(BigInteger.valueOf(150000000))
                   .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
                   .from("testFrom")
                   .to("testTo")

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/NotifyOnchainFundsSentHandlerTest.kt
@@ -4,6 +4,7 @@ import com.google.gson.reflect.TypeToken
 import io.micrometer.core.instrument.Counter
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import java.math.BigInteger
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -84,7 +85,7 @@ class NotifyOnchainFundsSentHandlerTest {
               .paymentOperation(
                 LedgerPaymentOperation.builder()
                   .id("12345")
-                  .amount(150000000)
+                  .amount(BigInteger.valueOf(150000000))
                   .asset(Asset.builder().discriminant(AssetType.ASSET_TYPE_NATIVE).build())
                   .from("testFrom")
                   .to("testTo")


### PR DESCRIPTION
### Description

- Handle contract payment events in the StellarRpcPaymentObserver and tests.
- Minor refactoring of LedgerClientHelp to reduce the size of the class and move them to calling classes if not commonly used.

### Context

- Add c-account support in the observer

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A
