### PR TITLE
[CHORE} Add concurrency configurations to on_pull_request and on_push_to_develop

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,10 +13,16 @@ jobs:
   essential_tests:
     needs: [ gradle_build ]
     uses: ./.github/workflows/sub_essential_tests.yml
+    concurrency:
+      group: ap-test-job
+      cancel-in-progress: false
 
   extended_tests:
     needs: [ gradle_build, essential_tests ]
     uses: ./.github/workflows/sub_extended_tests.yml
+    concurrency:
+      group: ap-test-job
+      cancel-in-progress: false
 
   codeql_analysis:
     uses: ./.github/workflows/sub_codeql_analysis.yml

--- a/.github/workflows/on_push_to_develop.yml
+++ b/.github/workflows/on_push_to_develop.yml
@@ -20,10 +20,16 @@ jobs:
   essential_tests:
     needs: [ gradle_build ]
     uses: ./.github/workflows/sub_essential_tests.yml
+    concurrency:
+      group: ap-test-job
+      cancel-in-progress: false
 
   extended_tests:
     needs: [ gradle_build, essential_tests ]
     uses: ./.github/workflows/sub_extended_tests.yml
+    concurrency:
+      group: ap-test-job
+      cancel-in-progress: false
 
   codeql_analysis:
     uses: ./.github/workflows/sub_codeql_analysis.yml


### PR DESCRIPTION
### Description

- Add concurrency configurations to on_pull_request and on_push_to_develop

### Context

- This is trying to avoid cancelling the waiting jobs of extended and essential tests.
