### PR TITLE
[ANCHOR-1058] Fix CRD and bump version to 3.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "3.1.1"
+  version = "3.1.2"
 
   tasks.jar {
     manifest {

--- a/core/src/main/java/org/stellar/anchor/util/AssetValidator.java
+++ b/core/src/main/java/org/stellar/anchor/util/AssetValidator.java
@@ -162,7 +162,7 @@ public class AssetValidator {
     // Validate receive configuration
     ReceiveOperation receiveInfo = sep31Info.getReceive();
     if (receiveInfo != null) {
-      if (receiveInfo.getMinAmount() < 0) {
+      if (receiveInfo.getMinAmount() != null && receiveInfo.getMinAmount() < 0) {
         errors.add(
             format(
                 "Asset %s: SEP-31 receive 'min_amount' must be non-negative (current value: %s).",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v3.1.1/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.1.1)
+[![Docker](https://badgen.net/badge/Latest%20Release/v3.1.2/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=3.1.2)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/helm-charts/reference-server/templates/externalsecrets.yaml
+++ b/helm-charts/reference-server/templates/externalsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets

--- a/helm-charts/secret-store/templates/secretstore.yaml
+++ b/helm-charts/secret-store/templates/secretstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: fake-secret-store

--- a/helm-charts/sep-service/templates/externalsecrets.yaml
+++ b/helm-charts/sep-service/templates/externalsecrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.fullName }}-secrets

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=3.1.1
+version=3.1.2


### PR DESCRIPTION
### What's changed

1. `apiVersion: external-secrets.io/v1beta1 -> v1` is needed to fix Jenkins (e.g https://github.com/stellar/anchor-platform/pull/1737) and has been proved working , so this 3.1.2 patch release is needed

2. Checking `receiveInfo.getMinAmount() != null `is needed due to same issue as this one https://github.com/stellar/anchor-platform/pull/1728
