### PR TITLE
[ANCHOR-1029] Support SRT in anchor platform

### DIFF
--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/callbacks/rate/RateService.kt
@@ -182,15 +182,16 @@ class RateService(private val quoteRepository: QuoteRepository) {
     val stellarUSDCtest = "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
     val stellarUSDCprod = "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
     val stellarJPYC = "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    val stellarSRT = "stellar:SRT:GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B"
     val prices =
       mapOf(
         Pair(fiatUSD, stellarCircleUSDCtest) to "1.02",
-        Pair(fiatUSD, stellarCircleUSDCtest) to "1.02",
         Pair(fiatUSD, stellarUSDCtest) to "1.02",
         Pair(fiatUSD, stellarJPYC) to "0.0083333",
+        Pair(fiatUSD, stellarSRT) to "0.145",
         Pair(fiatCAD, stellarUSDCtest) to "0.74",
         Pair(fiatCAD, stellarUSDCprod) to "0.74",
-        Pair(stellarUSDCtest, fiatUSD) to "1.05",
+        Pair(fiatCAD, stellarSRT) to "0.406",
         Pair(stellarUSDCtest, fiatUSD) to "1.05",
         Pair(stellarUSDCtest, stellarJPYC) to "0.0084",
         Pair(stellarUSDCtest, fiatCAD) to "1.37",
@@ -201,6 +202,8 @@ class RateService(private val quoteRepository: QuoteRepository) {
         Pair(stellarJPYC, stellarUSDCtest) to "120",
         Pair(stellarJPYC, stellarCircleUSDCtest) to "120",
         Pair(stellarJPYC, stellarUSDCprod) to "120",
+        Pair(stellarSRT, fiatUSD) to "6.9",
+        Pair(stellarSRT, fiatCAD) to "2.46",
       )
 
     private fun getPrice(sellAsset: String, buyAsset: String): String? {

--- a/kotlin-reference-server/src/main/kotlin/org/stellar/reference/service/SepHelper.kt
+++ b/kotlin-reference-server/src/main/kotlin/org/stellar/reference/service/SepHelper.kt
@@ -127,9 +127,7 @@ class SepHelper(private val cfg: Config) {
     try {
       resp = server.submitTransaction(transaction)
     } catch (e: BadRequestException) {
-      throw Exception(
-        "Failed to submit transaction with code: ${e.problem?.extras?.resultCodes?.transactionResultCode}"
-      )
+      throw Exception("Failed to submit transaction with code: ${e.problem?.extras?.resultCodes}")
     }
     assert(resp.successful)
     return resp.hash

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -136,7 +136,43 @@ items:
       enabled: true
       exchangeable_assets:
         - iso4217:USD
-
+  - id: stellar:SRT:GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B
+    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
+    significant_decimals: 7
+    sep6:
+      enabled: true
+      deposit:
+        enabled: true
+        methods:
+          - bank_account
+      withdraw:
+        enabled: true
+        methods:
+          - bank_account
+    sep24:
+      enabled: true
+      deposit:
+        enabled: true
+        fee_fixed: 1.0
+        methods:
+          - bank_account
+      withdraw:
+        enabled: true
+        fee_fixed: 1.0
+        methods:
+          - bank_account
+    sep31:
+      enabled: true
+      fee_fixed: 1.0
+      receive:
+        methods:
+          - bank_account
+      quotes_supported: true
+      quotes_required: false
+    sep38:
+      enabled: true
+      exchangeable_assets:
+        - iso4217:USD
   # Native asset
   - id: stellar:native
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF

--- a/service-runner/src/main/resources/config/assets.yaml
+++ b/service-runner/src/main/resources/config/assets.yaml
@@ -136,43 +136,7 @@ items:
       enabled: true
       exchangeable_assets:
         - iso4217:USD
-  - id: stellar:SRT:GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B
-    distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF
-    significant_decimals: 7
-    sep6:
-      enabled: true
-      deposit:
-        enabled: true
-        methods:
-          - bank_account
-      withdraw:
-        enabled: true
-        methods:
-          - bank_account
-    sep24:
-      enabled: true
-      deposit:
-        enabled: true
-        fee_fixed: 1.0
-        methods:
-          - bank_account
-      withdraw:
-        enabled: true
-        fee_fixed: 1.0
-        methods:
-          - bank_account
-    sep31:
-      enabled: true
-      fee_fixed: 1.0
-      receive:
-        methods:
-          - bank_account
-      quotes_supported: true
-      quotes_required: false
-    sep38:
-      enabled: true
-      exchangeable_assets:
-        - iso4217:USD
+
   # Native asset
   - id: stellar:native
     distribution_account: GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF

--- a/service-runner/src/main/resources/config/stellar.localhost.toml
+++ b/service-runner/src/main/resources/config/stellar.localhost.toml
@@ -11,14 +11,6 @@ DIRECT_PAYMENT_SERVER = "http://localhost:8080/sep31"
 ANCHOR_QUOTE_SERVER = "http://localhost:8080/sep38"
 
 [[CURRENCIES]]
-code = "SRT"
-issuer = "GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B"
-status = "test"
-is_asset_anchored = false
-anchor_asset_type = "crypto"
-desc = "Stellar Reference Token (SRT) is an asset issued on testnet and is used as an anchored asset for this reference server for demonstration and testing purposes."
-
-[[CURRENCIES]]
 code = "USDC"
 issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 status = "test"

--- a/service-runner/src/main/resources/config/stellar.localhost.toml
+++ b/service-runner/src/main/resources/config/stellar.localhost.toml
@@ -11,6 +11,14 @@ DIRECT_PAYMENT_SERVER = "http://localhost:8080/sep31"
 ANCHOR_QUOTE_SERVER = "http://localhost:8080/sep38"
 
 [[CURRENCIES]]
+code = "SRT"
+issuer = "GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B"
+status = "test"
+is_asset_anchored = false
+anchor_asset_type = "crypto"
+desc = "Stellar Reference Token (SRT) is an asset issued on testnet and is used as an anchored asset for this reference server for demonstration and testing purposes."
+
+[[CURRENCIES]]
 code = "USDC"
 issuer = "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
 status = "test"
@@ -36,7 +44,7 @@ desc = "XLM, the native token of the Stellar network."
 [DOCUMENTATION]
 ORG_NAME = "Stellar Development Foundation"
 ORG_URL = "https://stellar.org"
-ORG_DESCRIPTION = "SEP 24 reference server."
+ORG_DESCRIPTION = "The Stellar Development Foundation (SDF) is a non-profit organization whose mission is to create equitable access to the global financial system."
 ORG_KEYBASE = "stellar.public"
 ORG_TWITTER = "StellarOrg"
 ORG_GITHUB = "stellar"


### PR DESCRIPTION
### What's changed

1. Supports SRT usage in demo wallet SEP-6 by adding the `rate`
2. Improving error msg.  `....resultCodes` includes sth more meaningful like `op_src_no_trust `, whereas the `....resultCodes?.transactionResultCode` just always return `tx_failed`

### Test 
Tested with demo wallet with local setup, also tried SEP-6 and SEP-24 e2e tests with hardcoded SRT asset.
Once this PR being checked in, we can test against ap-dev instance
