### PR TITLE
Fix reference server values file

### DIFF
--- a/helm-charts/reference-server/templates/deployment.yaml
+++ b/helm-charts/reference-server/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: {{ .Values.config.app.platformApiEndpoint }}
             - name: APP.HORIZON_ENDPOINT
               value: {{ .Values.config.app.horizonEndpoint }}
+            - name: APP.RPC_ENDPOINT
+              value: {{ .Values.config.app.rpcEndpoint }}
             - name: DATA.URL
               value: {{ .Values.config.data.url }}
             - name: DATA.USER

--- a/helm-charts/reference-server/values.yaml
+++ b/helm-charts/reference-server/values.yaml
@@ -10,6 +10,7 @@ container:
 config:
   app:
     horizonEndpoint: https://horizon-testnet.stellar.org
+    rpcEndpoint: https://soroban-testnet.stellar.org
     platformApiEndpoint: http://anchor-platform-svc-platform:8085
   data:
     url: postgresql-ref:5432


### PR DESCRIPTION
### Description

This adds the `rpcEndpoint` config which is now required as of merging `feature/c-accounts` into `develop`

### Context

The reference server is crashing in dev. The config is also missing from the local deployment.

### Testing

- `./gradlew test`

### Documentation

N/A

### Known limitations

N/A

