### PR TITLE
[ops-3897] Upgrade external secrets crd version in all helm charts

### DIFF
--- a/helm-charts/reference-server/templates/externalsecrets.yaml
+++ b/helm-charts/reference-server/templates/externalsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets

--- a/helm-charts/secret-store/templates/secretstore.yaml
+++ b/helm-charts/secret-store/templates/secretstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: fake-secret-store

--- a/helm-charts/sep-service/templates/externalsecrets.yaml
+++ b/helm-charts/sep-service/templates/externalsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets


### PR DESCRIPTION
### Description

Upgrade the custom resource version for external secrets in helm charts
### Context

In our dev and prod clusters we have upgraded the external secrets operator and these custom resource versions must be upgraded
### Testing

This is the CR version working for other charts and groups of resources

### Documentation

https://external-secrets.io/latest/introduction/overview/#externalsecret