### PR TITLE
[ANCHOR-1101] Fix the observer metrics not updating.

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/AbstractPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/AbstractPaymentObserver.java
@@ -142,12 +142,10 @@ public abstract class AbstractPaymentObserver implements HealthCheckable {
    * @throws IOException if there is an error processing the event
    */
   void handleEvent(PaymentTransferEvent transferEvent) throws AnchorException, IOException {
-    metricLatestBlockRead.set(transferEvent.getLedgerTransaction().getLedger());
     // process the payment
     for (PaymentListener listener : paymentListeners) {
       listener.onReceived(transferEvent);
     }
-    metricLatestBlockProcessed.set(transferEvent.getLedgerTransaction().getLedger());
     publishingBackoffTimer.reset();
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/HorizonPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/HorizonPaymentObserver.java
@@ -85,6 +85,7 @@ public class HorizonPaymentObserver extends AbstractPaymentObserver {
         horizon
             .getServer()
             .payments()
+            .includeTransactions(true)
             .cursor(latestCursor)
             .order(RequestBuilder.Order.ASC)
             .limit(MAX_RESULTS);
@@ -99,7 +100,9 @@ public class HorizonPaymentObserver extends AbstractPaymentObserver {
               silenceTimeoutCount = 0;
               streamBackoffTimer.reset();
               try {
+                metricLatestBlockRead.set(operationResponse.getTransaction().getLedger());;
                 processOperation(operationResponse);
+                metricLatestBlockProcessed.set(operationResponse.getTransaction().getLedger());;
               } catch (TransactionException ex) {
                 errorEx("Error handling events", ex);
                 setStatus(DATABASE_ERROR);

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/HorizonPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/HorizonPaymentObserver.java
@@ -100,9 +100,11 @@ public class HorizonPaymentObserver extends AbstractPaymentObserver {
               silenceTimeoutCount = 0;
               streamBackoffTimer.reset();
               try {
-                metricLatestBlockRead.set(operationResponse.getTransaction().getLedger());;
+                metricLatestBlockRead.set(operationResponse.getTransaction().getLedger());
+                ;
                 processOperation(operationResponse);
-                metricLatestBlockProcessed.set(operationResponse.getTransaction().getLedger());;
+                metricLatestBlockProcessed.set(operationResponse.getTransaction().getLedger());
+                ;
               } catch (TransactionException ex) {
                 errorEx("Error handling events", ex);
                 setStatus(DATABASE_ERROR);

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.val;
 import org.stellar.anchor.api.asset.AssetInfo;
 import org.stellar.anchor.api.asset.StellarAssetInfo;
 import org.stellar.anchor.api.exception.AnchorException;
@@ -135,12 +136,20 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
   private void processEvents(List<EventInfo> events) {
     if (events == null || events.isEmpty()) return;
     debugF("Processing {} 'transfer' events", events.size());
+    val lastEvent = events.get(events.size() - 1);
+    if (lastEvent != null)
+      metricLatestBlockRead.set(lastEvent.getLedger());
+
     for (EventInfo event : events) {
       ShouldProcessResult result = shouldProcess(event);
       if (result.shouldProcess) {
         processTransferEvent(result);
       }
     }
+
+    if (lastEvent != null)
+      metricLatestBlockProcessed.set(lastEvent.getLedger());
+
   }
 
   private void processTransferEvent(ShouldProcessResult result) {

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/StellarRpcPaymentObserver.java
@@ -137,8 +137,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
     if (events == null || events.isEmpty()) return;
     debugF("Processing {} 'transfer' events", events.size());
     val lastEvent = events.get(events.size() - 1);
-    if (lastEvent != null)
-      metricLatestBlockRead.set(lastEvent.getLedger());
+    if (lastEvent != null) metricLatestBlockRead.set(lastEvent.getLedger());
 
     for (EventInfo event : events) {
       ShouldProcessResult result = shouldProcess(event);
@@ -147,9 +146,7 @@ public class StellarRpcPaymentObserver extends AbstractPaymentObserver {
       }
     }
 
-    if (lastEvent != null)
-      metricLatestBlockProcessed.set(lastEvent.getLedger());
-
+    if (lastEvent != null) metricLatestBlockProcessed.set(lastEvent.getLedger());
   }
 
   private void processTransferEvent(ShouldProcessResult result) {


### PR DESCRIPTION
### Description

- Fix the observer metrics not updating.
- For StellarRpc implementation, the metrics are updated only when the events are from accounts related to anchor platform.
- For Horizon implementation, the transactions are now included in the stream for the ledger number of the operation.

### Context

- Bug fixes.
