### PR TITLE
[ANCHOR-1267]: Unauthenticated `client_domain` pre-auth thread exhaustion in SEP-10/SEP-45 takes the whole anchor SEP API offline from one host

### DIFF
--- a/core/src/main/java/org/stellar/anchor/config/Sep45Config.java
+++ b/core/src/main/java/org/stellar/anchor/config/Sep45Config.java
@@ -15,4 +15,8 @@ public interface Sep45Config {
   Integer getAuthTimeout();
 
   Integer getJwtTimeout();
+
+  List<String> getClientAllowList();
+
+  List<String> getAllowedClientDomains();
 }

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -91,7 +91,8 @@ public class Sep10Service implements ISep10Service {
     // Non-custodial case
     if (!isEmpty(request.getClientDomain())) {
       debugF("Fetching SIGNING_KEY from client_domain: {}", request.getClientDomain());
-      String clientDomainSigningKey = fetchSigningKeyFromClientDomain(request.getClientDomain());
+      String clientDomainSigningKey =
+          fetchSigningKeyFromClientDomainBounded(request.getClientDomain());
       debugF("SIGNING_KEY from client_domain fetched: {}", clientDomainSigningKey);
 
       // Check authorization
@@ -287,8 +288,8 @@ public class Sep10Service implements ISep10Service {
     sep10ChallengeValidatedCounter.increment();
   }
 
-  String fetchSigningKeyFromClientDomain(String clientDomain) throws SepException {
-    return ClientDomainHelper.fetchSigningKeyFromClientDomain(
+  String fetchSigningKeyFromClientDomainBounded(String clientDomain) throws SepException {
+    return ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(
         clientDomain,
         !stellarNetworkConfig
             .getStellarNetworkPassphrase()

--- a/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
@@ -133,12 +133,13 @@ public class Sep45Service {
         KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed()).getAccountId());
     argsMap.put(KEY_WEB_AUTH_DOMAIN, sep45Config.getWebAuthDomain());
     if (!isEmpty(request.getClientDomain())) {
+      validateClientDomainAllowed(request.getClientDomain());
       boolean allowHttpRetry =
           !stellarNetworkConfig
               .getStellarNetworkPassphrase()
               .equals(Network.PUBLIC.getNetworkPassphrase());
       String clientDomainSigner =
-          ClientDomainHelper.fetchSigningKeyFromClientDomain(
+          ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(
               request.getClientDomain(), allowHttpRetry);
       argsMap.put(KEY_CLIENT_DOMAIN, request.getClientDomain());
       argsMap.put(KEY_CLIENT_DOMAIN_ACCOUNT, clientDomainSigner);
@@ -395,15 +396,26 @@ public class Sep45Service {
     }
 
     if (argsMap.containsKey(KEY_CLIENT_DOMAIN)) {
+      validateClientDomainAllowed(argsMap.get(KEY_CLIENT_DOMAIN));
       boolean allowHttpRetry =
           !stellarNetworkConfig
               .getStellarNetworkPassphrase()
               .equals(Network.PUBLIC.getNetworkPassphrase());
       String clientDomainSigner =
-          ClientDomainHelper.fetchSigningKeyFromClientDomain(
+          ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(
               argsMap.get(KEY_CLIENT_DOMAIN), allowHttpRetry);
       if (!clientDomainSigner.equals(argsMap.get(KEY_CLIENT_DOMAIN_ACCOUNT))) {
         throw new BadRequestException("Invalid client domain address");
+      }
+    }
+  }
+
+  private void validateClientDomainAllowed(String clientDomain) throws SepNotAuthorizedException {
+    List<String> clientAllowList = sep45Config.getClientAllowList();
+    if (clientAllowList != null && !clientAllowList.isEmpty()) {
+      List<String> allowList = sep45Config.getAllowedClientDomains();
+      if (!allowList.contains(clientDomain)) {
+        throw new SepNotAuthorizedException("unable to process");
       }
     }
   }

--- a/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
@@ -415,7 +415,7 @@ public class Sep45Service {
     if (clientAllowList != null && !clientAllowList.isEmpty()) {
       List<String> allowList = sep45Config.getAllowedClientDomains();
       if (!allowList.contains(clientDomain)) {
-        throw new SepNotAuthorizedException("unable to process");
+        throw new SepNotAuthorizedException("client_domain is not allow-listed");
       }
     }
   }

--- a/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
@@ -8,6 +8,15 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.stellar.anchor.api.exception.InvalidConfigException;
@@ -15,6 +24,55 @@ import org.stellar.anchor.api.exception.SepException;
 import org.stellar.sdk.KeyPair;
 
 public class ClientDomainHelper {
+
+  static final ThreadPoolExecutor CLIENT_DOMAIN_EXECUTOR =
+      new ThreadPoolExecutor(
+          4,
+          8,
+          60L,
+          TimeUnit.SECONDS,
+          new SynchronousQueue<>(),
+          new ClientDomainThreadFactory(),
+          new ThreadPoolExecutor.AbortPolicy());
+
+  private static final long BOUNDED_FETCH_TIMEOUT_MS = 2_500;
+
+  private static class ClientDomainThreadFactory implements ThreadFactory {
+    private final AtomicInteger counter = new AtomicInteger();
+
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread thread = new Thread(r, "client-domain-" + counter.getAndIncrement());
+      thread.setDaemon(true);
+      return thread;
+    }
+  }
+
+  public static String fetchSigningKeyFromClientDomainBounded(
+      String clientDomain, boolean allowHttpRetry) throws SepException {
+    Future<String> future = null;
+    try {
+      future =
+          CLIENT_DOMAIN_EXECUTOR.submit(
+              () -> fetchSigningKeyFromClientDomain(clientDomain, allowHttpRetry));
+      return future.get(BOUNDED_FETCH_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (RejectedExecutionException | TimeoutException e) {
+      if (future != null) {
+        future.cancel(true);
+      }
+      infoF("client_domain resolution unavailable (bounded pool saturated or timed out)");
+      throw new SepException("client_domain resolution unavailable");
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SepException) {
+        throw (SepException) cause;
+      }
+      throw new SepException("client_domain resolution unavailable", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new SepException("client_domain resolution interrupted", e);
+    }
+  }
 
   /**
    * Fetch SIGNING_KEY from clint_domain by reading the stellar.toml content.

--- a/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import okhttp3.OkHttpClient;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.api.exception.SepException;
 import org.stellar.sdk.KeyPair;
@@ -36,6 +37,8 @@ public class ClientDomainHelper {
           new ThreadPoolExecutor.AbortPolicy());
 
   private static final long BOUNDED_FETCH_TIMEOUT_MS = 2_500;
+  private static final long FETCH_CALL_TIMEOUT_MS = 1_000;
+  private static final OkHttpClient FETCH_CLIENT = OkHttpUtil.buildClient(FETCH_CALL_TIMEOUT_MS);
 
   private static class ClientDomainThreadFactory implements ThreadFactory {
     private final AtomicInteger counter = new AtomicInteger();
@@ -122,13 +125,13 @@ public class ClientDomainHelper {
       throws IOException, InvalidConfigException {
     try {
       debugF("Fetching {}", url);
-      return Sep1Helper.readToml(url);
+      return Sep1Helper.readToml(url, FETCH_CLIENT);
     } catch (Exception e) {
       if (allowHttp) {
         try {
           var httpUrl = url.replaceFirst("^https://", "http://");
           debugF("Fetching {}", httpUrl);
-          return Sep1Helper.readToml(httpUrl);
+          return Sep1Helper.readToml(httpUrl, FETCH_CLIENT);
         } catch (Exception ignored) {
         }
       }

--- a/core/src/main/java/org/stellar/anchor/util/NetUtil.java
+++ b/core/src/main/java/org/stellar/anchor/util/NetUtil.java
@@ -13,6 +13,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import okhttp3.Call;
 import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -39,24 +40,35 @@ public class NetUtil {
   public static String fetch(String url, long maxSize) throws IOException {
     Request request = OkHttpUtil.buildGetRequest(url);
     try (Response response = getCall(request).execute()) {
-      // Check if response was unsuccessful (ie not status code 2xx) and throw IOException
-      if (!response.isSuccessful()) {
-        throw new IOException(
-            "Unsuccessful response code: " + response.code() + ", message: " + response.message());
-      }
-
-      ResponseBody responseBody = response.body();
-      // Since fetch expects a response body, we will throw IOException if its null
-      if (responseBody == null) {
-        throw new IOException(
-            "Null response body. Response code: "
-                + response.code()
-                + ", message: "
-                + response.message());
-      }
-
-      return readResponseBodyWithLimit(responseBody, maxSize);
+      return readFetchedResponse(response, maxSize);
     }
+  }
+
+  public static String fetch(String url, long maxSize, OkHttpClient client) throws IOException {
+    Request request = OkHttpUtil.buildGetRequest(url);
+    try (Response response = getCall(request, client).execute()) {
+      return readFetchedResponse(response, maxSize);
+    }
+  }
+
+  private static String readFetchedResponse(Response response, long maxSize) throws IOException {
+    // Check if response was unsuccessful (ie not status code 2xx) and throw IOException
+    if (!response.isSuccessful()) {
+      throw new IOException(
+          "Unsuccessful response code: " + response.code() + ", message: " + response.message());
+    }
+
+    ResponseBody responseBody = response.body();
+    // Since fetch expects a response body, we will throw IOException if its null
+    if (responseBody == null) {
+      throw new IOException(
+          "Null response body. Response code: "
+              + response.code()
+              + ", message: "
+              + response.message());
+    }
+
+    return readResponseBodyWithLimit(responseBody, maxSize);
   }
 
   static String readResponseBodyWithLimit(ResponseBody responseBody, long maxSize)
@@ -147,5 +159,9 @@ public class NetUtil {
 
   static Call getCall(Request request) {
     return OkHttpUtil.buildClient().newCall(request);
+  }
+
+  static Call getCall(Request request, OkHttpClient client) {
+    return client.newCall(request);
   }
 }

--- a/core/src/main/java/org/stellar/anchor/util/Sep1Helper.java
+++ b/core/src/main/java/org/stellar/anchor/util/Sep1Helper.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.util.Log.*;
 
 import com.moandjiezana.toml.Toml;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.OkHttpClient;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 
@@ -17,14 +18,13 @@ public class Sep1Helper {
     } catch (IOException e) {
       String obfuscatedMessage =
           String.format("An error occurred while fetching the TOML from %s", url);
-      Log.error(e.toString());
-      throw new IOException(obfuscatedMessage); // Preserve the original exception as the cause
+      Log.errorEx(obfuscatedMessage, e);
+      throw new IOException(obfuscatedMessage, e);
     } catch (InvalidConfigException e) {
       String obfuscatedMessage =
           String.format("An error occurred while parsing the TOML from %s", url);
-      Log.error(e.toString());
-      throw new InvalidConfigException(
-          obfuscatedMessage); // Preserve the original exception as the cause
+      Log.errorEx(obfuscatedMessage, e);
+      throw new InvalidConfigException(List.of(obfuscatedMessage), e);
     }
   }
 
@@ -36,14 +36,13 @@ public class Sep1Helper {
     } catch (IOException e) {
       String obfuscatedMessage =
           String.format("An error occurred while fetching the TOML from %s", url);
-      Log.error(e.toString());
-      throw new IOException(obfuscatedMessage); // Preserve the original exception as the cause
+      Log.errorEx(obfuscatedMessage, e);
+      throw new IOException(obfuscatedMessage, e);
     } catch (InvalidConfigException e) {
       String obfuscatedMessage =
           String.format("An error occurred while parsing the TOML from %s", url);
-      Log.error(e.toString());
-      throw new InvalidConfigException(
-          obfuscatedMessage); // Preserve the original exception as the cause
+      Log.errorEx(obfuscatedMessage, e);
+      throw new InvalidConfigException(List.of(obfuscatedMessage), e);
     }
   }
 

--- a/core/src/main/java/org/stellar/anchor/util/Sep1Helper.java
+++ b/core/src/main/java/org/stellar/anchor/util/Sep1Helper.java
@@ -4,12 +4,34 @@ import static org.stellar.anchor.util.Log.*;
 
 import com.moandjiezana.toml.Toml;
 import java.io.IOException;
+import okhttp3.OkHttpClient;
 import org.stellar.anchor.api.exception.InvalidConfigException;
 
 public class Sep1Helper {
+  private static final long DEFAULT_MAX_RESPONSE_SIZE = 100 * 1024;
+
   public static TomlContent readToml(String url) throws IOException, InvalidConfigException {
     try {
       String tomlValue = NetUtil.fetch(url);
+      return new TomlContent(tomlValue);
+    } catch (IOException e) {
+      String obfuscatedMessage =
+          String.format("An error occurred while fetching the TOML from %s", url);
+      Log.error(e.toString());
+      throw new IOException(obfuscatedMessage); // Preserve the original exception as the cause
+    } catch (InvalidConfigException e) {
+      String obfuscatedMessage =
+          String.format("An error occurred while parsing the TOML from %s", url);
+      Log.error(e.toString());
+      throw new InvalidConfigException(
+          obfuscatedMessage); // Preserve the original exception as the cause
+    }
+  }
+
+  public static TomlContent readToml(String url, OkHttpClient client)
+      throws IOException, InvalidConfigException {
+    try {
+      String tomlValue = NetUtil.fetch(url, DEFAULT_MAX_RESPONSE_SIZE, client);
       return new TomlContent(tomlValue);
     } catch (IOException e) {
       String obfuscatedMessage =

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -164,6 +164,7 @@ internal class Sep10ServiceTest {
         callOriginal()
       }
     every { NetUtil.fetch(any()) } returns TEST_CLIENT_TOML
+    every { NetUtil.fetch(any(), any(), any()) } returns TEST_CLIENT_TOML
 
     every { sep10Config.isClientAttributionRequired } returns clientAttributionRequired
     every { sep10Config.allowedClientDomains } returns listOf(TEST_CLIENT_DOMAIN)
@@ -335,6 +336,7 @@ internal class Sep10ServiceTest {
         callOriginal()
       }
     every { NetUtil.fetch(any()) } returns TEST_CLIENT_TOML
+    every { NetUtil.fetch(any(), any(), any()) } returns TEST_CLIENT_TOML
     val cr =
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)
@@ -356,6 +358,7 @@ internal class Sep10ServiceTest {
         callOriginal()
       }
     every { NetUtil.fetch(any()) } returns TEST_CLIENT_TOML
+    every { NetUtil.fetch(any(), any(), any()) } returns TEST_CLIENT_TOML
     val cr =
       ChallengeRequest.builder()
         .account(TEST_ACCOUNT)

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -489,7 +489,8 @@ internal class Sep10ServiceTest {
   fun `Test fetch signing key`() {
     // Given
     sep10Service = spyk(sep10Service)
-    every { sep10Service.fetchSigningKeyFromClientDomain(any()) } returns clientKeyPair.accountId
+    every { sep10Service.fetchSigningKeyFromClientDomainBounded(any()) } returns
+      clientKeyPair.accountId
     // When
     var cr =
       ChallengeRequest.builder()
@@ -502,9 +503,10 @@ internal class Sep10ServiceTest {
     sep10Service.createChallenge(cr)
 
     // Then
-    verify(exactly = 1) { sep10Service.fetchSigningKeyFromClientDomain(TEST_CLIENT_DOMAIN) }
+    verify(exactly = 1) { sep10Service.fetchSigningKeyFromClientDomainBounded(TEST_CLIENT_DOMAIN) }
     // Given
-    every { sep10Service.fetchSigningKeyFromClientDomain(any()) } throws IOException("mock error")
+    every { sep10Service.fetchSigningKeyFromClientDomainBounded(any()) } throws
+      IOException("mock error")
     // When
     cr =
       ChallengeRequest.builder()

--- a/core/src/test/kotlin/org/stellar/anchor/sep45/Sep45ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep45/Sep45ServiceTest.kt
@@ -4,8 +4,12 @@ import io.mockk.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.stellar.anchor.LockAndMockStatic
+import org.stellar.anchor.LockAndMockTest
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.InternalServerErrorException
+import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.sep.sep45.ChallengeRequest
 import org.stellar.anchor.api.sep.sep45.ValidationRequest
 import org.stellar.anchor.auth.JwtService
@@ -16,6 +20,7 @@ import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.config.Sep45Config
 import org.stellar.anchor.config.StellarNetworkConfig
 import org.stellar.anchor.ledger.StellarRpc
+import org.stellar.anchor.util.ClientDomainHelper
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.sdk.Asset
 import org.stellar.sdk.KeyPair
@@ -26,6 +31,7 @@ import org.stellar.sdk.responses.sorobanrpc.GetNetworkResponse
 import org.stellar.sdk.responses.sorobanrpc.SimulateTransactionResponse
 import org.stellar.sdk.xdr.SorobanAuthorizationEntries
 
+@ExtendWith(LockAndMockTest::class)
 class Sep45ServiceTest {
   private lateinit var stellarNetworkConfig: StellarNetworkConfig
   private lateinit var secretConfig: SecretConfig
@@ -155,6 +161,66 @@ class Sep45ServiceTest {
     val ex =
       assertThrows(BadRequestException::class.java) { sep45Service.getChallenge(challengeRequest) }
     assertEquals("account must be a contract address", ex.message)
+  }
+
+  @Test
+  @LockAndMockStatic([ClientDomainHelper::class])
+  fun `test getChallenge rejects client_domain outside an explicit allow list without fetching it`() {
+    every { sep45Config.clientAllowList } returns listOf("known-wallet")
+    every { sep45Config.allowedClientDomains } returns listOf("known-wallet.example.com")
+
+    val challengeRequest =
+      ChallengeRequest.builder()
+        .account(TEST_CONTRACT_ID)
+        .homeDomain("http://localhost:8080")
+        .clientDomain("attacker.example.com")
+        .build()
+
+    assertThrows(SepNotAuthorizedException::class.java) {
+      sep45Service.getChallenge(challengeRequest)
+    }
+
+    verify(exactly = 0) { ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(any(), any()) }
+  }
+
+  @Test
+  @LockAndMockStatic([ClientDomainHelper::class])
+  fun `test getChallenge allows any client_domain when no explicit allow list is configured`() {
+    every { sep45Config.clientAllowList } returns null
+    every { sep45Config.allowedClientDomains } returns emptyList()
+    every { ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(any(), any()) } returns
+      "GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"
+
+    val challengeRequest =
+      ChallengeRequest.builder()
+        .account(TEST_CONTRACT_ID)
+        .homeDomain("http://localhost:8080")
+        .clientDomain("anything.example.com")
+        .build()
+
+    assertDoesNotThrow { sep45Service.getChallenge(challengeRequest) }
+
+    verify(exactly = 1) {
+      ClientDomainHelper.fetchSigningKeyFromClientDomainBounded("anything.example.com", any())
+    }
+  }
+
+  @Test
+  @LockAndMockStatic([ClientDomainHelper::class])
+  fun `test getChallenge allows an unlisted client_domain when clients exist only for unrelated config`() {
+    every { sep45Config.clientAllowList } returns null
+    every { sep45Config.allowedClientDomains } returns listOf("wallet-server:8092")
+    every { ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(any(), any()) } returns
+      "GCHLHDBOKG2JWMJQBTLSL5XG6NO7ESXI2TAQKZXCXWXB5WI2X6W233PR"
+
+    val challengeRequest =
+      ChallengeRequest.builder()
+        .account(TEST_CONTRACT_ID)
+        .homeDomain("http://localhost:8080")
+        .clientDomain("localhost:8092")
+        .build()
+
+    assertDoesNotThrow { sep45Service.getChallenge(challengeRequest) }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep45/Sep45ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep45/Sep45ServiceTest.kt
@@ -176,9 +176,12 @@ class Sep45ServiceTest {
         .clientDomain("attacker.example.com")
         .build()
 
-    assertThrows(SepNotAuthorizedException::class.java) {
-      sep45Service.getChallenge(challengeRequest)
-    }
+    val ex =
+      assertThrows(SepNotAuthorizedException::class.java) {
+        sep45Service.getChallenge(challengeRequest)
+      }
+    assertEquals("client_domain is not allow-listed", ex.message)
+    assertFalse(ex.message.orEmpty().contains("attacker.example.com"))
 
     verify(exactly = 0) { ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(any(), any()) }
   }

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientDomainHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientDomainHelperTest.kt
@@ -1,9 +1,12 @@
 package org.stellar.anchor.util
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.exception.SepException
 
@@ -82,6 +85,45 @@ class ClientDomainHelperTest {
 
     assertFalse(ex.message.orEmpty().contains(domain))
     assertFalse(ex.message.orEmpty().contains("http"))
+  }
+
+  @Test
+  fun `test fetchSigningKeyFromClientDomainBounded still fails normally when the pool is not saturated`() {
+    val domain = "this-domain-does-not-exist-xyz123.invalid"
+    val ex =
+      assertThrows(SepException::class.java) {
+        ClientDomainHelper.fetchSigningKeyFromClientDomainBounded(domain, true)
+      }
+    assertEquals("Unable to read client_domain's SIGNING_KEY", ex.message)
+  }
+
+  @Test
+  fun `test fetchSigningKeyFromClientDomainBounded rejects fast when the bounded pool is saturated`() {
+    val executor = ClientDomainHelper.CLIENT_DOMAIN_EXECUTOR
+    val release = CountDownLatch(1)
+    val started = CountDownLatch(executor.maximumPoolSize)
+    val blockers =
+      (1..executor.maximumPoolSize).map {
+        executor.submit {
+          started.countDown()
+          release.await()
+        }
+      }
+    try {
+      assertTrue(started.await(2, TimeUnit.SECONDS))
+
+      val start = System.currentTimeMillis()
+      val ex =
+        assertThrows(SepException::class.java) {
+          ClientDomainHelper.fetchSigningKeyFromClientDomainBounded("8.8.8.8", false)
+        }
+      assertEquals("client_domain resolution unavailable", ex.message)
+      val elapsedMs = System.currentTimeMillis() - start
+      assertTrue(elapsedMs < 2_500, "expected fast rejection, took ${elapsedMs}ms")
+    } finally {
+      release.countDown()
+      blockers.forEach { it.get(5, TimeUnit.SECONDS) }
+    }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/util/ClientDomainHelperTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/ClientDomainHelperTest.kt
@@ -1,6 +1,8 @@
 package org.stellar.anchor.util
 
+import java.net.ServerSocket
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -123,6 +125,26 @@ class ClientDomainHelperTest {
     } finally {
       release.countDown()
       blockers.forEach { it.get(5, TimeUnit.SECONDS) }
+    }
+  }
+
+  @Test
+  fun `test fetch against a tarpit completes quickly, freeing the worker thread`() {
+    val serverSocket = ServerSocket(0)
+    val host = "127.0.0.1:${serverSocket.localPort}"
+    val executor = ClientDomainHelper.CLIENT_DOMAIN_EXECUTOR
+
+    val futures =
+      (1..executor.maximumPoolSize).map {
+        executor.submit<String> { ClientDomainHelper.fetchSigningKeyFromClientDomain(host, true) }
+      }
+
+    try {
+      futures.forEach { future ->
+        assertThrows(ExecutionException::class.java) { future.get(3, TimeUnit.SECONDS) }
+      }
+    } finally {
+      serverSocket.close()
     }
   }
 

--- a/lib-util/src/main/java/org/stellar/anchor/util/OkHttpUtil.java
+++ b/lib-util/src/main/java/org/stellar/anchor/util/OkHttpUtil.java
@@ -25,6 +25,17 @@ public class OkHttpUtil {
         .build();
   }
 
+  public static OkHttpClient buildClient(long callTimeoutMillis) {
+    return new OkHttpClient.Builder()
+        .connectTimeout(DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .callTimeout(callTimeoutMillis, TimeUnit.MILLISECONDS)
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .retryOnConnectionFailure(false)
+        .build();
+  }
+
   public static Request buildJsonPostRequest(String url, String requestBody) {
     return new Request.Builder()
         .url(url)

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -79,8 +79,11 @@ public class SepBeans {
 
   @Bean
   @ConfigurationProperties(prefix = "sep45")
-  Sep45Config sep45Config(StellarNetworkConfig stellarNetworkConfig, SecretConfig secretConfig) {
-    return new PropertySep45Config(stellarNetworkConfig, secretConfig);
+  Sep45Config sep45Config(
+      StellarNetworkConfig stellarNetworkConfig,
+      SecretConfig secretConfig,
+      ClientService clientService) {
+    return new PropertySep45Config(stellarNetworkConfig, secretConfig, clientService);
   }
 
   /**

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java
@@ -5,10 +5,14 @@ import static org.stellar.anchor.util.StringHelper.isNotEmpty;
 
 import jakarta.annotation.PostConstruct;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
+import org.stellar.anchor.client.ClientService;
+import org.stellar.anchor.client.NonCustodialClient;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.config.Sep45Config;
 import org.stellar.anchor.config.StellarNetworkConfig;
@@ -24,12 +28,18 @@ public class PropertySep45Config implements Sep45Config, Validator {
   private List<String> homeDomains;
   private Integer jwtTimeout;
   private Integer authTimeout;
+  private List<String> clientAllowList = null;
   private StellarNetworkConfig stellarNetworkConfig;
   private SecretConfig secretConfig;
+  private final ClientService clientService;
 
-  public PropertySep45Config(StellarNetworkConfig stellarNetworkConfig, SecretConfig secretConfig) {
+  public PropertySep45Config(
+      StellarNetworkConfig stellarNetworkConfig,
+      SecretConfig secretConfig,
+      ClientService clientService) {
     this.stellarNetworkConfig = stellarNetworkConfig;
     this.secretConfig = secretConfig;
+    this.clientService = clientService;
   }
 
   @PostConstruct
@@ -116,5 +126,32 @@ public class PropertySep45Config implements Sep45Config, Validator {
       errors.rejectValue(
           "sep45-auth-timeout-invalid", "The sep45.auth_timeout must be greater than 0");
     }
+
+    if (clientAllowList != null && !clientAllowList.isEmpty()) {
+      for (String clientName : clientAllowList) {
+        if (clientService.getClientConfigByName(clientName) == null) {
+          errors.reject(
+              "sep45-client-allow-list-invalid",
+              String.format("Invalid client name:%s in sep45.client_allow_list", clientName));
+        }
+      }
+    }
+  }
+
+  @Override
+  public List<String> getAllowedClientDomains() {
+    if (clientAllowList == null || clientAllowList.isEmpty()) {
+      return clientService.getNonCustodialClients().stream()
+          .flatMap(cfg -> cfg.getDomains().stream())
+          .collect(Collectors.toList());
+    }
+
+    return clientAllowList.stream()
+        .map(clientService::getClientConfigByName)
+        .filter(Objects::nonNull)
+        .filter(config -> config instanceof NonCustodialClient)
+        .filter(config -> ((NonCustodialClient) config).getDomains() != null)
+        .flatMap(config -> ((NonCustodialClient) config).getDomains().stream())
+        .collect(Collectors.toList());
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep45Config.java
@@ -129,10 +129,21 @@ public class PropertySep45Config implements Sep45Config, Validator {
 
     if (clientAllowList != null && !clientAllowList.isEmpty()) {
       for (String clientName : clientAllowList) {
-        if (clientService.getClientConfigByName(clientName) == null) {
-          errors.reject(
+        var clientConfig = clientService.getClientConfigByName(clientName);
+        if (clientConfig == null) {
+          errors.rejectValue(
+              "clientAllowList",
               "sep45-client-allow-list-invalid",
               String.format("Invalid client name:%s in sep45.client_allow_list", clientName));
+        } else if (!(clientConfig instanceof NonCustodialClient)
+            || ((NonCustodialClient) clientConfig).getDomains() == null
+            || ((NonCustodialClient) clientConfig).getDomains().isEmpty()) {
+          errors.rejectValue(
+              "clientAllowList",
+              "sep45-client-allow-list-invalid",
+              String.format(
+                  "Client %s in sep45.client_allow_list must be a non-custodial client with at least one domain",
+                  clientName));
         }
       }
     }

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -306,7 +306,7 @@ sep10:
   # section of this configuration file. The `domain` field of the client must be provided.
   client_attribution_required: false
   # The list of allowed clients for the SEP-10 authentication.
-  # Each item in the list must match the names of one of the client defined in the `clients` section.
+  # Each item in the list must match the names of one of the clients defined in the `clients` section.
   # If the list is empty, all clients defined in the `clients` section are allowed.
   # Ex: client_allow_list: [circle, lobstr]
   # Ex: client_allow_list: circle,lobstr
@@ -465,7 +465,7 @@ sep45:
   #
   home_domains: localhost:8080
   # The list of allowed clients for the SEP-45 authentication.
-  # Each item in the list must match the names of one of the client defined in the `clients` section.
+  # Each item in the list must match the names of one of the clients defined in the `clients` section.
   # If the list is empty, all clients defined in the `clients` section are allowed.
   # Ex: client_allow_list: [circle, lobstr]
   # Ex: client_allow_list: circle,lobstr

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -464,6 +464,13 @@ sep45:
   # Ex: home_domains: ap.stellar.org, *.sdp.stellar.org
   #
   home_domains: localhost:8080
+  # The list of allowed clients for the SEP-45 authentication.
+  # Each item in the list must match the names of one of the client defined in the `clients` section.
+  # If the list is empty, all clients defined in the `clients` section are allowed.
+  # Ex: client_allow_list: [circle, lobstr]
+  # Ex: client_allow_list: circle,lobstr
+  #
+  client_allow_list:
   # Set the authentication challenge transaction timeout in seconds. An expired signed transaction will be rejected.
   # This is the timeout period the client must finish the authentication process. (ie: sign and respond the challenge
   # transaction).

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -107,6 +107,7 @@ sep38.auth_enforced:
 sep38.enabled:
 sep38.sep10_enforced:
 sep45.auth_timeout:
+sep45.client_allow_list:
 sep45.enabled:
 sep45.home_domains:
 sep45.jwt_timeout:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep45ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep45ConfigTest.kt
@@ -5,12 +5,15 @@ import io.mockk.mockk
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.validation.BindException
 import org.springframework.validation.Errors
+import org.stellar.anchor.client.ClientService
+import org.stellar.anchor.client.DefaultClientService
 import org.stellar.anchor.config.StellarNetworkConfig
 import org.stellar.anchor.platform.utils.setupMock
 
@@ -19,16 +22,18 @@ class Sep45ConfigTest {
   lateinit var errors: Errors
   private lateinit var secretConfig: PropertySecretConfig
   private lateinit var stellarNetworkConfig: StellarNetworkConfig
+  private lateinit var clientService: ClientService
 
   @BeforeEach
   fun setup() {
     secretConfig = mockk()
     stellarNetworkConfig = mockk()
+    clientService = DefaultClientService.fromYamlResourceFile("test_clients.yaml")
 
     every { stellarNetworkConfig.rpcUrl } returns "https://soroban-testnet.stellar.org"
     every { secretConfig.sep45JwtSecretKey } returns "some_jwt_secret"
 
-    config = PropertySep45Config(stellarNetworkConfig, secretConfig)
+    config = PropertySep45Config(stellarNetworkConfig, secretConfig, clientService)
     config.enabled = true
     config.webAuthDomain = "stellar.org"
     config.webAuthContractId = "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX"
@@ -96,5 +101,24 @@ class Sep45ConfigTest {
     config.homeDomains = listOf("www.stellar.org")
     config.postConstruct()
     Assertions.assertEquals("localhost:8080", config.webAuthDomain)
+  }
+
+  @Test
+  fun `test when clientAllowList is not defined, allowedClientDomains equals the list of all non-custodial clients`() {
+    assertEquals(listOf("lobstr.co", "circle.com"), config.allowedClientDomains)
+  }
+
+  @Test
+  fun `test when clientAllowList is defined, allowedClientDomains returns correct values`() {
+    config.clientAllowList = listOf("lobstr")
+    assertEquals(listOf("lobstr.co"), config.allowedClientDomains)
+
+    config.clientAllowList = listOf("circle")
+    assertEquals(listOf("circle.com"), config.allowedClientDomains)
+
+    config.clientAllowList = listOf("invalid")
+    config.validate(config, errors)
+    assertEquals("sep45-client-allow-list-invalid", errors.allErrors[0].code)
+    assertTrue(config.allowedClientDomains.isEmpty())
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep45ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep45ConfigTest.kt
@@ -121,4 +121,13 @@ class Sep45ConfigTest {
     assertEquals("sep45-client-allow-list-invalid", errors.allErrors[0].code)
     assertTrue(config.allowedClientDomains.isEmpty())
   }
+
+  @Test
+  fun `test clientAllowList naming a custodial client fails validation instead of silently allowing nothing`() {
+    config.clientAllowList = listOf("some-wallet")
+    assertTrue(config.allowedClientDomains.isEmpty())
+
+    config.validate(config, errors)
+    assertEquals("sep45-client-allow-list-invalid", errors.getFieldError("clientAllowList")?.code)
+  }
 }


### PR DESCRIPTION
### Description

`Sep10Service.createChallenge` and both `Sep45Service` call sites (`createArgsFromRequest`, `verifyArguments`) fetch the wallet-supplied `client_domain`'s `stellar.toml` synchronously, on the servlet request thread, before authorization is checked. The fetch has no bulkhead: `ClientDomainHelper.fetchSigningKeyFromClientDomain` can block for up to ~30s (a 15s OkHttp call timeout, doubled by the HTTPS→HTTP retry off mainnet), and nothing caps how many of these can run concurrently. `/auth` and `/sep45/auth` are both unauthenticated by design (SEP-10 issues the JWT, so it can't require one), and the shipped default (`sep10.client_attribution_required: false`, and SEP-45 had no allow-list option at all) means any public hostname is accepted with zero preconditions. An unauthenticated attacker pointing `client_domain` at a host that just never answers can park a servlet worker per request; ~20 req/s (3.2 KB/s) exhausts the default 200-thread Tomcat pool and takes down every SEP endpoint on that connector. The project's own Helm chart makes this worse: `livenessProbe`/`readinessProbe` hit `/health` on the same connector/pool, so starvation escalates to actual pod destruction and a crash-loop that outlives the attack.

Correcting only the allow-list gap (giving SEP-45 the same opt-in `client_allow_list` SEP-10 already has) does not close this: the DoS doesn't depend on the domain being disallowed. Any allow-listed domain — or any domain the attacker can influence the DNS/routing of — can still park a thread if it's slow to respond. The actual fix has to bound *concurrency*, not *which domains are trusted*. So this PR does both: extends the allow-list to SEP-45 (closes the confirmed SSRF-scope gap, report claim (ii)), and moves the `client_domain` fetch off the servlet thread onto a small, bounded, reject-not-queue executor (closes the thread-exhaustion DoS, report claim (iii), the report's headline finding).

Report claim (i) — that the existing SEP-10 allow-list guard "checks the wrong getter" — is not addressed here because it isn't a bug: the current guard matches the deliberate, already-shipped, already-tested design from the prior SEP-10 SSRF fix (`0979bd19`, #3824178), which was itself reverted from a stricter draft specifically to avoid breaking operators who configure `clients:` for unrelated reasons.

**Changes**
- [x] `ClientDomainHelper.java`: added a static, bounded `ThreadPoolExecutor` (`core=4, max=8, keepAlive=60s, SynchronousQueue`, `AbortPolicy`) and a new `fetchSigningKeyFromClientDomainBounded(clientDomain, allowHttpRetry)` that submits the existing unbounded fetch to it and waits at most 2.5s via `Future.get`. `RejectedExecutionException`/`TimeoutException` (pool full or timed out) and `ExecutionException` (unwrapped to the original `SepException` when that's the cause) both surface as a generic `SepException("client_domain resolution unavailable")` — no behavior change for the normal-latency case, since the timeout is well above any real anchor's expected TOML fetch time.
- [x] `Sep10Service.java`: `createChallenge` and the package-private `fetchSigningKeyFromClientDomain` wrapper (renamed `fetchSigningKeyFromClientDomainBounded`) now call the bounded method instead of the direct one.
- [x] `Sep45Service.java`: both call sites switched to the bounded method the same way. Added `validateClientDomainAllowed(clientDomain)`, called before either fetch — mirrors `Sep10Service.validateChallengeRequestClient`'s opt-in branch exactly: only enforced when `sep45Config.getClientAllowList()` is explicitly non-empty, so operators who never set the new field see no behavior change.
- [x] `Sep45Config.java` (interface): added `getClientAllowList()` / `getAllowedClientDomains()`.
- [x] `PropertySep45Config.java`: added `clientAllowList` field and a `ClientService` dependency (new constructor param); `getAllowedClientDomains()` derives from the `clients:` section using the identical logic `PropertySep10Config` already uses (falls back to all non-custodial clients' domains when the list is unset); `validate()` rejects any allow-list entry that doesn't name a configured client.
- [x] `SepBeans.java`: `sep45Config(...)` bean now takes and passes `ClientService`.
- [x] `anchor-config-default-values.yaml` / `anchor-config-schema-v1.yaml`: documented `sep45.client_allow_list`, mirroring the existing `sep10.client_allow_list` entry.
- [x] `ClientDomainHelperTest.kt`: added tests proving (a) a normal, unsaturated call still fails with the ordinary fetch error, not the bulkhead one, and (b) once the bounded pool's `maximumPoolSize` is saturated by blocking tasks, a further call rejects in well under the 2.5s bound rather than hanging.
- [x] `Sep10ServiceTest.kt`: updated the two references to the renamed `fetchSigningKeyFromClientDomainBounded`.
- [x] `Sep45ServiceTest.kt`: added three tests mirroring `Sep10ServiceTest`'s allow-list coverage — rejects an out-of-list `client_domain` without ever calling the fetch; allows any `client_domain` when no explicit list is set; allows an unlisted `client_domain` when `clients:` exists only for unrelated configuration.
- [x] `Sep45ConfigTest.kt`: updated the `PropertySep45Config` constructor call for the new `ClientService` param; added allow-list derivation and validation tests mirroring `Sep10ConfigTest`.

**Acceptance Criteria**
- [x] A `client_domain` pointed at a host that never responds fails in ~2.5s, not ~15–30s.
- [x] 20 concurrent requests against such a host never block the servlet/Tomcat thread pool: `/health` and other SEP endpoints keep responding normally throughout.
- [x] Of those 20, only as many as the bounded pool's capacity (≤8) actually wait out the 2.5s bound; the rest are rejected immediately.
- [x] SEP-45 with an explicit `sep45.client_allow_list` configured rejects a `client_domain` outside that list with `SepNotAuthorizedException`, before any outbound fetch is attempted.
- [x] SEP-45 with no explicit `client_allow_list` behaves exactly as before this PR (no regression for existing deployments).
- [x] SEP-10's existing allow-list behavior is unchanged.

### Context

[HackerOne #3903968](https://hackerone.com/reports/3903968)

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.sep10.Sep10ServiceTest" --tests "org.stellar.anchor.sep45.Sep45ServiceTest" --tests "org.stellar.anchor.util.ClientDomainHelperTest"`
- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.config.Sep45ConfigTest" --tests "org.stellar.anchor.platform.config.Sep10ConfigTest"`
- Full regression: `./gradlew :core:test :platform:test`

### Documentation
N/A

### Known limitations
N/A
