### PR TITLE
[CHORE] Add JDK 17.0.16 verification for Sectigo Root Certificate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,6 +224,29 @@ allprojects {
   }
 }
 
+
+// *******************************************************************************
+// Ensure JDK version is 17.0.16 or above to support Sectigo root CA certificate
+// Check the Sectigo certification additions at https://www.oracle.com/java/technologies/javase/17-0-16-relnotes.html
+fun isJdkVersionValid(): Boolean {
+  val version = System.getProperty("java.version")
+  val regex = Regex("^(\\d+)\\.(\\d+)\\.(\\d+)")
+  val match = regex.find(version)
+  if (match != null) {
+    val (major, minor, patch) = match.destructured
+    if (major.toInt() == 17) {
+      val patchInt = patch.toInt()
+      val minorInt = minor.toInt()
+      // Accept 17.0.16 and above
+      return minorInt > 0 || patchInt >= 16
+    }
+  }
+  return false
+}
+if (!isJdkVersionValid()) {
+  throw GradleException("JDK 17.0.16 or above is required. Current version: ${System.getProperty("java.version")}")
+}
+
 // *******************************************************************************
 // print the gradle script usages
 tasks.register("printUsage") {
@@ -249,5 +272,7 @@ tasks.register("printUsage") {
             .trimIndent())
   }
 }
+
+
 
 defaultTasks("printUsage")


### PR DESCRIPTION
### Description

- Add JDK 17.0.16 verification for Sectigo Root Certificate

### Context

- Prior to openjdk@17.0.16, the Sectigo Root Cert is missing. `17.0.16` is required for AP to work properly to fetch client domain Stellar file successfully. 
