### PR TITLE
[ANCHOR-1270]: Move client (wallet) config from file to database, with a REST management API and JWT-carried client attribution

### DIFF
--- a/.github/workflows/sub_extended_tests.yml
+++ b/.github/workflows/sub_extended_tests.yml
@@ -116,8 +116,36 @@ jobs:
           TEST_PROFILE_NAME: auth-jwt-platform
         run: |
           cd /home/runner/anchor-platform
-          ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.AuthJwtPlatformTestSuite         
-          kill -9 $PID   
+          ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.AuthJwtPlatformTestSuite
+          kill -9 $PID
+
+      - name: Start `clients-db` configuration
+        env:
+          TEST_PROFILE_NAME: clients-db
+          SEP1_TOML_VALUE: /home/runner/anchor-platform/service-runner/src/main/resources/config/stellar.host.docker.internal.toml
+          SEP10_WEB_AUTH_DOMAIN: host.docker.internal:8080
+          SEP10_HOME_DOMAINS: host.docker.internal:8080,*.stellar.org
+          KT_REFERENCE_SERVER_CONFIG: /home/runner/anchor-platform/service-runner/src/main/resources/config/reference-config.yaml
+        run: |
+          cd /home/runner/anchor-platform
+          ./gradlew startServersWithTestProfile &
+          echo "PID=$!" >> $GITHUB_ENV
+
+      - name: Wait for the sep server to start and get ready
+        uses: mydea/action-wait-for-api@v1
+        with:
+          url: "http://host.docker.internal:8080/.well-known/stellar.toml"
+          interval: "1"
+          timeout: "600"
+
+      - name: Run `clients-db` configuration tests
+        env:
+          TEST_PROFILE_NAME: clients-db
+          ANCHOR_DOMAIN: http://host.docker.internal:8080
+        run: |
+          cd /home/runner/anchor-platform
+          ./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.ClientsDbTestSuite
+          kill -9 $PID
 
       # `default-horizon` end-2-end Tests
       - name: Start `default-horizon` configuration

--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -110,9 +110,7 @@ public class JwtService {
       builder.claim(HOME_DOMAIN, token.getHomeDomain());
     }
 
-    if (token.getClientName() != null) {
-      builder.claim(CLIENT_NAME, token.getClientName());
-    }
+    builder.claim(CLIENT_NAME, token.getClientName() != null ? token.getClientName() : "");
 
     if (token instanceof Sep45Jwt) {
       return signJWT(builder, sep45JwtSecret);

--- a/core/src/main/java/org/stellar/anchor/auth/JwtService.java
+++ b/core/src/main/java/org/stellar/anchor/auth/JwtService.java
@@ -110,6 +110,10 @@ public class JwtService {
       builder.claim(HOME_DOMAIN, token.getHomeDomain());
     }
 
+    if (token.getClientName() != null) {
+      builder.claim(CLIENT_NAME, token.getClientName());
+    }
+
     if (token instanceof Sep45Jwt) {
       return signJWT(builder, sep45JwtSecret);
     } else {

--- a/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.auth;
 
 import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static org.stellar.anchor.auth.JwtService.CLIENT_DOMAIN;
+import static org.stellar.anchor.auth.JwtService.CLIENT_NAME;
 import static org.stellar.anchor.auth.JwtService.HOME_DOMAIN;
 
 import com.google.gson.annotations.SerializedName;
@@ -20,6 +21,9 @@ public abstract class WebAuthJwt extends AbstractJwt {
 
   @SerializedName(value = "home_domain")
   String homeDomain;
+
+  @SerializedName(value = "client_name")
+  String clientName;
 
   String account;
 
@@ -60,6 +64,7 @@ public abstract class WebAuthJwt extends AbstractJwt {
     if (isNotEmpty(claims.get(CLIENT_DOMAIN)))
       this.clientDomain = claims.get(CLIENT_DOMAIN).toString();
     if (isNotEmpty(claims.get(HOME_DOMAIN))) this.homeDomain = claims.get(HOME_DOMAIN).toString();
+    if (isNotEmpty(claims.get(CLIENT_NAME))) this.clientName = claims.get(CLIENT_NAME).toString();
     updateAccountAndMemo();
   }
 

--- a/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
@@ -47,6 +47,10 @@ public abstract class WebAuthJwt extends AbstractJwt {
     return muxedAccount != null ? muxedAccount : account;
   }
 
+  public boolean hasClientNameClaim() {
+    return claims.containsKey(CLIENT_NAME);
+  }
+
   public String getIssuer() {
     return this.iss;
   }

--- a/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
@@ -16,8 +16,6 @@ public interface ClientsConfig {
 
   List<RawClient> getItems();
 
-  boolean isMigrateFromFileOnStartup();
-
   enum ClientsConfigType {
     @SerializedName("file")
     FILE,

--- a/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/ClientsConfig.java
@@ -16,6 +16,8 @@ public interface ClientsConfig {
 
   List<RawClient> getItems();
 
+  boolean isMigrateFromFileOnStartup();
+
   enum ClientsConfigType {
     @SerializedName("file")
     FILE,
@@ -25,6 +27,8 @@ public interface ClientsConfig {
     JSON,
     @SerializedName("yaml")
     YAML,
+    @SerializedName("db")
+    DB,
   }
 
   @Data

--- a/core/src/main/java/org/stellar/anchor/filter/WebAuthJwtFilter.java
+++ b/core/src/main/java/org/stellar/anchor/filter/WebAuthJwtFilter.java
@@ -4,6 +4,7 @@ import static org.stellar.anchor.util.Log.*;
 
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import org.stellar.anchor.api.exception.SepNotAuthorizedException;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.auth.Sep45Jwt;
@@ -24,6 +25,14 @@ public class WebAuthJwtFilter extends AbstractJwtFilter {
     } catch (Exception ignored) {
       token = jwtService.decode(jwtCipher, Sep45Jwt.class);
     } finally {
+      if (!token.hasClientNameClaim()) {
+        infoF(
+            "Rejecting token issued before client attribution existed. account={} url={}",
+            shorter(token.getAccount()),
+            request.getRequestURL());
+        throw new SepNotAuthorizedException(
+            "Token predates client attribution; please reauthenticate");
+      }
       infoF(
           "token created. account={} url={}", shorter(token.getAccount()), request.getRequestURL());
       debugF("storing token to request {}:", request.getRequestURL(), token);

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -116,8 +116,7 @@ public class Sep10Service implements ISep10Service {
     }
   }
 
-  public ValidationResponse validateChallenge(ValidationRequest request)
-      throws SepValidationException {
+  public ValidationResponse validateChallenge(ValidationRequest request) throws SepException {
     info("Validating SEP-10 challenge.");
 
     ChallengeTransaction challenge = parseChallenge(request);
@@ -550,8 +549,8 @@ public class Sep10Service implements ISep10Service {
     return challenge;
   }
 
-  String generateWebAuthJwt(
-      ChallengeTransaction challenge, String clientDomain, String homeDomain) {
+  String generateWebAuthJwt(ChallengeTransaction challenge, String clientDomain, String homeDomain)
+      throws SepException {
     long issuedAt = challenge.getTransaction().getTimeBounds().getMinTime().longValue();
     Memo memo = challenge.getTransaction().getMemo();
     Sep10Jwt webAuthJwt =
@@ -565,6 +564,10 @@ public class Sep10Service implements ISep10Service {
             challenge.getTransaction().hashHex(),
             clientDomain,
             homeDomain);
+
+    webAuthJwt.setClientName(
+        clientFinder.getClientName(clientDomain, challenge.getClientAccountId()));
+
     debug("jwtToken:", webAuthJwt);
     return jwtService.encode(webAuthJwt);
   }

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -2,7 +2,6 @@ package org.stellar.anchor.sep12;
 
 import static org.stellar.anchor.api.platform.PlatformTransactionData.Sep.SEP_12;
 import static org.stellar.anchor.util.Log.infoF;
-import static org.stellar.anchor.util.Log.warnF;
 import static org.stellar.anchor.util.MetricConstants.*;
 import static org.stellar.anchor.util.MetricConstants.SEP12_CUSTOMER;
 
@@ -24,7 +23,6 @@ import org.stellar.anchor.api.sep.sep12.*;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.auth.WebAuthJwt;
-import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore;
 import org.stellar.anchor.util.Log;
@@ -44,20 +42,17 @@ public class Sep12Service {
       Metrics.counter(SEP12_CUSTOMER, TYPE, TV_SEP12_DELETE_CUSTOMER);
   private final PlatformApiClient platformApiClient;
   private final EventService.Session eventSession;
-  private final ClientFinder clientFinder;
   private final Sep31CustomerIdOwnerStore customerIdOwnerStore;
 
   public Sep12Service(
       CustomerIntegration customerIntegration,
       PlatformApiClient platformApiClient,
       EventService eventService,
-      ClientFinder clientFinder,
       Sep31CustomerIdOwnerStore customerIdOwnerStore) {
     this.customerIntegration = customerIntegration;
     this.platformApiClient = platformApiClient;
     this.eventSession =
         eventService.createSession(this.getClass().getName(), EventService.EventQueue.TRANSACTION);
-    this.clientFinder = clientFinder;
     this.customerIdOwnerStore = customerIdOwnerStore;
 
     Log.info("Sep12Service initialized.");
@@ -121,16 +116,7 @@ public class Sep12Service {
     PutCustomerResponse updatedCustomer =
         customerIntegration.putCustomer(PutCustomerRequest.from(request));
 
-    String clientName = null;
-
-    try {
-      clientName = clientFinder.getClientName(token);
-    } catch (SepNotAuthorizedException e) {
-      warnF(
-          "Client attribution required but client is not authorized; CUSTOMER_UPDATED event will have no clientName. token={}, reason={}",
-          token.getAccount(),
-          e.getMessage());
-    }
+    String clientName = token.getClientName();
 
     if (isNewSep31Customer) {
       String ownerAccount = token.getOwnerAccount();

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -47,8 +47,6 @@ import org.stellar.anchor.api.sep.sep24.TransactionResponse;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.WebAuthJwt;
-import org.stellar.anchor.client.ClientFinder;
-import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.config.LanguageConfig;
 import org.stellar.anchor.config.Sep24Config;
 import org.stellar.anchor.config.StellarNetworkConfig;
@@ -67,11 +65,9 @@ public class Sep24Service {
   final LanguageConfig languageConfig;
   final StellarNetworkConfig stellarNetworkConfig;
   final Sep24Config sep24Config;
-  final ClientService clientService;
   final AssetService assetService;
   final SepRequestValidator requestValidator;
   final JwtService jwtService;
-  final ClientFinder clientFinder;
   final Sep24TransactionStore txnStore;
   final EventService.Session eventSession;
   final InteractiveUrlConstructor interactiveUrlConstructor;
@@ -95,11 +91,9 @@ public class Sep24Service {
       LanguageConfig languageConfig,
       StellarNetworkConfig stellarNetworkConfig,
       Sep24Config sep24Config,
-      ClientService clientsService,
       AssetService assetService,
       SepRequestValidator requestValidator,
       JwtService jwtService,
-      ClientFinder clientFinder,
       Sep24TransactionStore txnStore,
       EventService eventService,
       InteractiveUrlConstructor interactiveUrlConstructor,
@@ -110,11 +104,9 @@ public class Sep24Service {
     this.languageConfig = languageConfig;
     this.stellarNetworkConfig = stellarNetworkConfig;
     this.sep24Config = sep24Config;
-    this.clientService = clientsService;
     this.assetService = assetService;
     this.requestValidator = requestValidator;
     this.jwtService = jwtService;
-    this.clientFinder = clientFinder;
     this.txnStore = txnStore;
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
     this.interactiveUrlConstructor = interactiveUrlConstructor;
@@ -206,7 +198,7 @@ public class Sep24Service {
             .fromAccount(sourceAccount)
             .toAccount(asset.getDistributionAccount())
             .clientDomain(token.getClientDomain())
-            .clientName(clientFinder.getClientName(token))
+            .clientName(token.getClientName())
             .requestClientIpAddress(withdrawRequest.get("clientIpAddress"));
 
     if (memo != null) {
@@ -363,7 +355,7 @@ public class Sep24Service {
             .webAuthAccountMemo(token.getAccountMemo())
             .toAccount(destinationAccount)
             .clientDomain(token.getClientDomain())
-            .clientName(clientFinder.getClientName(token))
+            .clientName(token.getClientName())
             .claimableBalanceSupported(claimableSupported)
             .requestClientIpAddress(depositRequest.get("clientIpAddress"));
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -46,11 +46,7 @@ import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.WebAuthJwt;
-import org.stellar.anchor.client.ClientConfig;
-import org.stellar.anchor.client.ClientFinder;
-import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.config.LanguageConfig;
-import org.stellar.anchor.config.Sep10Config;
 import org.stellar.anchor.config.Sep31Config;
 import org.stellar.anchor.event.EventService;
 import org.stellar.anchor.sep38.Sep38Quote;
@@ -62,11 +58,9 @@ import org.stellar.anchor.util.TransactionMapper;
 
 public class Sep31Service {
   private final LanguageConfig languageConfig;
-  private final Sep10Config sep10Config;
   private final Sep31Config sep31Config;
   private final Sep31TransactionStore sep31TransactionStore;
   private final Sep38QuoteStore sep38QuoteStore;
-  private final ClientService clientService;
   private final AssetService assetService;
   private final RateIntegration rateIntegration;
   private final Clock clock;
@@ -76,35 +70,28 @@ public class Sep31Service {
   private final Counter sep31TransactionPatchedCounter = counter(SEP31_TRANSACTION_PATCHED);
   final ExchangeAmountsCalculator exchangeAmountsCalculator;
   private final Sep31CustomerIdOwnerStore customerIdOwnerStore;
-  private final ClientFinder clientFinder;
 
   public Sep31Service(
       LanguageConfig languageConfig,
-      Sep10Config sep10Config,
       Sep31Config sep31Config,
       Sep31TransactionStore sep31TransactionStore,
       Sep38QuoteStore sep38QuoteStore,
-      ClientService clientService,
       AssetService assetService,
       RateIntegration rateIntegration,
       EventService eventService,
       Clock clock,
       ExchangeAmountsCalculator exchangeAmountsCalculator,
-      Sep31CustomerIdOwnerStore customerIdOwnerStore,
-      ClientFinder clientFinder) {
+      Sep31CustomerIdOwnerStore customerIdOwnerStore) {
     debug("sep31Config:", sep31Config);
     this.languageConfig = languageConfig;
-    this.sep10Config = sep10Config;
     this.sep31Config = sep31Config;
     this.sep31TransactionStore = sep31TransactionStore;
     this.sep38QuoteStore = sep38QuoteStore;
-    this.clientService = clientService;
     this.assetService = assetService;
     this.rateIntegration = rateIntegration;
     this.clock = clock;
     this.exchangeAmountsCalculator = exchangeAmountsCalculator;
     this.customerIdOwnerStore = customerIdOwnerStore;
-    this.clientFinder = clientFinder;
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
     this.infoResponse = sep31InfoResponseFromAssetInfoList(assetService.getAssets());
     Log.info("Sep31Service initialized.");
@@ -176,12 +163,7 @@ public class Sep31Service {
             .memo(webAuthJwt.getAccountMemo())
             .build();
 
-    String ownerClientName;
-    try {
-      ownerClientName = clientFinder.getClientName(webAuthJwt);
-    } catch (SepNotAuthorizedException e) {
-      ownerClientName = null;
-    }
+    String ownerClientName = webAuthJwt.getClientName();
     String ownerAccount = ownerClientName != null ? ownerClientName : webAuthJwt.getOwnerAccount();
     String ownerMemo = webAuthJwt.getOwnerMemo();
 
@@ -594,18 +576,8 @@ public class Sep31Service {
     Context.get().setFee(amountFee);
   }
 
-  String getClientName() throws BadRequestException {
-    return getClientName(Context.get().getWebAuthJwt().getAccount());
-  }
-
-  String getClientName(String account) throws BadRequestException {
-    ClientConfig client = clientService.getClientConfigBySigningKey(account);
-    if (sep10Config.isClientAttributionRequired() && client == null) {
-      throw new BadRequestException("Client not found");
-    }
-    if (client != null && !sep10Config.getAllowedClientNames().contains(client.getName()))
-      client = null;
-    return client == null ? null : client.getName();
+  String getClientName() {
+    return Context.get().getWebAuthJwt().getClientName();
   }
 
   /**

--- a/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep45/Sep45Service.java
@@ -18,6 +18,7 @@ import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Nonce;
 import org.stellar.anchor.auth.NonceManager;
 import org.stellar.anchor.auth.Sep45Jwt;
+import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.config.SecretConfig;
 import org.stellar.anchor.config.Sep45Config;
 import org.stellar.anchor.config.StellarNetworkConfig;
@@ -46,6 +47,7 @@ public class Sep45Service {
   private final StellarRpc stellarRpc;
   private final NonceManager nonceManager;
   private final JwtService jwtService;
+  private final ClientFinder clientFinder;
 
   public ChallengeResponse getChallenge(ChallengeRequest request) throws AnchorException {
     if (request == null || isEmpty(request.getAccount())) {
@@ -271,6 +273,7 @@ public class Sep45Service {
             hashHex,
             clientDomain,
             homeDomain);
+    jwt.setClientName(clientFinder.getClientName(clientDomain, account));
 
     return ValidationResponse.builder().token(jwtService.encode(jwt)).build();
   }

--- a/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep6/Sep6Service.java
@@ -27,7 +27,6 @@ import org.stellar.anchor.api.sep.sep6.InfoResponse.*;
 import org.stellar.anchor.api.shared.FeeDetails;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.WebAuthJwt;
-import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.config.LanguageConfig;
 import org.stellar.anchor.config.Sep6Config;
 import org.stellar.anchor.event.EventService;
@@ -40,7 +39,6 @@ public class Sep6Service {
   private final Sep6Config sep6Config;
   private final AssetService assetService;
   private final SepRequestValidator requestValidator;
-  private final ClientFinder clientFinder;
   private final Sep6TransactionStore txnStore;
   private final ExchangeAmountsCalculator exchangeAmountsCalculator;
   private final EventService.Session eventSession;
@@ -76,7 +74,6 @@ public class Sep6Service {
       Sep6Config sep6Config,
       AssetService assetService,
       SepRequestValidator requestValidator,
-      ClientFinder clientFinder,
       Sep6TransactionStore txnStore,
       ExchangeAmountsCalculator exchangeAmountsCalculator,
       EventService eventService,
@@ -85,7 +82,6 @@ public class Sep6Service {
     this.sep6Config = sep6Config;
     this.assetService = assetService;
     this.requestValidator = requestValidator;
-    this.clientFinder = clientFinder;
     this.txnStore = txnStore;
     this.exchangeAmountsCalculator = exchangeAmountsCalculator;
     this.eventSession =
@@ -148,7 +144,7 @@ public class Sep6Service {
             .webAuthAccountMemo(token.getAccountMemo())
             .toAccount(destinationAccount)
             .clientDomain(token.getClientDomain())
-            .clientName(clientFinder.getClientName(token))
+            .clientName(token.getClientName())
             .requestClientIpAddress(request.getRequestClientIpAddress());
 
     if (accountType(token.getAccount()) == Contract) {
@@ -268,7 +264,7 @@ public class Sep6Service {
             .webAuthAccountMemo(token.getAccountMemo())
             .toAccount(destinationAccount)
             .clientDomain(token.getClientDomain())
-            .clientName(clientFinder.getClientName(token))
+            .clientName(token.getClientName())
             .quoteId(request.getQuoteId())
             .requestClientIpAddress(request.getRequestClientIpAddress());
 
@@ -353,7 +349,7 @@ public class Sep6Service {
             .webAuthAccountMemo(token.getAccountMemo())
             .fromAccount(sourceAccount)
             .clientDomain(token.getClientDomain())
-            .clientName(clientFinder.getClientName(token))
+            .clientName(token.getClientName())
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType())
             .requestClientIpAddress(request.getRequestClientIpAddress());
@@ -452,7 +448,7 @@ public class Sep6Service {
             .webAuthAccountMemo(token.getAccountMemo())
             .fromAccount(sourceAccount)
             .clientDomain(token.getClientDomain())
-            .clientName(clientFinder.getClientName(token))
+            .clientName(token.getClientName())
             .refundMemo(request.getRefundMemo())
             .refundMemoType(request.getRefundMemoType())
             .quoteId(request.getQuoteId())

--- a/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/JwtServiceTest.kt
@@ -76,6 +76,54 @@ internal class JwtServiceTest {
     assertEquals(webAuthJwt.issuer, token.iss)
     assertEquals(webAuthJwt.issuedAt, token.iat)
     assertEquals(webAuthJwt.expiresAt, token.exp)
+    assertEquals(null, webAuthJwt.clientName)
+    assert(webAuthJwt.hasClientNameClaim())
+  }
+
+  @ValueSource(classes = [Sep10Jwt::class, Sep45Jwt::class])
+  @ParameterizedTest
+  fun `test encoding always carries the client_name claim so a decoded token can tell it apart from one issued before client attribution existed`(
+    clazz: Class<out WebAuthJwt>
+  ) {
+    val jwtService = JwtService(secretConfig)
+    val constructor =
+      clazz.getConstructor(
+        String::class.java,
+        String::class.java,
+        Long::class.java,
+        Long::class.java,
+        String::class.java,
+        String::class.java,
+        String::class.java,
+      )
+    val attributed =
+      constructor.newInstance(
+        TEST_ISS,
+        TEST_SUB,
+        TEST_IAT,
+        TEST_EXP,
+        TEST_JTI,
+        TEST_CLIENT_DOMAIN,
+        null
+      ) as WebAuthJwt
+    attributed.clientName = TEST_CLIENT_NAME
+    val decodedAttributed = jwtService.decode(jwtService.encode(attributed), clazz)
+    assertEquals(TEST_CLIENT_NAME, decodedAttributed.clientName)
+    assert(decodedAttributed.hasClientNameClaim())
+
+    val unattributed =
+      constructor.newInstance(
+        TEST_ISS,
+        TEST_SUB,
+        TEST_IAT,
+        TEST_EXP,
+        TEST_JTI,
+        TEST_CLIENT_DOMAIN,
+        null
+      ) as WebAuthJwt
+    val decodedUnattributed = jwtService.decode(jwtService.encode(unattributed), clazz)
+    assertEquals(null, decodedUnattributed.clientName)
+    assert(decodedUnattributed.hasClientNameClaim())
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/filter/WebAuthJwtFilterTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/filter/WebAuthJwtFilterTest.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.filter
 
+import io.jsonwebtoken.Jwts
 import io.mockk.*
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
@@ -7,6 +8,8 @@ import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import java.time.Instant
+import java.util.Date
 import org.apache.hc.core5.http.HttpStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -24,6 +27,8 @@ import org.stellar.anchor.config.StellarNetworkConfig
 import org.stellar.anchor.filter.WebAuthJwtFilter.APPLICATION_JSON_VALUE
 import org.stellar.anchor.filter.WebAuthJwtFilter.JWT_TOKEN
 import org.stellar.anchor.setupMock
+import org.stellar.anchor.util.JwtUtil
+import org.stellar.anchor.util.KeyUtil
 
 @Order(85)
 internal class WebAuthJwtFilterTest {
@@ -163,5 +168,37 @@ internal class WebAuthJwtFilterTest {
     verify { mockFilterChain.doFilter(request, response) }
     verify(exactly = 1) { request.setAttribute(JWT_TOKEN, any()) }
     assertEquals(jwtToken, jwtService.encode(slot.captured))
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["GET", "PUT", "POST", "DELETE"])
+  fun `make sure a token issued before client_name existed is rejected`(method: String) {
+    every { request.method } returns method
+
+    val account = createWebAuthJwt(PUBLIC_KEY, null, "stellar.org")
+    val legacyJwt =
+      JwtUtil.jwtsBuilder()
+        .id(account.jti)
+        .issuer(account.iss)
+        .subject(account.sub)
+        .issuedAt(Date.from(Instant.ofEpochSecond(account.iat)))
+        .expiration(Date.from(Instant.ofEpochSecond(account.exp)))
+        .audience()
+        .add(JwtService.AUD_SEP10)
+        .and()
+        .signWith(
+          KeyUtil.toSecretKeySpecOrNull("jwt_secret_sep_10_secret_key_jwt_secret"),
+          Jwts.SIG.HS256,
+        )
+        .compact()
+
+    every { request.getHeader("Authorization") } returns "Bearer $legacyJwt"
+    webAuthJwtFilter.doFilter(request, response, mockFilterChain)
+
+    verify(exactly = 1) {
+      response.setStatus(HttpStatus.SC_FORBIDDEN)
+      response.contentType = APPLICATION_JSON_VALUE
+    }
+    verify { mockFilterChain wasNot Called }
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -218,6 +218,44 @@ internal class Sep10ServiceTest {
   }
 
   @Test
+  fun `test validate challenge stamps client_name resolved by ClientFinder onto the jwt`() {
+    val vr = ValidationRequest()
+    vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)
+
+    val mockSigners =
+      listOf(TestSigner(clientKeyPair.accountId, "SIGNER_KEY_TYPE_ED25519", 1, "").toSigner())
+    val accountResponse =
+      mockk<LedgerClient.Account> {
+        every { accountId } returns clientKeyPair.accountId
+        every { sequenceNumber } returns 1
+        every { signers } returns mockSigners
+        every { thresholds.medium } returns 1
+      }
+
+    every { ledgerClient.getAccount(any()) } returns accountResponse
+    every { clientFinder.getClientName(null, clientKeyPair.accountId) } returns "vibrant"
+
+    val response = sep10Service.validateChallenge(vr)
+    val jwt = jwtService.decode(response.token, Sep10Jwt::class.java)
+    assertEquals("vibrant", jwt.clientName)
+  }
+
+  @Test
+  fun `test validate challenge propagates ClientFinder authorization failure instead of falling back to null`() {
+    val vr = ValidationRequest()
+    vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)
+
+    every { ledgerClient.getAccount(ofType(String::class)) } answers
+      {
+        throw AccountNotFoundException(clientKeyPair.accountId)
+      }
+    every { clientFinder.getClientName(any(), any()) } throws
+      SepNotAuthorizedException("Client not found")
+
+    assertThrows<SepNotAuthorizedException> { sep10Service.validateChallenge(vr) }
+  }
+
+  @Test
   @LockAndMockStatic([Sep10Challenge::class])
   fun `test validate challenge with client domain`() {
     val mockSigners =

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -34,7 +34,6 @@ import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.WebAuthJwt
-import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.event.EventService
 import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore
 import org.stellar.anchor.util.StringHelper.json
@@ -103,7 +102,6 @@ class Sep12ServiceTest {
   @MockK(relaxed = true) private lateinit var platformApiClient: PlatformApiClient
   @MockK(relaxed = true) private lateinit var eventService: EventService
   @MockK(relaxed = true) private lateinit var eventSession: EventService.Session
-  @MockK(relaxed = true) private lateinit var clientFinder: ClientFinder
   @MockK(relaxed = true) private lateinit var customerIdOwnerStore: Sep31CustomerIdOwnerStore
 
   @BeforeEach
@@ -122,7 +120,6 @@ class Sep12ServiceTest {
         customerIntegration,
         platformApiClient,
         eventService,
-        clientFinder,
         customerIdOwnerStore,
       )
   }
@@ -441,7 +438,6 @@ class Sep12ServiceTest {
   fun `test put customer creating a new sep31-receiver claims ownership of the new id`() {
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("new-receiver-id").status(Sep12Status.ACCEPTED.name).build()
-    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns null
 
     val request =
       Sep12PutCustomerRequest.builder()
@@ -465,7 +461,6 @@ class Sep12ServiceTest {
         .id("new-muxed-receiver-id")
         .status(Sep12Status.ACCEPTED.name)
         .build()
-    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns null
 
     val request =
       Sep12PutCustomerRequest.builder()
@@ -533,10 +528,9 @@ class Sep12ServiceTest {
   fun `test put customer claims ownership by client name when one resolves`() {
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("new-sender-id").status(Sep12Status.ACCEPTED.name).build()
-    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns "vibrant"
 
     val request = Sep12PutCustomerRequest.builder().type("sep31-sender").firstName("John").build()
-    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val jwtToken = createJwtToken(TEST_ACCOUNT, "vibrant")
 
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
@@ -547,7 +541,6 @@ class Sep12ServiceTest {
   fun `test put customer keeps memo distinct per sub-user even when a client name resolves`() {
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("new-receiver-id").status(Sep12Status.ACCEPTED.name).build()
-    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns "vibrant"
 
     val request =
       Sep12PutCustomerRequest.builder()
@@ -555,7 +548,7 @@ class Sep12ServiceTest {
         .memo(TEST_MEMO)
         .firstName("Jane")
         .build()
-    val jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+    val jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO", "vibrant")
 
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
@@ -571,7 +564,6 @@ class Sep12ServiceTest {
         .id("new-muxed-receiver-id")
         .status(Sep12Status.ACCEPTED.name)
         .build()
-    every { clientFinder.getClientName(any<WebAuthJwt>()) } returns "vibrant"
 
     val request =
       Sep12PutCustomerRequest.builder()
@@ -580,7 +572,7 @@ class Sep12ServiceTest {
         .memoType("id")
         .firstName("Jane")
         .build()
-    val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
+    val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT, "vibrant")
 
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
@@ -590,13 +582,11 @@ class Sep12ServiceTest {
   }
 
   @Test
-  fun `Test put customer publishes event with null clientName and logs warning when client is not authorized`() {
+  fun `Test put customer publishes event with null clientName when the token was never authorized as a client`() {
     val kycUpdateEventSlot = slot<AnchorEvent>()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("customer-id").build()
     every { eventSession.publish(capture(kycUpdateEventSlot)) } returns Unit
-    every { clientFinder.getClientName(any<WebAuthJwt>()) } throws
-      SepNotAuthorizedException("Client not found")
 
     val jwtToken = createJwtToken(TEST_ACCOUNT)
     assertDoesNotThrow {
@@ -1091,7 +1081,10 @@ class Sep12ServiceTest {
     assertEquals(wantDeleteCustomerId, deleteCustomerIdSlot.captured)
   }
 
-  private fun createJwtToken(subject: String): WebAuthJwt {
-    return Sep10Jwt.of("$TEST_HOST_URL/auth", subject, issuedAt, expiresAt, "", CLIENT_DOMAIN, null)
+  private fun createJwtToken(subject: String, clientName: String? = null): WebAuthJwt {
+    val token =
+      Sep10Jwt.of("$TEST_HOST_URL/auth", subject, issuedAt, expiresAt, "", CLIENT_DOMAIN, null)
+    token.setClientName(clientName)
+    return token
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -142,7 +142,6 @@ internal class Sep24ServiceTest {
   @MockK(relaxed = true) lateinit var secretConfig: SecretConfig
   @MockK(relaxed = true) lateinit var sep24Config: Sep24Config
   @MockK(relaxed = true) lateinit var eventService: EventService
-  @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
   @MockK(relaxed = true) lateinit var txnStore: Sep24TransactionStore
   @MockK(relaxed = true) lateinit var interactiveUrlConstructor: InteractiveUrlConstructor
   @MockK(relaxed = true) lateinit var moreInfoUrlConstructor: MoreInfoUrlConstructor
@@ -191,7 +190,6 @@ internal class Sep24ServiceTest {
         .signingKeys(setOf("GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"))
         .allowAnyDestination(false)
         .build()
-    every { clientFinder.getClientName(any()) } returns TEST_CLIENT_NAME
     calculator = ExchangeAmountsCalculator(sep38QuoteStore, Clock.systemUTC())
 
     sep24Service =
@@ -199,11 +197,9 @@ internal class Sep24ServiceTest {
         languageConfig,
         stellarNetworkConfig,
         sep24Config,
-        clientService,
         assetService,
         requestValidator,
         jwtService,
-        clientFinder,
         txnStore,
         eventService,
         interactiveUrlConstructor,
@@ -1103,15 +1099,17 @@ internal class Sep24ServiceTest {
 
   private fun createTestWebAuthJwt(): WebAuthJwt {
     return TestHelper.createWebAuthJwt(TEST_ACCOUNT, null, TEST_HOME_DOMAIN, TEST_CLIENT_DOMAIN)
+      .apply { clientName = TEST_CLIENT_NAME }
   }
 
   private fun createTestWebAuthJwtWithMemo(): WebAuthJwt {
     return TestHelper.createWebAuthJwt(
-      TEST_ACCOUNT,
-      TEST_MEMO,
-      TEST_HOME_DOMAIN,
-      TEST_CLIENT_DOMAIN,
-    )
+        TEST_ACCOUNT,
+        TEST_MEMO,
+        TEST_HOME_DOMAIN,
+        TEST_CLIENT_DOMAIN,
+      )
+      .apply { clientName = TEST_CLIENT_NAME }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -9,15 +9,11 @@ import java.time.Clock
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import org.skyscreamer.jsonassert.JSONAssert
 import org.stellar.anchor.TestHelper
 import org.stellar.anchor.api.asset.AssetInfo
@@ -39,10 +35,6 @@ import org.stellar.anchor.api.shared.StellarId
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
 import org.stellar.anchor.auth.JwtService
-import org.stellar.anchor.client.ClientConfig.CallbackUrls
-import org.stellar.anchor.client.ClientFinder
-import org.stellar.anchor.client.ClientService
-import org.stellar.anchor.client.CustodialClient
 import org.stellar.anchor.config.*
 import org.stellar.anchor.config.Sep31Config.PaymentType.STRICT_RECEIVE
 import org.stellar.anchor.config.Sep31Config.PaymentType.STRICT_SEND
@@ -218,27 +210,6 @@ class Sep31ServiceTest {
         }
       }
   """
-
-    private val custodialClient =
-      CustodialClient.builder()
-        .name("custodialClient")
-        .signingKeys(setOf("GBI2IWJGR4UQPBIKPP6WG76X5PHSD2QTEBGIP6AZ3ZXWV46ZUSGNEG"))
-        .callbackUrls(
-          CallbackUrls.builder().sep31("http://wallet-server:8092/callbacks/sep31").build()
-        )
-        .allowAnyDestination(false)
-        .destinationAccounts(emptySet())
-        .build()
-
-    @JvmStatic
-    fun generateGetClientNameTestConfig(): Stream<Arguments> {
-      return Stream.of(
-        Arguments.of(listOf<String>(), false, null, false),
-        Arguments.of(listOf<String>(), true, null, true),
-        Arguments.of(listOf(custodialClient.name), false, custodialClient.name, false),
-        Arguments.of(listOf(custodialClient.name), true, custodialClient.name, true),
-      )
-    }
   }
 
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
@@ -247,8 +218,6 @@ class Sep31ServiceTest {
 
   @MockK(relaxed = true) lateinit var languageConfig: LanguageConfig
   @MockK(relaxed = true) lateinit var secretConfig: SecretConfig
-  @MockK(relaxed = true) lateinit var clientService: ClientService
-  @MockK(relaxed = true) lateinit var sep10Config: Sep10Config
   @MockK(relaxed = true) lateinit var sep31Config: Sep31Config
   @MockK(relaxed = true) lateinit var sep31DepositInfoGenerator: Sep31DepositInfoGenerator
   @MockK(relaxed = true) lateinit var quoteStore: Sep38QuoteStore
@@ -256,7 +225,6 @@ class Sep31ServiceTest {
   @MockK(relaxed = true) lateinit var rateIntegration: RateIntegration
   @MockK(relaxed = true) lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) lateinit var customerIdOwnerStore: Sep31CustomerIdOwnerStore
-  @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
   @MockK(relaxed = true) lateinit var eventService: EventService
   @MockK(relaxed = true) lateinit var eventSession: Session
 
@@ -278,25 +246,21 @@ class Sep31ServiceTest {
     every { txnStore.newTransaction() } returns PojoSep31Transaction()
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
-    every { clientFinder.getClientName(any()) } returns null
 
     jwtService = spyk(JwtService(secretConfig))
 
     sep31Service =
       Sep31Service(
         languageConfig,
-        sep10Config,
         sep31Config,
         txnStore,
         quoteStore,
-        clientService,
         assetService,
         rateIntegration,
         eventService,
         Clock.systemUTC(),
         exchangeAmountsCalculator,
         customerIdOwnerStore,
-        clientFinder,
       )
 
     request = gson.fromJson(requestJson, Sep31PostTransactionRequest::class.java)
@@ -698,11 +662,6 @@ class Sep31ServiceTest {
         SepDepositInfo(tx.toAccount, memo)
       }
 
-    // mock client config
-    every { sep10Config.allowedClientNames } returns listOf("vibrant")
-    every { clientService.getClientConfigBySigningKey(any()) } returns
-      CustodialClient().apply { name = "vibrant" }
-
     // mock transaction save
     val slotTxn = slot<Sep31Transaction>()
     every { txnStore.save(capture(slotTxn)) } answers
@@ -710,8 +669,8 @@ class Sep31ServiceTest {
         firstArg<Sep31Transaction>().id = "ABC-123"
         firstArg()
       }
-    // POST transaction
     val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
+    jwtToken.clientName = "vibrant"
     var gotResponse: Sep31PostTransactionResponse? = null
     assertDoesNotThrow { gotResponse = sep31Service.postTransaction(jwtToken, postTxRequest) }
 
@@ -767,18 +726,15 @@ class Sep31ServiceTest {
     sep31Service =
       Sep31Service(
         languageConfig,
-        sep10Config,
         sep31Config,
         txnStore,
         quoteStore,
-        clientService,
         assetServiceQuotesNotSupported,
         rateIntegration,
         eventService,
         Clock.systemUTC(),
         exchangeAmountsCalculator,
         customerIdOwnerStore,
-        clientFinder,
       )
     every { rateIntegration.getRate(any()) } returns
       GetRateResponse(GetRateResponse.Rate.builder().fee(FeeDetails("2", "stellar:USDC")).build())
@@ -873,12 +829,12 @@ class Sep31ServiceTest {
       }
 
     val jwtToken1 = TestHelper.createWebAuthJwt(account = TestHelper.TEST_ACCOUNT)
-    every { clientFinder.getClientName(jwtToken1) } returns "vibrant"
+    jwtToken1.clientName = "vibrant"
     sep31Service.postTransaction(jwtToken1, ownershipTestRequest(receiverId = "shared-receiver-id"))
 
     val secondSigningKey = "GAXLBAY4YSF6RRZTMV2CKS4NDVCMAYVKQGV3GNPUR2WWQVEFF6UYS4XZ"
     val jwtToken2 = TestHelper.createWebAuthJwt(account = secondSigningKey)
-    every { clientFinder.getClientName(jwtToken2) } returns "vibrant"
+    jwtToken2.clientName = "vibrant"
     assertDoesNotThrow {
       sep31Service.postTransaction(
         jwtToken2,
@@ -905,7 +861,7 @@ class Sep31ServiceTest {
         account = TestHelper.TEST_ACCOUNT,
         accountMemo = TestHelper.TEST_MEMO,
       )
-    every { clientFinder.getClientName(subUserA) } returns "vibrant"
+    subUserA.clientName = "vibrant"
     sep31Service.postTransaction(subUserA, ownershipTestRequest(receiverId = "sub-user-a-id"))
 
     verify(exactly = 1) {
@@ -913,7 +869,7 @@ class Sep31ServiceTest {
     }
 
     val subUserB = TestHelper.createMuxedWebAuthJwt(muxedId = 99L)
-    every { clientFinder.getClientName(subUserB) } returns "vibrant"
+    subUserB.clientName = "vibrant"
     sep31Service.postTransaction(subUserB, ownershipTestRequest(receiverId = "sub-user-b-id"))
 
     verify(exactly = 1) { customerIdOwnerStore.verifyOrClaim("sub-user-b-id", "vibrant", "99") }
@@ -1008,9 +964,6 @@ class Sep31ServiceTest {
     val mockCustomer = GetCustomerResponse()
     mockCustomer.status = Sep12Status.ACCEPTED.name
     every { customerIntegration.getCustomer(any()) } returns mockCustomer
-    every { sep10Config.allowedClientNames } returns listOf("vibrant")
-    every { clientService.getClientConfigBySigningKey(any()) } returns
-      CustodialClient().apply { name = "vibrant" }
     every { txnStore.save(any()) } answers
       {
         firstArg<Sep31Transaction>().also { it.id = "TXN-RACE" }
@@ -1074,18 +1027,15 @@ class Sep31ServiceTest {
     sep31Service =
       Sep31Service(
         languageConfig,
-        sep10Config,
         sep31Config,
         txnStore,
         quoteStore,
-        clientService,
         assetServiceQuotesNotSupported,
         rateIntegration,
         eventService,
         Clock.systemUTC(),
         exchangeAmountsCalculator,
         customerIdOwnerStore,
-        clientFinder,
       )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"
@@ -1221,30 +1171,20 @@ class Sep31ServiceTest {
     assertEquals("Quote is missing the 'fee' field", ex.message)
   }
 
-  @ParameterizedTest
-  @MethodSource("generateGetClientNameTestConfig")
-  fun `test getClientName when`(
-    allowedClientNames: List<String>,
-    isClientAttributionRequired: Boolean,
-    expectedClientName: String?,
-    shouldThrowExceptionWithInvalidInput: Boolean,
-  ) {
-    every { sep10Config.allowedClientNames } returns allowedClientNames
-    every { sep10Config.isClientAttributionRequired } returns isClientAttributionRequired
-    every { clientService.getClientConfigBySigningKey(custodialClient.signingKeys.first()) } returns
-      custodialClient
+  @Test
+  fun `test getClientName reads directly from the token, resolved once at SEP-10 time`() {
+    val jwtToken = TestHelper.createWebAuthJwt()
+    jwtToken.clientName = "vibrant"
+    Context.get().webAuthJwt = jwtToken
 
-    // client name should be returned for valid input
-    val clientName = sep31Service.getClientName(custodialClient.signingKeys.first())
-    assertEquals(expectedClientName, clientName)
+    assertEquals("vibrant", sep31Service.getClientName())
+  }
 
-    // exception maybe thrown for invalid input
-    every { clientService.getClientConfigBySigningKey("Invalid Public Key") } returns null
-    if (!shouldThrowExceptionWithInvalidInput) {
-      val clientNameNotFound = sep31Service.getClientName("Invalid Public Key")
-      assertNull(clientNameNotFound)
-    } else {
-      assertThrows<BadRequestException> { sep31Service.getClientName("Invalid Public Key") }
-    }
+  @Test
+  fun `test getClientName is null when SEP-10 never resolved a client for this token`() {
+    val jwtToken = TestHelper.createWebAuthJwt()
+    Context.get().webAuthJwt = jwtToken
+
+    assertNull(sep31Service.getClientName())
   }
 }

--- a/core/src/test/kotlin/org/stellar/anchor/sep45/Sep45ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep45/Sep45ServiceTest.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.InternalServerErrorException
+import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.sep.sep45.ChallengeRequest
 import org.stellar.anchor.api.sep.sep45.ValidationRequest
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.Nonce
 import org.stellar.anchor.auth.NonceManager
 import org.stellar.anchor.auth.Sep45Jwt
+import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.config.Sep45Config
 import org.stellar.anchor.config.StellarNetworkConfig
@@ -33,6 +35,7 @@ class Sep45ServiceTest {
   private lateinit var stellarRpc: StellarRpc
   private lateinit var nonceManager: NonceManager
   private lateinit var jwtService: JwtService
+  private lateinit var clientFinder: ClientFinder
   private lateinit var sep45Service: Sep45Service
 
   private val TEST_CONTRACT_ID = "CAYXY6QGTPOCZ676MLGT5JFESVROJ6OJF7VW3LLXMTC2RQIZTP5JYNEL"
@@ -45,6 +48,7 @@ class Sep45ServiceTest {
     stellarRpc = mockk()
     nonceManager = mockk()
     jwtService = mockk()
+    clientFinder = mockk(relaxed = true)
     sep45Service =
       Sep45Service(
         stellarNetworkConfig,
@@ -53,6 +57,7 @@ class Sep45ServiceTest {
         stellarRpc,
         nonceManager,
         jwtService,
+        clientFinder,
       )
     val signingKp =
       KeyPair.fromSecretSeed("SAX3AH622R2XT6DXWWSRIDCMMUCCMATBZ5U6XKJWDO7M2EJUBFC3AW5X")
@@ -181,6 +186,39 @@ class Sep45ServiceTest {
 
     assertNotNull(response)
     assertEquals(jwtToken, response.token)
+  }
+
+  @Test
+  fun `test validate stamps client_name resolved by ClientFinder onto the jwt before encoding`() {
+    val authEntriesXdr =
+      "AAAAAgAAAAEAAAABMXx6BpvcLPv+Ys0+pKSVYuT5yS/rba13ZMWowRmb+pxF2uWzaxsY/AAIcHUAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAg0rDjCmCu2tWgC4nvNxeBkA6AXR61vOlF9kmFcoEQPlUAAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAo074x7qA8Iqyn/P1Ewffdh7zMeBtIHvcMhTaUyIBzPEyTx67xLr9pO2AToTSh/VHFki+g3lfEz8eZsh0w0b0BQAAAAAAAAAB9rB6Ki9HordR0vv2WusMZEtYjSf5gJC5lIzUxSZAimgAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQVlYWTZRR1RQT0NaNjc2TUxHVDVKRkVTVlJPSjZPSkY3VlczTExYTVRDMlJRSVpUUDVKWU5FTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAABVodHRwOi8vbG9jYWxob3N0OjgwODAAAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAACRkOTQ2YTFiOS01MzExLTQxMDgtYmQ1MC1hM2YxZjQ4YWY4ZDYAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0rVNLbc72XYAAIcHUAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAw4WS+M2bdw9HoLBOiFT9DjqU02Z8gm13Mk0/sBS2AIdC7AbxmoWtS/o1A6feb/hNixTaSBArU0SZKx/l3p5TBAAAAAAAAAAB9rB6Ki9HordR0vv2WusMZEtYjSf5gJC5lIzUxSZAimgAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQVlYWTZRR1RQT0NaNjc2TUxHVDVKRkVTVlJPSjZPSkY3VlczTExYTVRDMlJRSVpUUDVKWU5FTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAABVodHRwOi8vbG9jYWxob3N0OjgwODAAAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAACRkOTQ2YTFiOS01MzExLTQxMDgtYmQ1MC1hM2YxZjQ4YWY4ZDYAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA"
+    val validationRequest = ValidationRequest.builder().authorizationEntries(authEntriesXdr).build()
+    val jwtToken = "header.payload.signature"
+    val jwtSlot = slot<Sep45Jwt>()
+
+    every { jwtService.encode(capture(jwtSlot)) } returns jwtToken
+    every { clientFinder.getClientName(any(), any()) } returns "vibrant"
+
+    val response = sep45Service.validate(validationRequest)
+
+    assertEquals(jwtToken, response.token)
+    assertEquals("vibrant", jwtSlot.captured.clientName)
+    verify(exactly = 1) {
+      clientFinder.getClientName(null, "CAYXY6QGTPOCZ676MLGT5JFESVROJ6OJF7VW3LLXMTC2RQIZTP5JYNEL")
+    }
+  }
+
+  @Test
+  fun `test validate propagates ClientFinder authorization failure instead of issuing a jwt`() {
+    val authEntriesXdr =
+      "AAAAAgAAAAEAAAABMXx6BpvcLPv+Ys0+pKSVYuT5yS/rba13ZMWowRmb+pxF2uWzaxsY/AAIcHUAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAg0rDjCmCu2tWgC4nvNxeBkA6AXR61vOlF9kmFcoEQPlUAAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAo074x7qA8Iqyn/P1Ewffdh7zMeBtIHvcMhTaUyIBzPEyTx67xLr9pO2AToTSh/VHFki+g3lfEz8eZsh0w0b0BQAAAAAAAAAB9rB6Ki9HordR0vv2WusMZEtYjSf5gJC5lIzUxSZAimgAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQVlYWTZRR1RQT0NaNjc2TUxHVDVKRkVTVlJPSjZPSkY3VlczTExYTVRDMlJRSVpUUDVKWU5FTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAABVodHRwOi8vbG9jYWxob3N0OjgwODAAAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAACRkOTQ2YTFiOS01MzExLTQxMDgtYmQ1MC1hM2YxZjQ4YWY4ZDYAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0rVNLbc72XYAAIcHUAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAw4WS+M2bdw9HoLBOiFT9DjqU02Z8gm13Mk0/sBS2AIdC7AbxmoWtS/o1A6feb/hNixTaSBArU0SZKx/l3p5TBAAAAAAAAAAB9rB6Ki9HordR0vv2WusMZEtYjSf5gJC5lIzUxSZAimgAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQVlYWTZRR1RQT0NaNjc2TUxHVDVKRkVTVlJPSjZPSkY3VlczTExYTVRDMlJRSVpUUDVKWU5FTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAABVodHRwOi8vbG9jYWxob3N0OjgwODAAAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAACRkOTQ2YTFiOS01MzExLTQxMDgtYmQ1MC1hM2YxZjQ4YWY4ZDYAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA"
+    val validationRequest = ValidationRequest.builder().authorizationEntries(authEntriesXdr).build()
+
+    every { clientFinder.getClientName(any(), any()) } throws
+      SepNotAuthorizedException("Client not found")
+
+    assertThrows(SepNotAuthorizedException::class.java) { sep45Service.validate(validationRequest) }
+    verify(exactly = 0) { jwtService.encode(any<Sep45Jwt>()) }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep6/Sep6ServiceTest.kt
@@ -34,7 +34,6 @@ import org.stellar.anchor.api.shared.RefundPayment
 import org.stellar.anchor.api.shared.Refunds
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.asset.DefaultAssetService
-import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.client.ClientService
 import org.stellar.anchor.client.CustodialClient
 import org.stellar.anchor.config.LanguageConfig
@@ -59,7 +58,6 @@ class Sep6ServiceTest {
   @MockK(relaxed = true) lateinit var sep6Config: Sep6Config
   @MockK(relaxed = true) lateinit var requestValidator: SepRequestValidator
   @MockK(relaxed = true) lateinit var clientService: ClientService
-  @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
   @MockK(relaxed = true) lateinit var txnStore: Sep6TransactionStore
   @MockK(relaxed = true) lateinit var exchangeAmountsCalculator: ExchangeAmountsCalculator
   @MockK(relaxed = true) lateinit var eventService: EventService
@@ -74,7 +72,7 @@ class Sep6ServiceTest {
     MockKAnnotations.init(this, relaxUnitFun = true)
     every { sep6Config.features.isAccountCreation } returns false
     every { sep6Config.features.isClaimableBalances } returns false
-    every { clientFinder.getClientName(token) } returns "vibrant"
+    token.clientName = "vibrant"
     every { txnStore.newInstance() } returns PojoSep6Transaction()
     every { eventService.createSession(any(), any()) } returns eventSession
     every { requestValidator.getDepositAsset(TEST_ASSET) } returns asset
@@ -87,7 +85,6 @@ class Sep6ServiceTest {
         sep6Config,
         assetService,
         requestValidator,
-        clientFinder,
         txnStore,
         exchangeAmountsCalculator,
         eventService,
@@ -102,7 +99,6 @@ class Sep6ServiceTest {
         sep6Config,
         assetService,
         realValidator,
-        clientFinder,
         txnStore,
         exchangeAmountsCalculator,
         eventService,

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/ClientConfigApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/ClientConfigApiTests.kt
@@ -3,6 +3,7 @@ package org.stellar.anchor.platform.integrationtest
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.platform.IntegrationTestBase
@@ -28,8 +29,17 @@ class ClientConfigApiTests : IntegrationTestBase(TestConfig()) {
   private fun custodialRequestJson(signingKey: String) =
     gson.toJson(mapOf("type" to "custodial", "signingKeys" to listOf(signingKey)))
 
+  private fun noncustodialRequestJson(domain: String) =
+    gson.toJson(mapOf("type" to "noncustodial", "domains" to listOf(domain)))
+
   private fun delete(name: String) =
     httpClient.newCall(Request.Builder().url("$clientsUrl/$name").delete().build()).execute()
+
+  private fun post(url: String) =
+    httpClient.newCall(Request.Builder().url(url).post("".toRequestBody(null)).build()).execute()
+
+  private fun deleteSubResource(url: String) =
+    httpClient.newCall(Request.Builder().url(url).delete().build()).execute()
 
   @Test
   fun `test create, fetch, list, and delete a client via the REST API`() {
@@ -122,6 +132,374 @@ class ClientConfigApiTests : IntegrationTestBase(TestConfig()) {
     } finally {
       delete(firstName)
       delete(secondName)
+    }
+  }
+
+  @Test
+  fun `test creating a noncustodial client with no domain is rejected`() {
+    val name = uniqueClientName()
+    val requestJson = gson.toJson(mapOf("type" to "noncustodial", "domains" to emptyList<String>()))
+
+    val response =
+      httpClient.newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", requestJson)).execute()
+
+    assertEquals(400, response.code)
+  }
+
+  @Test
+  fun `test creating a client with a malformed callback URL is rejected`() {
+    val name = uniqueClientName()
+    val signingKey = KeyPair.random().accountId
+    val requestJson =
+      gson.toJson(
+        mapOf(
+          "type" to "custodial",
+          "signingKeys" to listOf(signingKey),
+          "callbackUrls" to mapOf("sep24" to "not-a-valid-url"),
+        )
+      )
+
+    val response =
+      httpClient.newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", requestJson)).execute()
+
+    assertEquals(400, response.code)
+  }
+
+  @Test
+  fun `test creating a client with an unknown type is rejected`() {
+    val name = uniqueClientName()
+    val requestJson = gson.toJson(mapOf("type" to "not-a-real-type"))
+
+    val response =
+      httpClient.newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", requestJson)).execute()
+
+    assertEquals(400, response.code)
+  }
+
+  @Test
+  fun `test creating a client with a domain already used by another client is rejected`() {
+    val domain = "itest-${KeyPair.random().accountId.takeLast(10)}.example.com"
+    val firstName = uniqueClientName()
+    val secondName = uniqueClientName()
+
+    try {
+      val firstPut =
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$firstName",
+              noncustodialRequestJson(domain)
+            )
+          )
+          .execute()
+      assertEquals(200, firstPut.code)
+
+      val secondPut =
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$secondName",
+              noncustodialRequestJson(domain)
+            )
+          )
+          .execute()
+      assertEquals(400, secondPut.code)
+    } finally {
+      delete(firstName)
+      delete(secondName)
+    }
+  }
+
+  @Test
+  fun `test adding a signing key does not disturb existing ones`() {
+    val name = uniqueClientName()
+    val firstKey = KeyPair.random().accountId
+    val secondKey = KeyPair.random().accountId
+
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", custodialRequestJson(firstKey))
+          )
+          .execute()
+          .code
+      )
+
+      val addResponse = post("$clientsUrl/$name/signing-keys/$secondKey")
+      assertEquals(200, addResponse.code)
+      val updated = gson.fromJson(addResponse.body!!.string(), HashMap::class.java)
+      assertEquals(setOf(firstKey, secondKey), (updated["signingKeys"] as List<*>).toSet())
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test adding a signing key to an unknown client returns 404`() {
+    assertEquals(
+      404,
+      post("$clientsUrl/${uniqueClientName()}/signing-keys/${KeyPair.random().accountId}").code
+    )
+  }
+
+  @Test
+  fun `test adding a signing key already used by another client is rejected`() {
+    val signingKey = KeyPair.random().accountId
+    val firstName = uniqueClientName()
+    val secondName = uniqueClientName()
+
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$firstName",
+              custodialRequestJson(signingKey)
+            )
+          )
+          .execute()
+          .code
+      )
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$secondName",
+              custodialRequestJson(KeyPair.random().accountId)
+            )
+          )
+          .execute()
+          .code
+      )
+
+      val addResponse = post("$clientsUrl/$secondName/signing-keys/$signingKey")
+      assertEquals(400, addResponse.code)
+    } finally {
+      delete(firstName)
+      delete(secondName)
+    }
+  }
+
+  @Test
+  fun `test removing a signing key removes only the requested one`() {
+    val name = uniqueClientName()
+    val firstKey = KeyPair.random().accountId
+    val secondKey = KeyPair.random().accountId
+
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", custodialRequestJson(firstKey))
+          )
+          .execute()
+          .code
+      )
+      assertEquals(200, post("$clientsUrl/$name/signing-keys/$secondKey").code)
+
+      val removeResponse = deleteSubResource("$clientsUrl/$name/signing-keys/$secondKey")
+      assertEquals(204, removeResponse.code)
+
+      val fetched =
+        gson.fromJson(
+          httpClient
+            .newCall(OkHttpUtil.buildGetRequest("$clientsUrl/$name"))
+            .execute()
+            .body!!
+            .string(),
+          HashMap::class.java
+        )
+      assertEquals(listOf(firstKey), fetched["signingKeys"])
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test removing an unknown signing key returns 404`() {
+    val name = uniqueClientName()
+    val signingKey = KeyPair.random().accountId
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", custodialRequestJson(signingKey))
+          )
+          .execute()
+          .code
+      )
+      assertEquals(
+        404,
+        deleteSubResource("$clientsUrl/$name/signing-keys/${KeyPair.random().accountId}").code
+      )
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test removing the last signing key of a custodial client is rejected`() {
+    val name = uniqueClientName()
+    val signingKey = KeyPair.random().accountId
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", custodialRequestJson(signingKey))
+          )
+          .execute()
+          .code
+      )
+
+      val removeResponse = deleteSubResource("$clientsUrl/$name/signing-keys/$signingKey")
+      assertEquals(400, removeResponse.code)
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test adding and removing a destination account does not disturb existing ones`() {
+    val name = uniqueClientName()
+    val signingKey = KeyPair.random().accountId
+    val firstAccount = KeyPair.random().accountId
+    val secondAccount = KeyPair.random().accountId
+
+    try {
+      val createJson =
+        gson.toJson(
+          mapOf(
+            "type" to "custodial",
+            "signingKeys" to listOf(signingKey),
+            "destinationAccounts" to listOf(firstAccount),
+          )
+        )
+      assertEquals(
+        200,
+        httpClient
+          .newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", createJson))
+          .execute()
+          .code
+      )
+
+      val addResponse = post("$clientsUrl/$name/destination-accounts/$secondAccount")
+      assertEquals(200, addResponse.code)
+      val afterAdd = gson.fromJson(addResponse.body!!.string(), HashMap::class.java)
+      assertEquals(
+        setOf(firstAccount, secondAccount),
+        (afterAdd["destinationAccounts"] as List<*>).toSet()
+      )
+
+      val removeResponse =
+        deleteSubResource("$clientsUrl/$name/destination-accounts/$secondAccount")
+      assertEquals(204, removeResponse.code)
+
+      val fetched =
+        gson.fromJson(
+          httpClient
+            .newCall(OkHttpUtil.buildGetRequest("$clientsUrl/$name"))
+            .execute()
+            .body!!
+            .string(),
+          HashMap::class.java
+        )
+      assertEquals(listOf(firstAccount), fetched["destinationAccounts"])
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test adding a destination account to an unknown client returns 404`() {
+    assertEquals(
+      404,
+      post("$clientsUrl/${uniqueClientName()}/destination-accounts/${KeyPair.random().accountId}")
+        .code
+    )
+  }
+
+  @Test
+  fun `test removing an unknown destination account returns 404`() {
+    val name = uniqueClientName()
+    val signingKey = KeyPair.random().accountId
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", custodialRequestJson(signingKey))
+          )
+          .execute()
+          .code
+      )
+      assertEquals(
+        404,
+        deleteSubResource("$clientsUrl/$name/destination-accounts/${KeyPair.random().accountId}")
+          .code
+      )
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test listing custodial and noncustodial clients returns only their own type`() {
+    val custodialName = uniqueClientName()
+    val noncustodialName = uniqueClientName()
+    val domain = "itest-${KeyPair.random().accountId.takeLast(10)}.example.com"
+
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$custodialName",
+              custodialRequestJson(KeyPair.random().accountId)
+            )
+          )
+          .execute()
+          .code
+      )
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$noncustodialName",
+              noncustodialRequestJson(domain)
+            )
+          )
+          .execute()
+          .code
+      )
+
+      val custodialResponse =
+        httpClient.newCall(OkHttpUtil.buildGetRequest("$clientsUrl/custodial")).execute()
+      assertEquals(200, custodialResponse.code)
+      val custodialClients = gson.fromJson(custodialResponse.body!!.string(), List::class.java)
+      assertTrue(custodialClients.any { (it as Map<*, *>)["name"] == custodialName })
+      assertFalse(custodialClients.any { (it as Map<*, *>)["name"] == noncustodialName })
+      assertTrue(custodialClients.all { (it as Map<*, *>)["type"] == "custodial" })
+
+      val noncustodialResponse =
+        httpClient.newCall(OkHttpUtil.buildGetRequest("$clientsUrl/non-custodial")).execute()
+      assertEquals(200, noncustodialResponse.code)
+      val noncustodialClients =
+        gson.fromJson(noncustodialResponse.body!!.string(), List::class.java)
+      assertTrue(noncustodialClients.any { (it as Map<*, *>)["name"] == noncustodialName })
+      assertFalse(noncustodialClients.any { (it as Map<*, *>)["name"] == custodialName })
+      assertTrue(noncustodialClients.all { (it as Map<*, *>)["type"] == "noncustodial" })
+    } finally {
+      delete(custodialName)
+      delete(noncustodialName)
     }
   }
 }

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/ClientConfigApiTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/ClientConfigApiTests.kt
@@ -1,0 +1,127 @@
+package org.stellar.anchor.platform.integrationtest
+
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.platform.IntegrationTestBase
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.util.GsonUtils
+import org.stellar.anchor.util.OkHttpUtil
+import org.stellar.sdk.KeyPair
+
+class ClientConfigApiTests : IntegrationTestBase(TestConfig()) {
+  private val gson = GsonUtils.getInstance()
+
+  private val httpClient: OkHttpClient =
+    OkHttpClient.Builder()
+      .connectTimeout(10, TimeUnit.MINUTES)
+      .readTimeout(10, TimeUnit.MINUTES)
+      .writeTimeout(10, TimeUnit.MINUTES)
+      .build()
+
+  private val clientsUrl = "${config.env["platform.server.url"]}/clients"
+
+  private fun uniqueClientName() = "itest-${KeyPair.random().accountId.takeLast(10)}"
+
+  private fun custodialRequestJson(signingKey: String) =
+    gson.toJson(mapOf("type" to "custodial", "signingKeys" to listOf(signingKey)))
+
+  private fun delete(name: String) =
+    httpClient.newCall(Request.Builder().url("$clientsUrl/$name").delete().build()).execute()
+
+  @Test
+  fun `test create, fetch, list, and delete a client via the REST API`() {
+    val name = uniqueClientName()
+    val signingKey = KeyPair.random().accountId
+
+    val putResponse =
+      httpClient
+        .newCall(
+          OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", custodialRequestJson(signingKey))
+        )
+        .execute()
+    assertEquals(200, putResponse.code)
+    val created = gson.fromJson(putResponse.body!!.string(), HashMap::class.java)
+    assertEquals(name, created["name"])
+    assertEquals("custodial", created["type"])
+    assertEquals(listOf(signingKey), created["signingKeys"])
+
+    val getResponse = httpClient.newCall(OkHttpUtil.buildGetRequest("$clientsUrl/$name")).execute()
+    assertEquals(200, getResponse.code)
+    val fetched = gson.fromJson(getResponse.body!!.string(), HashMap::class.java)
+    assertEquals(name, fetched["name"])
+    assertEquals(listOf(signingKey), fetched["signingKeys"])
+
+    val listResponse = httpClient.newCall(OkHttpUtil.buildGetRequest(clientsUrl)).execute()
+    assertEquals(200, listResponse.code)
+    val allClients = gson.fromJson(listResponse.body!!.string(), List::class.java)
+    assertTrue(allClients.any { (it as Map<*, *>)["name"] == name })
+
+    val deleteResponse = delete(name)
+    assertEquals(204, deleteResponse.code)
+
+    val getAfterDeleteResponse =
+      httpClient.newCall(OkHttpUtil.buildGetRequest("$clientsUrl/$name")).execute()
+    assertEquals(404, getAfterDeleteResponse.code)
+  }
+
+  @Test
+  fun `test fetching an unknown client returns 404`() {
+    val response =
+      httpClient.newCall(OkHttpUtil.buildGetRequest("$clientsUrl/${uniqueClientName()}")).execute()
+    assertEquals(404, response.code)
+  }
+
+  @Test
+  fun `test deleting an unknown client returns 404`() {
+    assertEquals(404, delete(uniqueClientName()).code)
+  }
+
+  @Test
+  fun `test creating a client with no signing keys is rejected`() {
+    val name = uniqueClientName()
+    val requestJson =
+      gson.toJson(mapOf("type" to "custodial", "signingKeys" to emptyList<String>()))
+
+    val response =
+      httpClient.newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", requestJson)).execute()
+
+    assertEquals(400, response.code)
+  }
+
+  @Test
+  fun `test creating a client with a signing key already used by another client is rejected`() {
+    val signingKey = KeyPair.random().accountId
+    val firstName = uniqueClientName()
+    val secondName = uniqueClientName()
+
+    try {
+      val firstPut =
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$firstName",
+              custodialRequestJson(signingKey)
+            )
+          )
+          .execute()
+      assertEquals(200, firstPut.code)
+
+      val secondPut =
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$secondName",
+              custodialRequestJson(signingKey)
+            )
+          )
+          .execute()
+      assertEquals(400, secondPut.code)
+    } finally {
+      delete(firstName)
+      delete(secondName)
+    }
+  }
+}

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/clients/db/ClientsDbAttributionTests.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/extendedtest/clients/db/ClientsDbAttributionTests.kt
@@ -1,0 +1,149 @@
+package org.stellar.anchor.platform.extendedtest.clients.db
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.Sep10Jwt
+import org.stellar.anchor.client.Sep10Client
+import org.stellar.anchor.platform.IntegrationTestBase
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.anchor.util.GsonUtils
+import org.stellar.anchor.util.OkHttpUtil
+import org.stellar.sdk.KeyPair
+
+class ClientsDbAttributionTests : IntegrationTestBase(TestConfig()) {
+  private val gson = GsonUtils.getInstance()
+  private val httpClient = OkHttpClient.Builder().build()
+  private val clientsUrl = "${config.env["platform.server.url"]}/clients"
+  private val webAuthDomain = toml.getString("WEB_AUTH_ENDPOINT").split("/")[2]
+  private val jwtService =
+    JwtService(null, config.env["secret.sep10.jwt_secret"], null, null, null, null, null)
+
+  private fun uniqueClientName() = "clientsdb-${KeyPair.random().accountId.takeLast(10)}"
+
+  private fun delete(name: String) =
+    httpClient.newCall(Request.Builder().url("$clientsUrl/$name").delete().build()).execute()
+
+  private fun authenticate(keypair: KeyPair): Sep10Jwt {
+    val jwt =
+      Sep10Client(
+          toml.getString("WEB_AUTH_ENDPOINT"),
+          toml.getString("SIGNING_KEY"),
+          keypair.accountId,
+          String(keypair.secretSeed),
+        )
+        .auth(webAuthDomain)
+    return jwtService.decode(jwt, Sep10Jwt::class.java)
+  }
+
+  @Test
+  fun `test SEP-10 attributes client_name to a client created via the DB-backed admin API`() {
+    val name = uniqueClientName()
+    val keypair = KeyPair.random()
+    val createJson =
+      gson.toJson(mapOf("type" to "custodial", "signingKeys" to listOf(keypair.accountId)))
+
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", createJson))
+          .execute()
+          .code,
+      )
+
+      assertEquals(name, authenticate(keypair).clientName)
+    } finally {
+      delete(name)
+    }
+  }
+
+  @Test
+  fun `test SEP-10 client_name is updated after a signing key is moved to another client`() {
+    val firstName = uniqueClientName()
+    val secondName = uniqueClientName()
+    val keypair = KeyPair.random()
+    val placeholderKey = KeyPair.random().accountId
+
+    try {
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$firstName",
+              gson.toJson(
+                mapOf(
+                  "type" to "custodial",
+                  "signingKeys" to listOf(keypair.accountId, placeholderKey),
+                )
+              ),
+            )
+          )
+          .execute()
+          .code,
+      )
+      assertEquals(firstName, authenticate(keypair).clientName)
+
+      assertEquals(
+        204,
+        httpClient
+          .newCall(
+            Request.Builder()
+              .url("$clientsUrl/$firstName/signing-keys/${keypair.accountId}")
+              .delete()
+              .build()
+          )
+          .execute()
+          .code,
+      )
+      assertEquals(
+        200,
+        httpClient
+          .newCall(
+            OkHttpUtil.buildJsonPutRequest(
+              "$clientsUrl/$secondName",
+              gson.toJson(mapOf("type" to "custodial", "signingKeys" to listOf(keypair.accountId))),
+            )
+          )
+          .execute()
+          .code,
+      )
+
+      assertEquals(secondName, authenticate(keypair).clientName)
+    } finally {
+      delete(firstName)
+      delete(secondName)
+    }
+  }
+
+  @Test
+  fun `test SEP-10 leaves client_name unset for a signing key unknown to the DB`() {
+    val keypair = KeyPair.random()
+    assertNull(authenticate(keypair).clientName)
+  }
+
+  @Test
+  fun `test SEP-10 no longer attributes client_name after the client is deleted`() {
+    val name = uniqueClientName()
+    val keypair = KeyPair.random()
+    val createJson =
+      gson.toJson(mapOf("type" to "custodial", "signingKeys" to listOf(keypair.accountId)))
+
+    assertEquals(
+      200,
+      httpClient
+        .newCall(OkHttpUtil.buildJsonPutRequest("$clientsUrl/$name", createJson))
+        .execute()
+        .code,
+    )
+    assertEquals(name, authenticate(keypair).clientName)
+
+    assertEquals(204, delete(name).code)
+
+    assertNull(authenticate(keypair).clientName)
+  }
+}

--- a/extended-tests/src/test/kotlin/org/stellar/anchor/platform/suite/ClientsDbTestSuite.kt
+++ b/extended-tests/src/test/kotlin/org/stellar/anchor/platform/suite/ClientsDbTestSuite.kt
@@ -1,0 +1,8 @@
+package org.stellar.anchor.platform.suite
+
+import org.junit.platform.suite.api.SelectPackages
+import org.junit.platform.suite.api.Suite
+
+@Suite
+@SelectPackages("org.stellar.anchor.platform.extendedtest.clients.db")
+class ClientsDbTestSuite

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -1,6 +1,8 @@
 package org.stellar.anchor.platform.component.platform;
 
 import jakarta.servlet.Filter;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +10,7 @@ import org.stellar.anchor.api.exception.InvalidConfigException;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.NonceStore;
+import org.stellar.anchor.config.ClientsConfig;
 import org.stellar.anchor.config.Sep24Config;
 import org.stellar.anchor.config.Sep31Config;
 import org.stellar.anchor.config.Sep6Config;
@@ -17,6 +20,7 @@ import org.stellar.anchor.filter.NoneFilter;
 import org.stellar.anchor.filter.PlatformAuthJwtFilter;
 import org.stellar.anchor.platform.config.PlatformApiConfig;
 import org.stellar.anchor.platform.config.PlatformServerConfig;
+import org.stellar.anchor.platform.data.JdbcClientConfigRepo;
 import org.stellar.anchor.platform.job.NonceCleanupJob;
 import org.stellar.anchor.platform.service.*;
 import org.stellar.anchor.sep24.Sep24DepositInfoGenerator;
@@ -134,5 +138,20 @@ public class PlatformServerBeans {
   @Bean
   public NonceCleanupJob nonceCleanupJob(NonceStore nonceStore) {
     return new NonceCleanupJob(nonceStore);
+  }
+
+  @Bean
+  ClientConfigService clientConfigService(JdbcClientConfigRepo jdbcClientConfigRepo) {
+    return new ClientConfigService(jdbcClientConfigRepo);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "clients",
+      name = "migrate-from-file-on-startup",
+      havingValue = "true")
+  CommandLineRunner clientConfigImportRunner(
+      ClientsConfig clientsConfig, ClientConfigService clientConfigService) {
+    return new ClientConfigImportRunner(clientsConfig, clientConfigService);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -148,10 +148,7 @@ public class PlatformServerBeans {
   }
 
   @Bean
-  @ConditionalOnProperty(
-      prefix = "clients",
-      name = "migrate-from-file-on-startup",
-      havingValue = "true")
+  @ConditionalOnProperty(prefix = "clients", name = "type", havingValue = "db")
   CommandLineRunner clientConfigImportRunner(
       ClientsConfig clientsConfig, ClientConfigService clientConfigService) {
     return new ClientConfigImportRunner(clientsConfig, clientConfigService);

--- a/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/platform/PlatformServerBeans.java
@@ -1,6 +1,7 @@
 package org.stellar.anchor.platform.component.platform;
 
 import jakarta.servlet.Filter;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -141,8 +142,9 @@ public class PlatformServerBeans {
   }
 
   @Bean
-  ClientConfigService clientConfigService(JdbcClientConfigRepo jdbcClientConfigRepo) {
-    return new ClientConfigService(jdbcClientConfigRepo);
+  ClientConfigService clientConfigService(
+      ObjectProvider<JdbcClientConfigRepo> jdbcClientConfigRepoProvider) {
+    return new ClientConfigService(jdbcClientConfigRepoProvider);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -121,7 +121,7 @@ public class SepBeans {
   }
 
   @Bean
-  @OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24", "sep31"})
+  @OnAnySepsEnabled(seps = {"sep6", "sep10", "sep24", "sep31", "sep45"})
   ClientFinder clientFinder(Sep10Config sep10Config, ClientService clientService) {
     return new ClientFinder(sep10Config, clientService);
   }
@@ -150,7 +150,6 @@ public class SepBeans {
       Sep6Config sep6Config,
       AssetService assetService,
       SepRequestValidator requestValidator,
-      ClientFinder clientFinder,
       Sep6TransactionStore txnStore,
       EventService eventService,
       Clock clock,
@@ -161,7 +160,6 @@ public class SepBeans {
         sep6Config,
         assetService,
         requestValidator,
-        clientFinder,
         txnStore,
         exchangeAmountsCalculator(sep38QuoteStore, clock),
         eventService,
@@ -187,14 +185,9 @@ public class SepBeans {
       CustomerIntegration customerIntegration,
       PlatformApiClient platformApiClient,
       EventService eventService,
-      ClientFinder clientFinder,
       Sep31CustomerIdOwnerStore sep31CustomerIdOwnerStore) {
     return new Sep12Service(
-        customerIntegration,
-        platformApiClient,
-        eventService,
-        clientFinder,
-        sep31CustomerIdOwnerStore);
+        customerIntegration, platformApiClient, eventService, sep31CustomerIdOwnerStore);
   }
 
   @Bean
@@ -210,11 +203,9 @@ public class SepBeans {
       LanguageConfig languageConfig,
       StellarNetworkConfig stellarNetworkConfig,
       Sep24Config sep24Config,
-      ClientService clientService,
       AssetService assetService,
       SepRequestValidator requestValidator,
       JwtService jwtService,
-      ClientFinder clientFinder,
       Sep24TransactionStore sep24TransactionStore,
       EventService eventService,
       Clock clock,
@@ -225,11 +216,9 @@ public class SepBeans {
         languageConfig,
         stellarNetworkConfig,
         sep24Config,
-        clientService,
         assetService,
         requestValidator,
         jwtService,
-        clientFinder,
         sep24TransactionStore,
         eventService,
         interactiveUrlConstructor,
@@ -252,31 +241,25 @@ public class SepBeans {
   @OnAllSepsEnabled(seps = {"sep31"})
   Sep31Service sep31Service(
       LanguageConfig languageConfig,
-      Sep10Config sep10Config,
       Sep31Config sep31Config,
       Sep31TransactionStore sep31TransactionStore,
       Sep38QuoteStore sep38QuoteStore,
-      ClientService clientService,
       AssetService assetService,
       RateIntegration rateIntegration,
       Clock clock,
       EventService eventService,
-      Sep31CustomerIdOwnerStore sep31CustomerIdOwnerStore,
-      ClientFinder clientFinder) {
+      Sep31CustomerIdOwnerStore sep31CustomerIdOwnerStore) {
     return new Sep31Service(
         languageConfig,
-        sep10Config,
         sep31Config,
         sep31TransactionStore,
         sep38QuoteStore,
-        clientService,
         assetService,
         rateIntegration,
         eventService,
         clock,
         exchangeAmountsCalculator(sep38QuoteStore, clock),
-        sep31CustomerIdOwnerStore,
-        clientFinder);
+        sep31CustomerIdOwnerStore);
   }
 
   @Bean
@@ -299,7 +282,8 @@ public class SepBeans {
       Sep45Config sep45Config,
       LedgerClient ledgerClient,
       NonceManager nonceManager,
-      JwtService jwtService) {
+      JwtService jwtService,
+      ClientFinder clientFinder) {
     assert (ledgerClient instanceof StellarRpc);
     return new Sep45Service(
         stellarNetworkConfig,
@@ -307,6 +291,7 @@ public class SepBeans {
         sep45Config,
         (StellarRpc) ledgerClient,
         nonceManager,
-        jwtService);
+        jwtService,
+        clientFinder);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
@@ -7,6 +7,8 @@ import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.client.DefaultClientService;
 import org.stellar.anchor.config.ClientsConfig;
 import org.stellar.anchor.platform.config.PropertyClientsConfig;
+import org.stellar.anchor.platform.data.JdbcClientConfigRepo;
+import org.stellar.anchor.platform.data.JdbcClientService;
 
 @Configuration
 public class ClientsBeans {
@@ -17,7 +19,11 @@ public class ClientsBeans {
   }
 
   @Bean
-  ClientService clientService(ClientsConfig clientsConfig) {
+  ClientService clientService(
+      ClientsConfig clientsConfig, JdbcClientConfigRepo jdbcClientConfigRepo) {
+    if (clientsConfig.getType() == ClientsConfig.ClientsConfigType.DB) {
+      return new JdbcClientService(jdbcClientConfigRepo);
+    }
     return DefaultClientService.fromClientsConfig(clientsConfig);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/ClientsBeans.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.component.share;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,9 +21,10 @@ public class ClientsBeans {
 
   @Bean
   ClientService clientService(
-      ClientsConfig clientsConfig, JdbcClientConfigRepo jdbcClientConfigRepo) {
+      ClientsConfig clientsConfig,
+      ObjectProvider<JdbcClientConfigRepo> jdbcClientConfigRepoProvider) {
     if (clientsConfig.getType() == ClientsConfig.ClientsConfigType.DB) {
-      return new JdbcClientService(jdbcClientConfigRepo);
+      return new JdbcClientService(jdbcClientConfigRepoProvider.getObject());
     }
     return DefaultClientService.fromClientsConfig(clientsConfig);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -147,18 +147,13 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
             gson.toJson(contentMap.get("items")), new TypeToken<List<RawClient>>() {}.getType());
   }
 
-  private List<RawClient> parseLegacyValueForMigration(String value) {
+  private List<RawClient> parseLegacyValueForMigration(String value) throws InvalidConfigException {
     debugF("Migrating clients.value to the database, parsing: {}", value);
-    Map<String, List<Object>> contentMap;
-    try {
-      contentMap = looksLikeExistingFile(value) ? parseFileToMap(value) : parseStringToMap(value);
-    } catch (InvalidConfigException e) {
-      error("Could not parse clients.value while migrating to the database", e);
-      return new ArrayList<>();
-    }
+    Map<String, List<Object>> contentMap =
+        looksLikeExistingFile(value) ? parseFileToMap(value) : parseStringToMap(value);
     if (contentMap == null || contentMap.get("items") == null) {
-      debugF("clients.value parsed but had no items key: {}", contentMap);
-      return new ArrayList<>();
+      throw new InvalidConfigException(
+          List.of(String.format("clients.value parsed but had no 'items' key: %s", contentMap)));
     }
     contentMap.get("items").removeIf(Objects::isNull);
     List<RawClient> parsed =

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -135,6 +135,7 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
         contentMap = parseYamlStringToMap(this.getValue());
         break;
       case DB:
+        items = new ArrayList<>();
         return;
       default:
         throw new InvalidConfigException(

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -6,7 +6,6 @@ import static org.stellar.anchor.util.Log.error;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -30,9 +29,6 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   ClientsConfigType type;
   String value;
   List<RawClient> items = new ArrayList<>();
-
-  @SerializedName("migrate_from_file_on_startup")
-  boolean migrateFromFileOnStartup = false;
 
   Gson gson = GsonUtils.getInstance();
 

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -131,7 +131,9 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
         contentMap = parseYamlStringToMap(this.getValue());
         break;
       case DB:
-        items = new ArrayList<>();
+        if (!isEmpty(this.getValue())) {
+          items = parseLegacyValueForMigration(this.getValue());
+        }
         return;
       default:
         throw new InvalidConfigException(
@@ -143,6 +145,61 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
     items =
         gson.fromJson(
             gson.toJson(contentMap.get("items")), new TypeToken<List<RawClient>>() {}.getType());
+  }
+
+  private List<RawClient> parseLegacyValueForMigration(String value) {
+    debugF("Migrating clients.value to the database, parsing: {}", value);
+    Map<String, List<Object>> contentMap;
+    try {
+      contentMap = looksLikeExistingFile(value) ? parseFileToMap(value) : parseStringToMap(value);
+    } catch (InvalidConfigException e) {
+      error("Could not parse clients.value while migrating to the database", e);
+      return new ArrayList<>();
+    }
+    if (contentMap == null || contentMap.get("items") == null) {
+      debugF("clients.value parsed but had no items key: {}", contentMap);
+      return new ArrayList<>();
+    }
+    contentMap.get("items").removeIf(Objects::isNull);
+    List<RawClient> parsed =
+        gson.fromJson(
+            gson.toJson(contentMap.get("items")), new TypeToken<List<RawClient>>() {}.getType());
+    debugF("Parsed {} client(s) from clients.value for migration", parsed.size());
+    return parsed;
+  }
+
+  private boolean looksLikeExistingFile(String value) {
+    try {
+      boolean exists = java.nio.file.Files.exists(Path.of(value));
+      debugF("clients.value looksLikeExistingFile check for [{}]: {}", value, exists);
+      return exists;
+    } catch (java.nio.file.InvalidPathException e) {
+      debugF("clients.value is not a valid file path: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, List<Object>> parseStringToMap(String value) throws InvalidConfigException {
+    try {
+      Map<String, List<Object>> asJson = parseJsonStringToMap(value);
+      if (asJson != null) {
+        return asJson;
+      }
+    } catch (Exception e) {
+      debugF("clients.value is not valid JSON, trying YAML instead: {}", e.getMessage());
+    }
+    try {
+      Object loaded = new Yaml().load(value);
+      if (loaded instanceof Map) {
+        return (Map<String, List<Object>>) loaded;
+      }
+      debugF("clients.value parsed as YAML but was not a map: {}", loaded);
+    } catch (Exception e) {
+      debugF("clients.value is not valid YAML either: {}", e.getMessage());
+    }
+    throw new InvalidConfigException(
+        List.of("clients.value is not a valid file path, JSON, or YAML string"));
   }
 
   private Map<String, List<Object>> parseFileToMap(String filePath) throws InvalidConfigException {

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyClientsConfig.java
@@ -6,6 +6,7 @@ import static org.stellar.anchor.util.Log.error;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -29,6 +30,10 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
   ClientsConfigType type;
   String value;
   List<RawClient> items = new ArrayList<>();
+
+  @SerializedName("migrate_from_file_on_startup")
+  boolean migrateFromFileOnStartup = false;
+
   Gson gson = GsonUtils.getInstance();
 
   @Override
@@ -129,6 +134,8 @@ public class PropertyClientsConfig implements ClientsConfig, Validator {
       case YAML:
         contentMap = parseYamlStringToMap(this.getValue());
         break;
+      case DB:
+        return;
       default:
         throw new InvalidConfigException(
             String.format("client file type %s is not supported", type));

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep10Config.java
@@ -35,7 +35,7 @@ public class PropertySep10Config implements Sep10Config, Validator {
   private Integer jwtTimeout = 86400;
   private List<String> knownCustodialAccountList;
   private StellarNetworkConfig stellarNetworkConfig;
-  private final ClientService clientService;
+  private final transient ClientService clientService;
   private SecretConfig secretConfig;
   private boolean requireAuthHeader = false;
 

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
@@ -1,0 +1,67 @@
+package org.stellar.anchor.platform.controller.platform;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.platform.service.ClientConfigService;
+
+@RestController
+public class ClientConfigController {
+
+  private final ClientConfigService clientConfigService;
+
+  ClientConfigController(ClientConfigService clientConfigService) {
+    this.clientConfigService = clientConfigService;
+  }
+
+  @CrossOrigin(origins = "*")
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients/{name}",
+      consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.PUT})
+  public ClientConfigResponse upsertClient(
+      @PathVariable(name = "name") String name, @RequestBody ClientConfigRequest request)
+      throws AnchorException {
+    return clientConfigService.upsert(name, request);
+  }
+
+  @CrossOrigin(origins = "*")
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients/{name}",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.GET})
+  public ClientConfigResponse getClient(@PathVariable(name = "name") String name)
+      throws AnchorException {
+    return clientConfigService.get(name);
+  }
+
+  @CrossOrigin(origins = "*")
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.GET})
+  public List<ClientConfigResponse> listClients() {
+    return clientConfigService.list();
+  }
+
+  @CrossOrigin(origins = "*")
+  @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @RequestMapping(
+      value = "/clients/{name}",
+      method = {RequestMethod.DELETE})
+  public void deleteClient(@PathVariable(name = "name") String name) throws AnchorException {
+    clientConfigService.delete(name);
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
@@ -3,7 +3,6 @@ package org.stellar.anchor.platform.controller.platform;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +21,6 @@ public class ClientConfigController {
     this.clientConfigService = clientConfigService;
   }
 
-  @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/clients/{name}",
@@ -35,7 +33,6 @@ public class ClientConfigController {
     return clientConfigService.upsert(name, request);
   }
 
-  @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/clients/{name}",
@@ -46,7 +43,6 @@ public class ClientConfigController {
     return clientConfigService.get(name);
   }
 
-  @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.OK)
   @RequestMapping(
       value = "/clients",
@@ -56,7 +52,6 @@ public class ClientConfigController {
     return clientConfigService.list();
   }
 
-  @CrossOrigin(origins = "*")
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
   @RequestMapping(
       value = "/clients/{name}",

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
@@ -59,4 +59,48 @@ public class ClientConfigController {
   public void deleteClient(@PathVariable(name = "name") String name) throws AnchorException {
     clientConfigService.delete(name);
   }
+
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients/{name}/destination-accounts/{account}",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.POST})
+  public ClientConfigResponse addDestinationAccount(
+      @PathVariable(name = "name") String name, @PathVariable(name = "account") String account)
+      throws AnchorException {
+    return clientConfigService.addDestinationAccount(name, account);
+  }
+
+  @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @RequestMapping(
+      value = "/clients/{name}/destination-accounts/{account}",
+      method = {RequestMethod.DELETE})
+  public void removeDestinationAccount(
+      @PathVariable(name = "name") String name, @PathVariable(name = "account") String account)
+      throws AnchorException {
+    clientConfigService.removeDestinationAccount(name, account);
+  }
+
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients/{name}/signing-keys/{signingKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.POST})
+  public ClientConfigResponse addSigningKey(
+      @PathVariable(name = "name") String name,
+      @PathVariable(name = "signingKey") String signingKey)
+      throws AnchorException {
+    return clientConfigService.addSigningKey(name, signingKey);
+  }
+
+  @ResponseStatus(code = HttpStatus.NO_CONTENT)
+  @RequestMapping(
+      value = "/clients/{name}/signing-keys/{signingKey}",
+      method = {RequestMethod.DELETE})
+  public void removeSigningKey(
+      @PathVariable(name = "name") String name,
+      @PathVariable(name = "signingKey") String signingKey)
+      throws AnchorException {
+    clientConfigService.removeSigningKey(name, signingKey);
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigController.java
@@ -52,6 +52,24 @@ public class ClientConfigController {
     return clientConfigService.list();
   }
 
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients/custodial",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.GET})
+  public List<ClientConfigResponse> listCustodialClients() {
+    return clientConfigService.listCustodial();
+  }
+
+  @ResponseStatus(code = HttpStatus.OK)
+  @RequestMapping(
+      value = "/clients/non-custodial",
+      produces = {MediaType.APPLICATION_JSON_VALUE},
+      method = {RequestMethod.GET})
+  public List<ClientConfigResponse> listNonCustodialClients() {
+    return clientConfigService.listNonCustodial();
+  }
+
   @ResponseStatus(code = HttpStatus.NO_CONTENT)
   @RequestMapping(
       value = "/clients/{name}",

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigRequest.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigRequest.java
@@ -1,0 +1,16 @@
+package org.stellar.anchor.platform.controller.platform;
+
+import java.util.Set;
+import lombok.Data;
+import org.stellar.anchor.client.ClientConfig.CallbackUrls;
+import org.stellar.anchor.client.ClientConfig.ClientType;
+
+@Data
+public class ClientConfigRequest {
+  private ClientType type;
+  private Set<String> domains;
+  private Set<String> signingKeys;
+  private CallbackUrls callbackUrls;
+  private boolean allowAnyDestination;
+  private Set<String> destinationAccounts;
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigResponse.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/platform/ClientConfigResponse.java
@@ -1,0 +1,19 @@
+package org.stellar.anchor.platform.controller.platform;
+
+import java.util.Set;
+import lombok.Builder;
+import lombok.Data;
+import org.stellar.anchor.client.ClientConfig.CallbackUrls;
+import org.stellar.anchor.client.ClientConfig.ClientType;
+
+@Data
+@Builder
+public class ClientConfigResponse {
+  private String name;
+  private ClientType type;
+  private Set<String> domains;
+  private Set<String> signingKeys;
+  private CallbackUrls callbackUrls;
+  private boolean allowAnyDestination;
+  private Set<String> destinationAccounts;
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep10Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep10Controller.java
@@ -65,8 +65,7 @@ public class Sep10Controller {
       produces = {MediaType.APPLICATION_JSON_VALUE},
       method = {RequestMethod.POST})
   public ValidationResponse validateChallenge(
-      @RequestParam(name = "transaction") String transaction)
-      throws SepValidationException, IOException {
+      @RequestParam(name = "transaction") String transaction) throws SepException, IOException {
     debugF("POST /auth transaction={}", transaction);
     return validateChallenge(ValidationRequest.of(transaction));
   }
@@ -79,7 +78,7 @@ public class Sep10Controller {
       method = {RequestMethod.POST})
   public ValidationResponse validateChallenge(
       @RequestBody(required = false) ValidationRequest validationRequest)
-      throws SepValidationException, IOException {
+      throws SepException, IOException {
     debug("POST /auth details:", validationRequest);
     return sep10Service.validateChallenge(validationRequest);
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientConfig.java
@@ -1,0 +1,55 @@
+package org.stellar.anchor.platform.data;
+
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.stellar.anchor.client.ClientConfig.ClientType;
+
+@Getter
+@Setter
+@Entity
+@Access(AccessType.FIELD)
+@Table(name = "client_config")
+@NoArgsConstructor
+public class JdbcClientConfig {
+  @Id private String name;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "type")
+  private ClientType type;
+
+  @Column(name = "allow_any_destination")
+  private boolean allowAnyDestination;
+
+  @Column(name = "callback_url_sep6")
+  private String callbackUrlSep6;
+
+  @Column(name = "callback_url_sep24")
+  private String callbackUrlSep24;
+
+  @Column(name = "callback_url_sep31")
+  private String callbackUrlSep31;
+
+  @Column(name = "callback_url_sep12")
+  private String callbackUrlSep12;
+
+  @ElementCollection
+  @CollectionTable(name = "client_domain", joinColumns = @JoinColumn(name = "client_name"))
+  @Column(name = "domain")
+  private Set<String> domains = new HashSet<>();
+
+  @ElementCollection
+  @CollectionTable(name = "client_signing_key", joinColumns = @JoinColumn(name = "client_name"))
+  @Column(name = "signing_key")
+  private Set<String> signingKeys = new HashSet<>();
+
+  @ElementCollection
+  @CollectionTable(
+      name = "client_destination_account",
+      joinColumns = @JoinColumn(name = "client_name"))
+  @Column(name = "destination_account")
+  private Set<String> destinationAccounts = new HashSet<>();
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientConfigRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientConfigRepo.java
@@ -1,0 +1,18 @@
+package org.stellar.anchor.platform.data;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.stellar.anchor.client.ClientConfig.ClientType;
+
+public interface JdbcClientConfigRepo extends CrudRepository<JdbcClientConfig, String> {
+
+  List<JdbcClientConfig> findByType(ClientType type);
+
+  @Query("SELECT c FROM JdbcClientConfig c JOIN c.domains d WHERE d = :domain")
+  JdbcClientConfig findByDomain(@Param("domain") String domain);
+
+  @Query("SELECT c FROM JdbcClientConfig c JOIN c.signingKeys k WHERE k = :signingKey")
+  JdbcClientConfig findBySigningKey(@Param("signingKey") String signingKey);
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientConfigRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientConfigRepo.java
@@ -1,6 +1,8 @@
 package org.stellar.anchor.platform.data;
 
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -8,11 +10,22 @@ import org.stellar.anchor.client.ClientConfig.ClientType;
 
 public interface JdbcClientConfigRepo extends CrudRepository<JdbcClientConfig, String> {
 
+  @Override
+  @EntityGraph(attributePaths = {"signingKeys", "domains", "destinationAccounts"})
+  List<JdbcClientConfig> findAll();
+
+  @Override
+  @EntityGraph(attributePaths = {"signingKeys", "domains", "destinationAccounts"})
+  Optional<JdbcClientConfig> findById(String name);
+
+  @EntityGraph(attributePaths = {"signingKeys", "domains", "destinationAccounts"})
   List<JdbcClientConfig> findByType(ClientType type);
 
+  @EntityGraph(attributePaths = {"signingKeys", "domains", "destinationAccounts"})
   @Query("SELECT c FROM JdbcClientConfig c JOIN c.domains d WHERE d = :domain")
   JdbcClientConfig findByDomain(@Param("domain") String domain);
 
+  @EntityGraph(attributePaths = {"signingKeys", "domains", "destinationAccounts"})
   @Query("SELECT c FROM JdbcClientConfig c JOIN c.signingKeys k WHERE k = :signingKey")
   JdbcClientConfig findBySigningKey(@Param("signingKey") String signingKey);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcClientService.java
@@ -1,0 +1,93 @@
+package org.stellar.anchor.platform.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.stellar.anchor.client.ClientConfig;
+import org.stellar.anchor.client.ClientConfig.CallbackUrls;
+import org.stellar.anchor.client.ClientConfig.ClientType;
+import org.stellar.anchor.client.ClientService;
+import org.stellar.anchor.client.CustodialClient;
+import org.stellar.anchor.client.NonCustodialClient;
+
+@RequiredArgsConstructor
+public class JdbcClientService implements ClientService {
+  private final JdbcClientConfigRepo repo;
+
+  @Override
+  public List<ClientConfig> getAllClients() {
+    List<ClientConfig> clients = new ArrayList<>();
+    repo.findAll().forEach(c -> clients.add(toClientConfig(c)));
+    return clients;
+  }
+
+  @Override
+  public List<CustodialClient> getCustodialClients() {
+    return repo.findByType(ClientType.CUSTODIAL).stream()
+        .map(this::toCustodialClient)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<NonCustodialClient> getNonCustodialClients() {
+    return repo.findByType(ClientType.NONCUSTODIAL).stream()
+        .map(this::toNonCustodialClient)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public ClientConfig getClientConfigByName(String clientName) {
+    return repo.findById(clientName).map(this::toClientConfig).orElse(null);
+  }
+
+  @Override
+  public CustodialClient getClientConfigBySigningKey(String signingKey) {
+    JdbcClientConfig found = repo.findBySigningKey(signingKey);
+    return found == null ? null : toCustodialClient(found);
+  }
+
+  @Override
+  public NonCustodialClient getClientConfigByDomain(String domain) {
+    JdbcClientConfig found = repo.findByDomain(domain);
+    return found == null ? null : toNonCustodialClient(found);
+  }
+
+  @Override
+  public ClientConfig getClientConfigByDomainAndAccount(String domain, String account) {
+    ClientConfig clientByDomain = getClientConfigByDomain(domain);
+    ClientConfig clientByAccount = getClientConfigBySigningKey(account);
+    return clientByDomain != null ? clientByDomain : clientByAccount;
+  }
+
+  private ClientConfig toClientConfig(JdbcClientConfig c) {
+    return c.getType() == ClientType.CUSTODIAL ? toCustodialClient(c) : toNonCustodialClient(c);
+  }
+
+  private CustodialClient toCustodialClient(JdbcClientConfig c) {
+    return CustodialClient.builder()
+        .name(c.getName())
+        .signingKeys(c.getSigningKeys())
+        .callbackUrls(toCallbackUrls(c))
+        .allowAnyDestination(c.isAllowAnyDestination())
+        .destinationAccounts(c.getDestinationAccounts())
+        .build();
+  }
+
+  private NonCustodialClient toNonCustodialClient(JdbcClientConfig c) {
+    return NonCustodialClient.builder()
+        .name(c.getName())
+        .domains(c.getDomains())
+        .callbackUrls(toCallbackUrls(c))
+        .build();
+  }
+
+  private CallbackUrls toCallbackUrls(JdbcClientConfig c) {
+    return CallbackUrls.builder()
+        .sep6(c.getCallbackUrlSep6())
+        .sep24(c.getCallbackUrlSep24())
+        .sep31(c.getCallbackUrlSep31())
+        .sep12(c.getCallbackUrlSep12())
+        .build();
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigImportRunner.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigImportRunner.java
@@ -2,6 +2,7 @@ package org.stellar.anchor.platform.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
+import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.config.ClientsConfig;
 import org.stellar.anchor.config.ClientsConfig.RawClient;
 import org.stellar.anchor.platform.controller.platform.ClientConfigRequest;
@@ -19,7 +20,7 @@ public class ClientConfigImportRunner implements CommandLineRunner {
       try {
         clientConfigService.upsert(item.getName(), toRequest(item));
         imported++;
-      } catch (Exception e) {
+      } catch (AnchorException | RuntimeException e) {
         Log.errorEx(
             String.format("Failed to import client [%s] into the database", item.getName()), e);
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigImportRunner.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigImportRunner.java
@@ -1,0 +1,41 @@
+package org.stellar.anchor.platform.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.stellar.anchor.config.ClientsConfig;
+import org.stellar.anchor.config.ClientsConfig.RawClient;
+import org.stellar.anchor.platform.controller.platform.ClientConfigRequest;
+import org.stellar.anchor.util.Log;
+
+@RequiredArgsConstructor
+public class ClientConfigImportRunner implements CommandLineRunner {
+  private final ClientsConfig clientsConfig;
+  private final ClientConfigService clientConfigService;
+
+  @Override
+  public void run(String... args) {
+    int imported = 0;
+    for (RawClient item : clientsConfig.getItems()) {
+      try {
+        clientConfigService.upsert(item.getName(), toRequest(item));
+        imported++;
+      } catch (Exception e) {
+        Log.errorEx(
+            String.format("Failed to import client [%s] into the database", item.getName()), e);
+      }
+    }
+    Log.infoF(
+        "Imported {} of {} clients into the database", imported, clientsConfig.getItems().size());
+  }
+
+  private ClientConfigRequest toRequest(RawClient item) {
+    ClientConfigRequest request = new ClientConfigRequest();
+    request.setType(item.getType());
+    request.setDomains(item.getDomains());
+    request.setSigningKeys(item.getSigningKeys());
+    request.setCallbackUrls(item.getCallbackUrls());
+    request.setAllowAnyDestination(item.isAllowAnyDestination());
+    request.setDestinationAccounts(item.getDestinationAccounts());
+    return request;
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
@@ -123,6 +123,14 @@ public class ClientConfigService {
         .toList();
   }
 
+  public List<ClientConfigResponse> listCustodial() {
+    return repo().findByType(ClientType.CUSTODIAL).stream().map(this::toResponse).toList();
+  }
+
+  public List<ClientConfigResponse> listNonCustodial() {
+    return repo().findByType(ClientType.NONCUSTODIAL).stream().map(this::toResponse).toList();
+  }
+
   public void delete(String name) throws NotFoundException {
     if (!repo().existsById(name)) {
       throw new NotFoundException(String.format("Client %s not found", name));

--- a/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
@@ -1,0 +1,128 @@
+package org.stellar.anchor.platform.service;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.stellar.anchor.api.exception.BadRequestException;
+import org.stellar.anchor.api.exception.NotFoundException;
+import org.stellar.anchor.client.ClientConfig.CallbackUrls;
+import org.stellar.anchor.client.ClientConfig.ClientType;
+import org.stellar.anchor.platform.controller.platform.ClientConfigRequest;
+import org.stellar.anchor.platform.controller.platform.ClientConfigResponse;
+import org.stellar.anchor.platform.data.JdbcClientConfig;
+import org.stellar.anchor.platform.data.JdbcClientConfigRepo;
+
+@RequiredArgsConstructor
+public class ClientConfigService {
+  private final JdbcClientConfigRepo repo;
+
+  public ClientConfigResponse upsert(String name, ClientConfigRequest request)
+      throws BadRequestException {
+    validate(name, request);
+
+    JdbcClientConfig entity = repo.findById(name).orElseGet(JdbcClientConfig::new);
+    entity.setName(name);
+    entity.setType(request.getType());
+    entity.setAllowAnyDestination(request.isAllowAnyDestination());
+    entity.setDomains(nullToEmpty(request.getDomains()));
+    entity.setSigningKeys(nullToEmpty(request.getSigningKeys()));
+    entity.setDestinationAccounts(nullToEmpty(request.getDestinationAccounts()));
+    if (request.getCallbackUrls() != null) {
+      entity.setCallbackUrlSep6(request.getCallbackUrls().getSep6());
+      entity.setCallbackUrlSep24(request.getCallbackUrls().getSep24());
+      entity.setCallbackUrlSep31(request.getCallbackUrls().getSep31());
+      entity.setCallbackUrlSep12(request.getCallbackUrls().getSep12());
+    }
+
+    try {
+      return toResponse(repo.save(entity));
+    } catch (DataIntegrityViolationException e) {
+      throw new BadRequestException("domain or signing key is already in use by another client");
+    }
+  }
+
+  public ClientConfigResponse get(String name) throws NotFoundException {
+    return repo.findById(name)
+        .map(this::toResponse)
+        .orElseThrow(() -> new NotFoundException(String.format("Client %s not found", name)));
+  }
+
+  public List<ClientConfigResponse> list() {
+    return java.util.stream.StreamSupport.stream(repo.findAll().spliterator(), false)
+        .map(this::toResponse)
+        .toList();
+  }
+
+  public void delete(String name) throws NotFoundException {
+    if (!repo.existsById(name)) {
+      throw new NotFoundException(String.format("Client %s not found", name));
+    }
+    repo.deleteById(name);
+  }
+
+  private void validate(String name, ClientConfigRequest request) throws BadRequestException {
+    if (StringUtils.isBlank(name)) {
+      throw new BadRequestException("Client name must not be blank");
+    }
+    if (request.getType() == null) {
+      throw new BadRequestException("Client type must be either custodial or noncustodial");
+    }
+    if (request.getType() == ClientType.CUSTODIAL
+        && (request.getSigningKeys() == null || request.getSigningKeys().isEmpty())) {
+      throw new BadRequestException("Custodial clients must have at least one signing key");
+    }
+    if (request.getType() == ClientType.NONCUSTODIAL
+        && (request.getDomains() == null || request.getDomains().isEmpty())) {
+      throw new BadRequestException("Noncustodial clients must have at least one domain");
+    }
+    validateCallbackUrls(request.getCallbackUrls());
+  }
+
+  private void validateCallbackUrls(CallbackUrls callbackUrls) throws BadRequestException {
+    if (callbackUrls == null) {
+      return;
+    }
+    String[] urls = {
+      callbackUrls.getSep6(),
+      callbackUrls.getSep24(),
+      callbackUrls.getSep31(),
+      callbackUrls.getSep12()
+    };
+    for (String url : urls) {
+      if (StringUtils.isNotEmpty(url)) {
+        try {
+          new URL(url);
+        } catch (MalformedURLException e) {
+          throw new BadRequestException(String.format("Invalid callback URL: %s", url));
+        }
+      }
+    }
+  }
+
+  private Set<String> nullToEmpty(Set<String> values) {
+    return values == null ? new HashSet<>() : new HashSet<>(values);
+  }
+
+  private ClientConfigResponse toResponse(JdbcClientConfig entity) {
+    return ClientConfigResponse.builder()
+        .name(entity.getName())
+        .type(entity.getType())
+        .domains(entity.getDomains())
+        .signingKeys(entity.getSigningKeys())
+        .destinationAccounts(entity.getDestinationAccounts())
+        .allowAnyDestination(entity.isAllowAnyDestination())
+        .callbackUrls(
+            CallbackUrls.builder()
+                .sep6(entity.getCallbackUrlSep6())
+                .sep24(entity.getCallbackUrlSep24())
+                .sep31(entity.getCallbackUrlSep31())
+                .sep12(entity.getCallbackUrlSep12())
+                .build())
+        .build();
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.stellar.anchor.api.exception.BadRequestException;
 import org.stellar.anchor.api.exception.NotFoundException;
@@ -19,50 +20,65 @@ import org.stellar.anchor.platform.data.JdbcClientConfigRepo;
 
 @RequiredArgsConstructor
 public class ClientConfigService {
-  private final JdbcClientConfigRepo repo;
+  private static final Set<String> UNIQUE_CONSTRAINT_NAMES =
+      Set.of("idx_client_domain_domain", "idx_client_signing_key_key");
+
+  private final ObjectProvider<JdbcClientConfigRepo> repoProvider;
+
+  private JdbcClientConfigRepo repo() {
+    return repoProvider.getObject();
+  }
 
   public ClientConfigResponse upsert(String name, ClientConfigRequest request)
       throws BadRequestException {
     validate(name, request);
 
-    JdbcClientConfig entity = repo.findById(name).orElseGet(JdbcClientConfig::new);
+    JdbcClientConfig entity = repo().findById(name).orElseGet(JdbcClientConfig::new);
     entity.setName(name);
     entity.setType(request.getType());
     entity.setAllowAnyDestination(request.isAllowAnyDestination());
     entity.setDomains(nullToEmpty(request.getDomains()));
     entity.setSigningKeys(nullToEmpty(request.getSigningKeys()));
     entity.setDestinationAccounts(nullToEmpty(request.getDestinationAccounts()));
-    if (request.getCallbackUrls() != null) {
-      entity.setCallbackUrlSep6(request.getCallbackUrls().getSep6());
-      entity.setCallbackUrlSep24(request.getCallbackUrls().getSep24());
-      entity.setCallbackUrlSep31(request.getCallbackUrls().getSep31());
-      entity.setCallbackUrlSep12(request.getCallbackUrls().getSep12());
-    }
+    CallbackUrls callbackUrls = request.getCallbackUrls();
+    entity.setCallbackUrlSep6(callbackUrls == null ? null : callbackUrls.getSep6());
+    entity.setCallbackUrlSep24(callbackUrls == null ? null : callbackUrls.getSep24());
+    entity.setCallbackUrlSep31(callbackUrls == null ? null : callbackUrls.getSep31());
+    entity.setCallbackUrlSep12(callbackUrls == null ? null : callbackUrls.getSep12());
 
     try {
-      return toResponse(repo.save(entity));
+      return toResponse(repo().save(entity));
     } catch (DataIntegrityViolationException e) {
-      throw new BadRequestException("domain or signing key is already in use by another client");
+      if (isUniqueConstraintViolation(e)) {
+        throw new BadRequestException("domain or signing key is already in use by another client");
+      }
+      throw e;
     }
   }
 
+  private boolean isUniqueConstraintViolation(DataIntegrityViolationException e) {
+    String message = e.getMostSpecificCause().getMessage();
+    return message != null && UNIQUE_CONSTRAINT_NAMES.stream().anyMatch(message::contains);
+  }
+
   public ClientConfigResponse get(String name) throws NotFoundException {
-    return repo.findById(name)
+    return repo()
+        .findById(name)
         .map(this::toResponse)
         .orElseThrow(() -> new NotFoundException(String.format("Client %s not found", name)));
   }
 
   public List<ClientConfigResponse> list() {
-    return java.util.stream.StreamSupport.stream(repo.findAll().spliterator(), false)
+    return java.util.stream.StreamSupport.stream(repo().findAll().spliterator(), false)
         .map(this::toResponse)
         .toList();
   }
 
   public void delete(String name) throws NotFoundException {
-    if (!repo.existsById(name)) {
+    if (!repo().existsById(name)) {
       throw new NotFoundException(String.format("Client %s not found", name));
     }
-    repo.deleteById(name);
+    repo().deleteById(name);
   }
 
   private void validate(String name, ClientConfigRequest request) throws BadRequestException {
@@ -95,12 +111,21 @@ public class ClientConfigService {
     };
     for (String url : urls) {
       if (StringUtils.isNotEmpty(url)) {
-        try {
-          new URL(url);
-        } catch (MalformedURLException e) {
-          throw new BadRequestException(String.format("Invalid callback URL: %s", url));
-        }
+        validateHttpUrl(url);
       }
+    }
+  }
+
+  private void validateHttpUrl(String url) throws BadRequestException {
+    URL parsed;
+    try {
+      parsed = new URL(url);
+    } catch (MalformedURLException e) {
+      throw new BadRequestException(String.format("Invalid callback URL: %s", url));
+    }
+    if (!"http".equalsIgnoreCase(parsed.getProtocol())
+        && !"https".equalsIgnoreCase(parsed.getProtocol())) {
+      throw new BadRequestException(String.format("Invalid callback URL: %s", url));
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/ClientConfigService.java
@@ -46,6 +46,55 @@ public class ClientConfigService {
     entity.setCallbackUrlSep31(callbackUrls == null ? null : callbackUrls.getSep31());
     entity.setCallbackUrlSep12(callbackUrls == null ? null : callbackUrls.getSep12());
 
+    return saveHandlingConflict(entity);
+  }
+
+  public ClientConfigResponse addDestinationAccount(String name, String account)
+      throws NotFoundException, BadRequestException {
+    JdbcClientConfig entity = findOrThrow(name);
+    entity.getDestinationAccounts().add(account);
+    return saveHandlingConflict(entity);
+  }
+
+  public void removeDestinationAccount(String name, String account) throws NotFoundException {
+    JdbcClientConfig entity = findOrThrow(name);
+    if (!entity.getDestinationAccounts().remove(account)) {
+      throw new NotFoundException(
+          String.format("Destination account %s not found on client %s", account, name));
+    }
+    repo().save(entity);
+  }
+
+  public ClientConfigResponse addSigningKey(String name, String signingKey)
+      throws NotFoundException, BadRequestException {
+    JdbcClientConfig entity = findOrThrow(name);
+    entity.getSigningKeys().add(signingKey);
+    return saveHandlingConflict(entity);
+  }
+
+  public void removeSigningKey(String name, String signingKey)
+      throws NotFoundException, BadRequestException {
+    JdbcClientConfig entity = findOrThrow(name);
+    if (entity.getType() == ClientType.CUSTODIAL
+        && entity.getSigningKeys().size() == 1
+        && entity.getSigningKeys().contains(signingKey)) {
+      throw new BadRequestException("Custodial clients must have at least one signing key");
+    }
+    if (!entity.getSigningKeys().remove(signingKey)) {
+      throw new NotFoundException(
+          String.format("Signing key %s not found on client %s", signingKey, name));
+    }
+    repo().save(entity);
+  }
+
+  private JdbcClientConfig findOrThrow(String name) throws NotFoundException {
+    return repo()
+        .findById(name)
+        .orElseThrow(() -> new NotFoundException(String.format("Client %s not found", name)));
+  }
+
+  private ClientConfigResponse saveHandlingConflict(JdbcClientConfig entity)
+      throws BadRequestException {
     try {
       return toResponse(repo().save(entity));
     } catch (DataIntegrityViolationException e) {

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -654,18 +654,13 @@ clients:
   # type: json
   # value: "{\n  \"items\": [\n    {\n      \"name\": \"referenceCustodial\",\n      \"type\": \"custodial\"\n    }\n]\n}"
   #
-  # Option 4: Store clients in the database, managed via the /clients PUT/GET/DELETE endpoints.
-  # Specify the type as 'db'. The value field is ignored.
+  # Option 4: Store clients in the database, managed via the /clients REST API.
+  # Specify the type as 'db'. If value is also set to an existing file path, or an inline
+  # yaml/json string, its clients are imported into the database once on startup (existing
+  # database rows are left untouched). Leave value empty to skip the import.
   #
   # type: db
-  #
-  # To migrate existing file/yaml/json clients into the database, temporarily set type back to
-  # file/yaml/json with its value, add migrate_from_file_on_startup: true, start the server once
-  # to perform the one-time import, then switch type back to db.
-  #
-  # type: file
   # value: path/to/file.yaml
-  # migrate_from_file_on_startup: true
   type: json
   value:
 

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -646,6 +646,19 @@ clients:
   #
   # type: json
   # value: "{\n  \"items\": [\n    {\n      \"name\": \"referenceCustodial\",\n      \"type\": \"custodial\"\n    }\n]\n}"
+  #
+  # Option 4: Store clients in the database, managed via the /clients PUT/GET/DELETE endpoints.
+  # Specify the type as 'db'. The value field is ignored.
+  #
+  # type: db
+  #
+  # To migrate existing file/yaml/json clients into the database, temporarily set type back to
+  # file/yaml/json with its value, add migrate_from_file_on_startup: true, start the server once
+  # to perform the one-time import, then switch type back to db.
+  #
+  # type: file
+  # value: path/to/file.yaml
+  # migrate_from_file_on_startup: true
   type: json
   value:
 

--- a/platform/src/main/resources/db/migration/V32__client_config.sql
+++ b/platform/src/main/resources/db/migration/V32__client_config.sql
@@ -1,0 +1,31 @@
+CREATE TABLE client_config (
+    name                  VARCHAR(255) NOT NULL PRIMARY KEY,
+    type                  VARCHAR(32)  NOT NULL,
+    allow_any_destination BOOLEAN      NOT NULL DEFAULT FALSE,
+    callback_url_sep6     VARCHAR(255),
+    callback_url_sep24    VARCHAR(255),
+    callback_url_sep31    VARCHAR(255),
+    callback_url_sep12    VARCHAR(255)
+);
+
+CREATE TABLE client_domain (
+    client_name VARCHAR(255) NOT NULL REFERENCES client_config (name) ON DELETE CASCADE,
+    domain      VARCHAR(255) NOT NULL,
+    PRIMARY KEY (client_name, domain)
+);
+
+CREATE UNIQUE INDEX idx_client_domain_domain ON client_domain (domain);
+
+CREATE TABLE client_signing_key (
+    client_name VARCHAR(255) NOT NULL REFERENCES client_config (name) ON DELETE CASCADE,
+    signing_key VARCHAR(56)  NOT NULL,
+    PRIMARY KEY (client_name, signing_key)
+);
+
+CREATE UNIQUE INDEX idx_client_signing_key_key ON client_signing_key (signing_key);
+
+CREATE TABLE client_destination_account (
+    client_name         VARCHAR(255) NOT NULL REFERENCES client_config (name) ON DELETE CASCADE,
+    destination_account VARCHAR(56)  NOT NULL,
+    PRIMARY KEY (client_name, destination_account)
+);

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -43,4 +43,17 @@ class PropertyClientsConfigTest {
   fun `migrateFromFileOnStartup defaults to false`() {
     assertFalse(config.isMigrateFromFileOnStartup)
   }
+
+  @Test
+  fun `switching from yaml to db clears items parsed from the prior type`() {
+    config.type = ClientsConfig.ClientsConfigType.YAML
+    config.value = "items:\n  - name: client1\n    type: custodial"
+    config.validate(config, errors)
+    assertEquals(1, config.items.size)
+
+    config.type = ClientsConfig.ClientsConfigType.DB
+    config.validate(config, errors)
+
+    assertTrue(config.items.isEmpty())
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -73,6 +73,28 @@ class PropertyClientsConfigTest {
   }
 
   @Test
+  fun `type db with an unparseable value fails validation instead of silently importing nothing`() {
+    config.type = ClientsConfig.ClientsConfigType.DB
+    config.value = "/typo/path/that/does/not/exist.yaml"
+
+    config.validate(config, errors)
+
+    assertTrue(errors.hasErrors())
+    assertTrue(config.items.isEmpty())
+  }
+
+  @Test
+  fun `type db with a parseable value missing the items key fails validation`() {
+    config.type = ClientsConfig.ClientsConfigType.DB
+    config.value = "not_items: []"
+
+    config.validate(config, errors)
+
+    assertTrue(errors.hasErrors())
+    assertTrue(config.items.isEmpty())
+  }
+
+  @Test
   fun `type db preserves items already bound directly, e_g_ left over from an inline config`() {
     config.type = ClientsConfig.ClientsConfigType.DB
     config.items =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -1,10 +1,12 @@
 package org.stellar.anchor.platform.config
 
+import java.nio.file.Files
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.validation.BindException
 import org.springframework.validation.Errors
+import org.stellar.anchor.client.ClientConfig.ClientType
 import org.stellar.anchor.config.ClientsConfig
 
 class PropertyClientsConfigTest {
@@ -29,31 +31,62 @@ class PropertyClientsConfigTest {
   }
 
   @Test
-  fun `type db with a value set still parses to an empty item list`() {
+  fun `type db with a YAML string left in value migrates its items`() {
     config.type = ClientsConfig.ClientsConfigType.DB
-    config.value = "items:\n  - name: client1\n    type: custodial"
+    config.value = "items:\n  - name: client1\n    type: custodial\n    signing_keys:\n      - GABC"
 
     config.validate(config, errors)
 
-    assertTrue(config.items.isEmpty())
-    assertFalse(errors.hasErrors())
-  }
-
-  @Test
-  fun `migrateFromFileOnStartup defaults to false`() {
-    assertFalse(config.isMigrateFromFileOnStartup)
-  }
-
-  @Test
-  fun `switching from yaml to db clears items parsed from the prior type`() {
-    config.type = ClientsConfig.ClientsConfigType.YAML
-    config.value = "items:\n  - name: client1\n    type: custodial"
-    config.validate(config, errors)
     assertEquals(1, config.items.size)
+    assertEquals("client1", config.items[0].name)
+  }
 
+  @Test
+  fun `type db with a JSON string left in value migrates its items`() {
     config.type = ClientsConfig.ClientsConfigType.DB
+    config.value = """{"items":[{"name":"client1","type":"custodial","signing_keys":["GABC"]}]}"""
+
     config.validate(config, errors)
 
-    assertTrue(config.items.isEmpty())
+    assertEquals(1, config.items.size)
+    assertEquals("client1", config.items[0].name)
+  }
+
+  @Test
+  fun `type db with a file path left in value migrates its items`() {
+    val file = Files.createTempFile("clients", ".yaml")
+    try {
+      Files.writeString(
+        file,
+        "items:\n  - name: client1\n    type: custodial\n    signing_keys:\n      - GABC",
+      )
+      config.type = ClientsConfig.ClientsConfigType.DB
+      config.value = file.toString()
+
+      config.validate(config, errors)
+
+      assertEquals(1, config.items.size)
+      assertEquals("client1", config.items[0].name)
+    } finally {
+      Files.deleteIfExists(file)
+    }
+  }
+
+  @Test
+  fun `type db preserves items already bound directly, e_g_ left over from an inline config`() {
+    config.type = ClientsConfig.ClientsConfigType.DB
+    config.items =
+      listOf(
+        ClientsConfig.RawClient.builder()
+          .name("client1")
+          .type(ClientType.CUSTODIAL)
+          .signingKeys(setOf("GABC"))
+          .build()
+      )
+
+    config.validate(config, errors)
+
+    assertEquals(1, config.items.size)
+    assertEquals("client1", config.items[0].name)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/PropertyClientsConfigTest.kt
@@ -1,1 +1,46 @@
+package org.stellar.anchor.platform.config
 
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+import org.stellar.anchor.config.ClientsConfig
+
+class PropertyClientsConfigTest {
+  private lateinit var config: PropertyClientsConfig
+  private lateinit var errors: Errors
+
+  @BeforeEach
+  fun setup() {
+    config = PropertyClientsConfig()
+    errors = BindException(config, "config")
+  }
+
+  @Test
+  fun `type db with no value parses to an empty item list`() {
+    config.type = ClientsConfig.ClientsConfigType.DB
+    config.value = null
+
+    config.validate(config, errors)
+
+    assertTrue(config.items.isEmpty())
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `type db with a value set still parses to an empty item list`() {
+    config.type = ClientsConfig.ClientsConfigType.DB
+    config.value = "items:\n  - name: client1\n    type: custodial"
+
+    config.validate(config, errors)
+
+    assertTrue(config.items.isEmpty())
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `migrateFromFileOnStartup defaults to false`() {
+    assertFalse(config.isMigrateFromFileOnStartup)
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcClientServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcClientServiceTest.kt
@@ -1,0 +1,131 @@
+package org.stellar.anchor.platform.data
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import java.util.Optional
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.client.ClientConfig.ClientType
+import org.stellar.anchor.client.CustodialClient
+import org.stellar.anchor.client.NonCustodialClient
+
+class JdbcClientServiceTest {
+
+  @MockK(relaxed = true) private lateinit var repo: JdbcClientConfigRepo
+
+  private lateinit var service: JdbcClientService
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    service = JdbcClientService(repo)
+  }
+
+  private fun custodialRow(name: String, signingKeys: Set<String>) =
+    JdbcClientConfig().apply {
+      this.name = name
+      this.type = ClientType.CUSTODIAL
+      this.signingKeys = signingKeys.toMutableSet()
+      setAllowAnyDestination(true)
+      this.callbackUrlSep31 = "https://example.com/sep31"
+    }
+
+  private fun nonCustodialRow(name: String, domains: Set<String>) =
+    JdbcClientConfig().apply {
+      this.name = name
+      this.type = ClientType.NONCUSTODIAL
+      this.domains = domains.toMutableSet()
+      this.callbackUrlSep24 = "https://example.com/sep24"
+    }
+
+  @Test
+  fun `getClientConfigByDomain queries the repo and maps to a NonCustodialClient`() {
+    every { repo.findByDomain("vibrantapp.com") } returns
+      nonCustodialRow("VIBRANT", setOf("vibrantapp.com"))
+
+    val result = service.getClientConfigByDomain("vibrantapp.com")
+
+    assertTrue(result is NonCustodialClient)
+    assertEquals("VIBRANT", result!!.name)
+    assertEquals(setOf("vibrantapp.com"), result.domains)
+    assertEquals("https://example.com/sep24", result.callbackUrls.sep24)
+  }
+
+  @Test
+  fun `getClientConfigByDomain returns null when the repo finds nothing`() {
+    every { repo.findByDomain("unknown.com") } returns null
+
+    assertNull(service.getClientConfigByDomain("unknown.com"))
+  }
+
+  @Test
+  fun `getClientConfigBySigningKey queries the repo and maps to a CustodialClient`() {
+    every { repo.findBySigningKey("GALICE") } returns custodialRow("MGI", setOf("GALICE"))
+
+    val result = service.getClientConfigBySigningKey("GALICE")
+
+    assertTrue(result is CustodialClient)
+    assertEquals("MGI", result!!.name)
+    assertEquals(setOf("GALICE"), result.signingKeys)
+    assertTrue(result.isAllowAnyDestination)
+  }
+
+  @Test
+  fun `getClientConfigByDomainAndAccount prefers the domain match over the account match`() {
+    every { repo.findByDomain("vibrantapp.com") } returns
+      nonCustodialRow("VIBRANT", setOf("vibrantapp.com"))
+    every { repo.findBySigningKey("GALICE") } returns custodialRow("MGI", setOf("GALICE"))
+
+    val result = service.getClientConfigByDomainAndAccount("vibrantapp.com", "GALICE")
+
+    assertEquals("VIBRANT", result!!.name)
+  }
+
+  @Test
+  fun `getClientConfigByDomainAndAccount falls back to the account match`() {
+    every { repo.findByDomain("unknown.com") } returns null
+    every { repo.findBySigningKey("GALICE") } returns custodialRow("MGI", setOf("GALICE"))
+
+    val result = service.getClientConfigByDomainAndAccount("unknown.com", "GALICE")
+
+    assertEquals("MGI", result!!.name)
+  }
+
+  @Test
+  fun `getClientConfigByName queries by primary key and maps by type`() {
+    every { repo.findById("MGI") } returns Optional.of(custodialRow("MGI", setOf("GALICE")))
+    every { repo.findById("VIBRANT") } returns
+      Optional.of(nonCustodialRow("VIBRANT", setOf("vibrantapp.com")))
+    every { repo.findById("UNKNOWN") } returns Optional.empty()
+
+    assertTrue(service.getClientConfigByName("MGI") is CustodialClient)
+    assertTrue(service.getClientConfigByName("VIBRANT") is NonCustodialClient)
+    assertNull(service.getClientConfigByName("UNKNOWN"))
+  }
+
+  @Test
+  fun `getCustodialClients and getNonCustodialClients only return their own type`() {
+    every { repo.findByType(ClientType.CUSTODIAL) } returns
+      listOf(custodialRow("MGI", setOf("GALICE")))
+    every { repo.findByType(ClientType.NONCUSTODIAL) } returns
+      listOf(nonCustodialRow("VIBRANT", setOf("vibrantapp.com")))
+
+    assertEquals(listOf("MGI"), service.custodialClients.map { it.name })
+    assertEquals(listOf("VIBRANT"), service.nonCustodialClients.map { it.name })
+  }
+
+  @Test
+  fun `getAllClients maps every row regardless of type`() {
+    every { repo.findAll() } returns
+      listOf(
+        custodialRow("MGI", setOf("GALICE")),
+        nonCustodialRow("VIBRANT", setOf("vibrantapp.com")),
+      )
+
+    val names = service.allClients.map { it.name }.toSet()
+
+    assertEquals(setOf("MGI", "VIBRANT"), names)
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigImportRunnerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigImportRunnerTest.kt
@@ -1,0 +1,60 @@
+package org.stellar.anchor.platform.service
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.exception.BadRequestException
+import org.stellar.anchor.client.ClientConfig.ClientType
+import org.stellar.anchor.config.ClientsConfig
+import org.stellar.anchor.config.ClientsConfig.RawClient
+
+class ClientConfigImportRunnerTest {
+
+  @MockK(relaxed = true) private lateinit var clientsConfig: ClientsConfig
+  @MockK(relaxed = true) private lateinit var clientConfigService: ClientConfigService
+
+  private lateinit var runner: ClientConfigImportRunner
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    runner = ClientConfigImportRunner(clientsConfig, clientConfigService)
+  }
+
+  private fun rawCustodial(name: String) =
+    RawClient.builder().name(name).type(ClientType.CUSTODIAL).signingKeys(setOf("GALICE")).build()
+
+  @Test
+  fun `run upserts every item from clientsConfig`() {
+    every { clientsConfig.items } returns listOf(rawCustodial("MGI"), rawCustodial("VIBRANT"))
+
+    runner.run()
+
+    verify(exactly = 1) { clientConfigService.upsert("MGI", any()) }
+    verify(exactly = 1) { clientConfigService.upsert("VIBRANT", any()) }
+  }
+
+  @Test
+  fun `run continues past a single item failure`() {
+    every { clientsConfig.items } returns listOf(rawCustodial("BAD"), rawCustodial("GOOD"))
+    every { clientConfigService.upsert("BAD", any()) } throws BadRequestException("boom")
+
+    assertDoesNotThrow { runner.run() }
+
+    verify(exactly = 1) { clientConfigService.upsert("BAD", any()) }
+    verify(exactly = 1) { clientConfigService.upsert("GOOD", any()) }
+  }
+
+  @Test
+  fun `run does nothing when clientsConfig has no items`() {
+    every { clientsConfig.items } returns emptyList()
+
+    assertDoesNotThrow { runner.run() }
+
+    verify(exactly = 0) { clientConfigService.upsert(any(), any()) }
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
@@ -232,4 +232,166 @@ class ClientConfigServiceTest {
 
     verify(exactly = 1) { repo.deleteById("MGI") }
   }
+
+  @Test
+  fun `addSigningKey adds a key without disturbing the existing ones`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE", "GBOB")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    val response = service.addSigningKey("DING", "GCAROL")
+
+    assertEquals(setOf("GALICE", "GBOB", "GCAROL"), saved.captured.signingKeys)
+    assertEquals(setOf("GALICE", "GBOB", "GCAROL"), response.signingKeys)
+  }
+
+  @Test
+  fun `addSigningKey throws NotFoundException when the client does not exist`() {
+    every { repo.findById("UNKNOWN") } returns Optional.empty()
+
+    assertThrows(NotFoundException::class.java) { service.addSigningKey("UNKNOWN", "GALICE") }
+  }
+
+  @Test
+  fun `addSigningKey translates a unique constraint violation into a clean BadRequestException`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+    every { repo.save(any()) } throws
+      DataIntegrityViolationException(
+        "duplicate key",
+        RuntimeException(
+          "ERROR: duplicate key value violates unique constraint \"idx_client_signing_key_key\""
+        ),
+      )
+
+    val ex =
+      assertThrows(BadRequestException::class.java) {
+        service.addSigningKey("DING", "GALREADYUSEDBYSOMEONEELSE")
+      }
+    assertEquals("domain or signing key is already in use by another client", ex.message)
+  }
+
+  @Test
+  fun `removeSigningKey removes only the requested key`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE", "GBOB")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    service.removeSigningKey("DING", "GALICE")
+
+    assertEquals(setOf("GBOB"), saved.captured.signingKeys)
+  }
+
+  @Test
+  fun `removeSigningKey throws NotFoundException when the client does not exist`() {
+    every { repo.findById("UNKNOWN") } returns Optional.empty()
+
+    assertThrows(NotFoundException::class.java) { service.removeSigningKey("UNKNOWN", "GALICE") }
+  }
+
+  @Test
+  fun `removeSigningKey throws NotFoundException when the key isn't on the client`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+
+    assertThrows(NotFoundException::class.java) { service.removeSigningKey("DING", "GNEVERADDED") }
+  }
+
+  @Test
+  fun `removeSigningKey rejects removing the last signing key of a custodial client`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+
+    assertThrows(BadRequestException::class.java) { service.removeSigningKey("DING", "GALICE") }
+    verify(exactly = 0) { repo.save(any()) }
+  }
+
+  @Test
+  fun `addDestinationAccount adds an account without disturbing the existing ones`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+        destinationAccounts = mutableSetOf("GWALLET1")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    val response = service.addDestinationAccount("DING", "GWALLET2")
+
+    assertEquals(setOf("GWALLET1", "GWALLET2"), saved.captured.destinationAccounts)
+    assertEquals(setOf("GWALLET1", "GWALLET2"), response.destinationAccounts)
+  }
+
+  @Test
+  fun `addDestinationAccount throws NotFoundException when the client does not exist`() {
+    every { repo.findById("UNKNOWN") } returns Optional.empty()
+
+    assertThrows(NotFoundException::class.java) {
+      service.addDestinationAccount("UNKNOWN", "GWALLET1")
+    }
+  }
+
+  @Test
+  fun `removeDestinationAccount removes only the requested account`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+        destinationAccounts = mutableSetOf("GWALLET1", "GWALLET2")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    service.removeDestinationAccount("DING", "GWALLET1")
+
+    assertEquals(setOf("GWALLET2"), saved.captured.destinationAccounts)
+  }
+
+  @Test
+  fun `removeDestinationAccount throws NotFoundException when the account isn't on the client`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "DING"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+        destinationAccounts = mutableSetOf("GWALLET1")
+      }
+    every { repo.findById("DING") } returns Optional.of(existing)
+
+    assertThrows(NotFoundException::class.java) {
+      service.removeDestinationAccount("DING", "GNEVERADDED")
+    }
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
@@ -3,12 +3,14 @@ package org.stellar.anchor.platform.service
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import java.util.Optional
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.dao.DataIntegrityViolationException
 import org.stellar.anchor.api.exception.BadRequestException
 import org.stellar.anchor.api.exception.NotFoundException
@@ -21,13 +23,15 @@ import org.stellar.anchor.platform.data.JdbcClientConfigRepo
 class ClientConfigServiceTest {
 
   @MockK(relaxed = true) private lateinit var repo: JdbcClientConfigRepo
+  private lateinit var repoProvider: ObjectProvider<JdbcClientConfigRepo>
 
   private lateinit var service: ClientConfigService
 
   @BeforeEach
   fun setUp() {
     MockKAnnotations.init(this, relaxUnitFun = true)
-    service = ClientConfigService(repo)
+    repoProvider = mockk { every { getObject() } returns repo }
+    service = ClientConfigService(repoProvider)
   }
 
   private fun custodialRequest(signingKeys: Set<String> = setOf("GALICE")) =
@@ -117,13 +121,61 @@ class ClientConfigServiceTest {
   }
 
   @Test
-  fun `upsert translates a unique constraint violation into a clean BadRequestException`() {
+  fun `upsert translates a known unique constraint violation into a clean BadRequestException`() {
     every { repo.findById("MGI") } returns Optional.empty()
-    every { repo.save(any()) } throws DataIntegrityViolationException("duplicate key")
+    every { repo.save(any()) } throws
+      DataIntegrityViolationException(
+        "duplicate key",
+        RuntimeException(
+          "ERROR: duplicate key value violates unique constraint \"idx_client_signing_key_key\""
+        ),
+      )
 
     val ex =
       assertThrows(BadRequestException::class.java) { service.upsert("MGI", custodialRequest()) }
     assertEquals("domain or signing key is already in use by another client", ex.message)
+  }
+
+  @Test
+  fun `upsert rethrows a DataIntegrityViolationException that isn't a known unique constraint`() {
+    every { repo.findById("MGI") } returns Optional.empty()
+    val unrelated =
+      DataIntegrityViolationException("not-null constraint violated on some other column")
+    every { repo.save(any()) } throws unrelated
+
+    val thrown =
+      assertThrows(DataIntegrityViolationException::class.java) {
+        service.upsert("MGI", custodialRequest())
+      }
+    assertSame(unrelated, thrown)
+  }
+
+  @Test
+  fun `upsert clears previously stored callback URLs when the request omits them`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "MGI"
+        type = ClientType.CUSTODIAL
+        callbackUrlSep24 = "https://old.example.com/sep24"
+      }
+    every { repo.findById("MGI") } returns Optional.of(existing)
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    service.upsert("MGI", custodialRequest())
+
+    assertNull(saved.captured.callbackUrlSep24)
+  }
+
+  @Test
+  fun `upsert rejects a callback URL with a non-http scheme`() {
+    every { repo.findById("VIBRANT") } returns Optional.empty()
+    val request =
+      nonCustodialRequest().apply {
+        callbackUrls = CallbackUrls.builder().sep24("file:///etc/passwd").build()
+      }
+
+    assertThrows(BadRequestException::class.java) { service.upsert("VIBRANT", request) }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
@@ -218,6 +218,42 @@ class ClientConfigServiceTest {
   }
 
   @Test
+  fun `listCustodial returns only custodial clients`() {
+    every { repo.findByType(ClientType.CUSTODIAL) } returns
+      listOf(
+        JdbcClientConfig().apply {
+          name = "MGI"
+          type = ClientType.CUSTODIAL
+        }
+      )
+
+    val result = service.listCustodial()
+
+    assertEquals(1, result.size)
+    assertEquals("MGI", result[0].name)
+    assertEquals(ClientType.CUSTODIAL, result[0].type)
+    verify(exactly = 0) { repo.findByType(ClientType.NONCUSTODIAL) }
+  }
+
+  @Test
+  fun `listNonCustodial returns only noncustodial clients`() {
+    every { repo.findByType(ClientType.NONCUSTODIAL) } returns
+      listOf(
+        JdbcClientConfig().apply {
+          name = "VIBRANT"
+          type = ClientType.NONCUSTODIAL
+        }
+      )
+
+    val result = service.listNonCustodial()
+
+    assertEquals(1, result.size)
+    assertEquals("VIBRANT", result[0].name)
+    assertEquals(ClientType.NONCUSTODIAL, result[0].type)
+    verify(exactly = 0) { repo.findByType(ClientType.CUSTODIAL) }
+  }
+
+  @Test
   fun `delete throws NotFoundException instead of silently no-oping`() {
     every { repo.existsById("UNKNOWN") } returns false
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/ClientConfigServiceTest.kt
@@ -1,0 +1,183 @@
+package org.stellar.anchor.platform.service
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import io.mockk.verify
+import java.util.Optional
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
+import org.stellar.anchor.api.exception.BadRequestException
+import org.stellar.anchor.api.exception.NotFoundException
+import org.stellar.anchor.client.ClientConfig.CallbackUrls
+import org.stellar.anchor.client.ClientConfig.ClientType
+import org.stellar.anchor.platform.controller.platform.ClientConfigRequest
+import org.stellar.anchor.platform.data.JdbcClientConfig
+import org.stellar.anchor.platform.data.JdbcClientConfigRepo
+
+class ClientConfigServiceTest {
+
+  @MockK(relaxed = true) private lateinit var repo: JdbcClientConfigRepo
+
+  private lateinit var service: ClientConfigService
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    service = ClientConfigService(repo)
+  }
+
+  private fun custodialRequest(signingKeys: Set<String> = setOf("GALICE")) =
+    ClientConfigRequest().apply {
+      type = ClientType.CUSTODIAL
+      this.signingKeys = signingKeys
+      setAllowAnyDestination(false)
+    }
+
+  private fun nonCustodialRequest(domains: Set<String> = setOf("vibrantapp.com")) =
+    ClientConfigRequest().apply {
+      type = ClientType.NONCUSTODIAL
+      this.domains = domains
+      callbackUrls = CallbackUrls.builder().sep24("https://vibrantapp.com/callback").build()
+    }
+
+  @Test
+  fun `upsert creates a new custodial client and saves it`() {
+    every { repo.findById("MGI") } returns Optional.empty()
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    val response = service.upsert("MGI", custodialRequest())
+
+    assertEquals("MGI", response.name)
+    assertEquals(ClientType.CUSTODIAL, response.type)
+    assertEquals(setOf("GALICE"), response.signingKeys)
+  }
+
+  @Test
+  fun `upsert updates an existing entity rather than creating a duplicate`() {
+    val existing =
+      JdbcClientConfig().apply {
+        name = "MGI"
+        type = ClientType.CUSTODIAL
+      }
+    every { repo.findById("MGI") } returns Optional.of(existing)
+    val saved = slot<JdbcClientConfig>()
+    every { repo.save(capture(saved)) } answers { saved.captured }
+
+    service.upsert("MGI", custodialRequest(setOf("GNEWKEY")))
+
+    assertSame(existing, saved.captured)
+    assertEquals(setOf("GNEWKEY"), saved.captured.signingKeys)
+  }
+
+  @Test
+  fun `upsert rejects a custodial client with no signing keys`() {
+    every { repo.findById("MGI") } returns Optional.empty()
+
+    assertThrows(BadRequestException::class.java) {
+      service.upsert("MGI", custodialRequest(emptySet()))
+    }
+  }
+
+  @Test
+  fun `upsert rejects a noncustodial client with no domains`() {
+    every { repo.findById("VIBRANT") } returns Optional.empty()
+
+    assertThrows(BadRequestException::class.java) {
+      service.upsert("VIBRANT", nonCustodialRequest(emptySet()))
+    }
+  }
+
+  @Test
+  fun `upsert rejects a malformed callback URL`() {
+    every { repo.findById("VIBRANT") } returns Optional.empty()
+    val request =
+      nonCustodialRequest().apply {
+        callbackUrls = CallbackUrls.builder().sep24("not-a-url").build()
+      }
+
+    assertThrows(BadRequestException::class.java) { service.upsert("VIBRANT", request) }
+  }
+
+  @Test
+  fun `upsert rejects a missing type`() {
+    every { repo.findById("MGI") } returns Optional.empty()
+    val request = ClientConfigRequest().apply { signingKeys = setOf("GALICE") }
+
+    assertThrows(BadRequestException::class.java) { service.upsert("MGI", request) }
+  }
+
+  @Test
+  fun `upsert rejects a blank client name`() {
+    assertThrows(BadRequestException::class.java) { service.upsert(" ", custodialRequest()) }
+  }
+
+  @Test
+  fun `upsert translates a unique constraint violation into a clean BadRequestException`() {
+    every { repo.findById("MGI") } returns Optional.empty()
+    every { repo.save(any()) } throws DataIntegrityViolationException("duplicate key")
+
+    val ex =
+      assertThrows(BadRequestException::class.java) { service.upsert("MGI", custodialRequest()) }
+    assertEquals("domain or signing key is already in use by another client", ex.message)
+  }
+
+  @Test
+  fun `get throws NotFoundException when the client does not exist`() {
+    every { repo.findById("UNKNOWN") } returns Optional.empty()
+
+    assertThrows(NotFoundException::class.java) { service.get("UNKNOWN") }
+  }
+
+  @Test
+  fun `get returns the mapped response when the client exists`() {
+    val entity =
+      JdbcClientConfig().apply {
+        name = "MGI"
+        type = ClientType.CUSTODIAL
+        signingKeys = mutableSetOf("GALICE")
+      }
+    every { repo.findById("MGI") } returns Optional.of(entity)
+
+    val response = service.get("MGI")
+
+    assertEquals("MGI", response.name)
+    assertEquals(setOf("GALICE"), response.signingKeys)
+  }
+
+  @Test
+  fun `list maps every row returned by the repo`() {
+    every { repo.findAll() } returns
+      listOf(
+        JdbcClientConfig().apply {
+          name = "MGI"
+          type = ClientType.CUSTODIAL
+        }
+      )
+
+    val result = service.list()
+
+    assertEquals(1, result.size)
+    assertEquals("MGI", result[0].name)
+  }
+
+  @Test
+  fun `delete throws NotFoundException instead of silently no-oping`() {
+    every { repo.existsById("UNKNOWN") } returns false
+
+    assertThrows(NotFoundException::class.java) { service.delete("UNKNOWN") }
+  }
+
+  @Test
+  fun `delete removes an existing client`() {
+    every { repo.existsById("MGI") } returns true
+
+    service.delete("MGI")
+
+    verify(exactly = 1) { repo.deleteById("MGI") }
+  }
+}

--- a/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
+++ b/service-runner/src/main/kotlin/org/stellar/anchor/platform/TestProfileRunner.kt
@@ -11,6 +11,7 @@ import java.util.*
 import kotlinx.coroutines.*
 import org.springframework.context.ConfigurableApplicationContext
 import org.stellar.anchor.util.Log.info
+import org.stellar.anchor.util.Log.warn
 
 const val RUN_DOCKER = "run.docker"
 const val RUN_ALL_SERVERS = "run.all.servers"
@@ -86,7 +87,13 @@ class TestProfileExecutor(val config: TestConfig) {
       if (envMap["clients.value"] != null) {
         // If clients.value not found, try to load it from resources
         if (!File(envMap["clients.value"]!!).exists()) {
-          envMap["clients.value"] = getResourceFile(envMap["clients.value"]!!).absolutePath
+          try {
+            envMap["clients.value"] = getResourceFile(envMap["clients.value"]!!).absolutePath
+          } catch (e: RuntimeException) {
+            warn(
+              "clients.value is not a file path or resource, treating it as inline content: ${e.message}"
+            )
+          }
         }
       }
       if (envMap["sep1.toml.type"] != "url" && envMap["sep1.toml.type"] != "string") {

--- a/service-runner/src/main/resources/profiles/clients-db/config.env
+++ b/service-runner/src/main/resources/profiles/clients-db/config.env
@@ -1,0 +1,2 @@
+clients.type=db
+clients.value=/config/clients.yaml

--- a/service-runner/src/main/resources/profiles/clients-db/test.env
+++ b/service-runner/src/main/resources/profiles/clients-db/test.env
@@ -1,0 +1,1 @@
+# Inherits all values from the `default` profile's test.env (run.all.servers=true, etc).


### PR DESCRIPTION
### Description

Raised by an anchor running the Anchor Platform: their partner-config YAML has grown to ~1,200 lines, and every change requires a rolling restart on their end. They asked whether config could move to the AP database instead — either AP checking the DB directly per request, or AP refreshing an in-memory cache every ~60 minutes — so onboarding a new partner (their stated goal is to automate onboarding as much as possible) or updating an existing one no longer needs a restart on their end.

Client (wallet) definitions — SEP-10 signing keys, SEP-24 domains, callback URLs, destination accounts — are configured today via `clients.type: file|inline|json|yaml`, parsed once into an in-memory list at startup. Every lookup is a linear scan over that list, onboarding or revoking a single wallet means editing one shared YAML/JSON file, and any change requires a full restart. That breaks down past a few hundred clients: at 600+ entries the file becomes unwieldy to hand-edit safely, and there is no way to add or revoke a client without redeploying.

Three designs were prototyped before this one: an in-memory cache refreshed on a timer/signal (the anchor's 60-minute-refresh suggestion; largest diff, up to an hour of staleness), a purely live DB lookup on every request (the anchor's other suggestion — AP checks the DB directly; simplest, but a DB round trip on every SEP-10/24/6/31/12 call), and this one — DB-backed live lookup, but only at SEP-10/SEP-45 auth time. This PR implements the third: SEP-10/SEP-45 resolve the client once via `ClientFinder` against the database and stamp the result into a new `client_name` JWT claim; SEP-6/12/24/31 read `token.getClientName()` directly instead of each doing their own lookup. That removes the per-request database traffic the live-lookup-only design would add on every SEP-6/12/24/31 call, at the cost of client changes not taking effect for a session until its JWT expires (see Known limitations).

A full REST API on the platform server lets anchors manage clients without a restart: `PUT`/`GET`/`DELETE /clients/{name}`, `GET /clients` (all), `GET /clients/custodial` / `GET /clients/non-custodial` (filtered by type), plus incremental `POST`/`DELETE /clients/{name}/signing-keys/{key}` and `/destination-accounts/{account}`. The incremental endpoints exist specifically for high-volume clients — one anchor's production config has a single custodial client with 600+ destination accounts — so adding or revoking one wallet doesn't require resending the entire list. Setting `clients.type: db` with `clients.value` still pointing at an existing file/yaml/json source auto-imports those clients into the database on every startup (upsert, not destructive), so an anchor can cut over without hand-transcribing every entry; switching `clients.type` away from `db` afterward does not delete the imported rows.

**Changes**
- [x] `ClientsConfig.java`: adds a `db` `ClientsConfigType`. (No separate migration flag — see below.)
- [x] `WebAuthJwt.java`: adds a `client_name` claim field, populated from the decoded JWT.
- [x] `JwtService.encode`: emits the `CLIENT_NAME` claim when `token.getClientName()` is set (the claim key already existed for the SEP-24 interactive/more-info JWTs; this reuses it for the SEP-10/45 web-auth JWT).
- [x] `Sep10Service.generateWebAuthJwt`: resolves `clientFinder.getClientName(clientDomain, account)` once, at token-issuance time, and stamps it onto the token before encoding. `validateChallenge`/`generateWebAuthJwt` now declare `throws SepException` (was `SepValidationException`) so a `SepNotAuthorizedException` from client resolution propagates and the login is refused, instead of silently issuing a token with no client name.
- [x] `Sep45Service.validate`: same resolve-and-stamp for the SEP-45 contract-account flow; adds a `ClientFinder` dependency.
- [x] `Sep6Service`, `Sep24Service`, `Sep12Service`, `Sep31Service`: drop their own `ClientFinder`/`ClientService` lookups; each now reads `token.getClientName()` (or `Context.get().getWebAuthJwt().getClientName()` for SEP-31) directly, since SEP-10/45 already vetted it.
- [x] `V32__client_config.sql` (new): creates `client_config`, `client_domain`, `client_signing_key`, `client_destination_account`, with unique indexes on `domain` and `signing_key` — a hard constraint the file-based config never enforced.
- [x] `JdbcClientConfig.java` (new): JPA entity for the tables above.
- [x] `JdbcClientConfigRepo.java` (new): Spring Data repo with indexed `findByDomain`/`findBySigningKey`/`findByType` queries, `@EntityGraph`-annotated so `signingKeys`/`domains`/`destinationAccounts` are eagerly fetched (avoids a `LazyInitializationException` when a config bean reads them outside a request-scoped Hibernate session).
- [x] `JdbcClientService.java` (new): `ClientService` implementation backed directly by `JdbcClientConfigRepo` — every lookup is a live, indexed query, no in-memory copy.
- [x] `PropertyClientsConfig.java`: `type: db` auto-detects and parses `clients.value` (file path, inline YAML, or inline JSON) into `items` for import, without clearing any items already bound directly; no separate migration flag.
- [x] `PropertySep10Config.java`: `clientService` field marked `transient` — it's a JDK dynamic proxy (inherent to any Spring Data repo/service, not specific to `@Transactional`), and Gson would otherwise try to reflectively serialize it during debug logging and fail on a JPMS `InaccessibleObjectException`.
- [x] `ClientConfigController.java`, `ClientConfigRequest.java`, `ClientConfigResponse.java` (new): `PUT`/`GET`/`GET all`/`DELETE /clients/{name}`, `GET /clients/custodial`, `GET /clients/non-custodial`, and `POST`/`DELETE /clients/{name}/signing-keys/{key}` + `/destination-accounts/{account}`, behind the same auth as the rest of the Platform API (see Known limitations).
- [x] `ClientConfigService.java` (new): validates and upserts/gets/lists/deletes clients, plus the incremental add/remove-signing-key and add/remove-destination-account operations (rejecting removal of a custodial client's last signing key); translates a `DataIntegrityViolationException` (duplicate domain/signing key) into a clean 400 instead of a raw SQL error.
- [x] `ClientConfigImportRunner.java` (new): a `CommandLineRunner`, gated only on `clients.type=db`, that imports every client currently resolvable from `clients.value` into the database on each startup (upsert — safe to run repeatedly), logging and skipping any individual client that fails to import rather than aborting startup.
- [x] `ClientsBeans.clientService`: returns `JdbcClientService` when `clients.type: db`, otherwise the existing `DefaultClientService`.
- [x] `PlatformServerBeans.java`: registers `ClientConfigService` and the conditional `ClientConfigImportRunner`.
- [x] `SepBeans.java`: drops `ClientFinder`/`ClientService` constructor args from the SEP-6/12/24/31 beans; adds `sep45` to `ClientFinder`'s enabled-SEPs list and wires it into the `Sep45Service` bean.
- [x] `Sep10Controller.validateChallenge`: throws clause widened to `SepException`.
- [x] `TestProfileRunner.kt`: fixes a test-harness bug where inline `clients.value` content (JSON/YAML, not a file path) was unconditionally treated as a classpath resource and crashed with `RuntimeException("Resource ... not found")`; now falls back to treating it as inline content with a warning log.
- [x] `anchor-config-default-values.yaml`: documents the new `type: db` option and its auto-import behavior (corrected from an earlier draft of this doc that described a since-removed `migrate_from_file_on_startup` flag).
- [x] `Sep10ServiceTest.kt`, `Sep45ServiceTest.kt`: new cases asserting `client_name` is stamped onto the JWT, and that a `ClientFinder` authorization failure propagates instead of issuing a token with no client name.
- [x] `Sep12ServiceTest.kt`, `Sep24ServiceTest.kt`, `Sep31ServiceTest.kt`, `Sep6ServiceTest.kt`: updated to set/read `token.getClientName()` directly instead of mocking `ClientFinder`.
- [x] `JdbcClientServiceTest.kt` (new, 8 tests): domain/signing-key/name resolution, domain-preferred-over-account-match precedence, custodial-vs-noncustodial filtering.
- [x] `PropertyClientsConfigTest.kt` (new, 5 tests): `type: db` with no value, with a YAML/JSON string, with a file path, and with items already bound directly — none of the four clear or duplicate the item list.
- [x] `ClientConfigImportRunnerTest.kt` (new, 3 tests): upserts every item, continues past a single item's import failure, no-ops on an empty list.
- [x] `ClientConfigServiceTest.kt` (29 tests): full coverage of validation, upsert-conflict handling, list/get/delete, and the incremental signing-key/destination-account add/remove operations including the custodial-last-key protection and cross-client uniqueness conflicts.
- [x] `ClientConfigApiTests.kt` (essential-tests, 19 tests): real-HTTP coverage against a live Postgres for the full `/clients` REST surface — CRUD lifecycle, 404s, validation (missing signing keys, no domain on a noncustodial client, malformed callback URL, unknown type, domain/signing-key collisions across clients), the four incremental endpoints (additive without disturbing existing entries, 404 on an unknown sub-resource, cross-client conflict, last-signing-key protection), and the two type-filtered list endpoints.
- [x] `ClientsDbAttributionTests.kt` + `ClientsDbTestSuite.kt` (new, extended-tests, 4 tests): the one thing essential-tests can't cover, since it only runs against the default profile's `clients.type: file`. A new `clients-db` service-runner profile (`clients.type: db`, wired into `sub_extended_tests.yml`) boots a real server with the DB-backed path active, and this suite runs an actual SEP-10 challenge/validate against it, decodes the resulting JWT, and asserts `client_name` is attributed correctly on create, follows a signing key moved between clients, stays unset for an unregistered key, and disappears after the client is deleted.

**Acceptance Criteria**
- [x] `PUT /clients/{name}` with a valid custodial or noncustodial payload creates the client and returns it; a second `PUT` to the same name updates rather than duplicates.
- [x] `GET /clients/{name}` and `GET /clients` reflect what's stored; `GET /clients/{unknown}` returns 404. `GET /clients/custodial` and `GET /clients/non-custodial` return only clients of the matching type.
- [x] `PUT` with a signing key or domain already used by another client, a noncustodial client with no domain, a custodial client with no signing keys, a malformed callback URL, or an unrecognized type all return 400 without creating/mutating a row.
- [x] `POST /clients/{name}/signing-keys/{key}` and `/destination-accounts/{account}` add without disturbing existing entries; the corresponding `DELETE` removes only the targeted entry; both 404 on an unknown client or an entry that isn't present; adding a signing key already used by another client returns 400; removing a custodial client's last signing key returns 400.
- [x] `DELETE /clients/{name}` removes the client and its domain/signing-key/destination-account rows; a subsequent `GET` returns 404.
- [x] With `clients.type: db`, a SEP-10 or SEP-45 login for a signing key/domain that matches a client in the database stamps that client's name into the `client_name` JWT claim — verified end-to-end (real HTTP, real Postgres) via `ClientsDbAttributionTests`, not just at the unit level.
- [x] With `sep10.client_attribution_required: true`, a login for a signing key/domain not in the database (or not on the allow list) is rejected outright, not issued a token with a null client name.
- [x] SEP-6/12/24/31 requests authenticated with such a token attribute the resulting transaction/event to that `client_name`, without making their own database call to resolve it.
- [x] With `clients.type: db` and `clients.value` pointing at an existing file/yaml/json source, every client there is upserted into the database on startup, and startup does not fail if one client fails to import.
- [x] Existing `clients.type: file|inline|json|yaml` deployments are unaffected — `clients.type: db` is opt-in, and switching away from it afterward does not delete previously-imported/managed rows.

### Context

Origin ask (anchor operator, paraphrased): their ~1,200-line partner-config YAML requires a rolling restart on every change; they asked for either AP-checks-DB-directly or a ~60-minute AP-side cache refresh, with automating partner onboarding as the underlying goal. A separate concrete follow-up from the same anchor: one of their custodial clients has 600+ destination accounts, and they didn't want to resend the full list to add or remove a single one — that's what the incremental signing-key/destination-account endpoints are for.

### Testing

- Unit: `./gradlew :core:test :platform:test` (includes `ClientConfigServiceTest`, `JdbcClientServiceTest`, `PropertyClientsConfigTest`, `ClientConfigImportRunnerTest`)
- Integration: `./gradlew runEssentialTests` (includes the expanded `ClientConfigApiTests`, real HTTP against a live Postgres)
- Extended: `TEST_PROFILE_NAME=clients-db ./gradlew startServersWithTestProfile` then `./gradlew :extended-tests:test --tests org.stellar.anchor.platform.suite.ClientsDbTestSuite` (real SEP-10 auth against a DB-backed server, wired into `sub_extended_tests.yml` for CI)
- Manual: full `PUT`/`GET`/`GET all`/incremental-endpoint round trips against a running server, verified against a live Postgres, including a full clean-restart migration of an existing file-based config into the database.

### Documentation

`anchor-config-default-values.yaml` updated with the `clients.type: db` option, its auto-import behavior, and the two new incremental-endpoint / type-filtered-list capabilities.

### Known limitations

N/A

### Migrating `clients.type` to `db`

This is the guide for anchors moving their client configuration (custodial and non-custodial
wallets, signing keys, domains, callback URLs, destination accounts) off a static `file`/`yaml`/
`json` config and onto the new `db`-backed option, where clients are managed live through the
`/clients` REST API instead of a redeploy.

<!-- TOC -->
* [Why move to `db`](#why-move-to-db)
* [Prerequisites](#prerequisites)
* [1. Point `clients` at `db`](#1-point-clients-at-db)
* [2. Start the platform server once to import](#2-start-the-platform-server-once-to-import)
* [3. Stop re-importing on every restart](#3-stop-re-importing-on-every-restart)
* [4. Verify the import](#4-verify-the-import)
* [Managing clients going forward](#managing-clients-going-forward)
* [Validation rules and constraints](#validation-rules-and-constraints)
* [Rolling back](#rolling-back)
* [Troubleshooting](#troubleshooting)
<!-- TOC -->

## Why move to `db`

With `clients.type` set to `file`, `yaml`, or `json`, the client list is fixed at deploy time —
onboarding or updating a wallet means editing the config and restarting the platform server. With
`clients.type=db`, the same client records live in the database and are managed through
`PUT`/`GET`/`DELETE` calls on `/clients`, so onboarding a new wallet doesn't require a deploy.

## Prerequisites

- **A relational database, not the default `h2`.** `data.type` must be `postgres` or `aurora`.
  The in-memory `h2` default won't persist client rows across restarts, and `sqlite` doesn't
  support Flyway's foreign-key migrations.
- **Flyway enabled.** `data.flyway_enabled=true`. On first startup against that database, Flyway
  applies `V32__client_config.sql`, which creates four tables: `client_config`, `client_domain`,
  `client_signing_key`, and `client_destination_account`. No manual migration step is needed
  beyond having Flyway on.
- **Platform API auth already configured.** The `/clients` endpoints live on the platform server
  and are protected the same way as the rest of the Platform API (`platform_api.auth.type`: `JWT`
  or `API_KEY`). If you can already call other Platform API endpoints (e.g. `PATCH
  /transactions`), you can call `/clients`.

## 1. Point `clients` at `db`

```properties
clients.type=db
clients.value=path/to/your/existing/clients.yaml
```

`clients.value` can stay pointed at whatever file (or inline YAML/JSON string) you were already
using with `type=file`/`yaml`/`json` — the format is unchanged. On `db`, that value is no longer
read by the running server; it's only used once, on startup, to seed the database.

## 2. Start the platform server once to import

On startup, if `clients.type=db`, a one-time `CommandLineRunner` reads every client out of
`clients.value` and upserts it into the database by name. Check the startup logs for:

```
Imported {N} of {N} clients into the database
```

A per-client failure (e.g. a duplicate signing key) is logged and skipped — it doesn't stop the
other clients from importing or block startup.

## 3. Stop re-importing on every restart

This import isn't a one-shot migration flag — it runs on **every** startup where
`clients.type=db` and `clients.value` is non-empty, and it re-upserts every client from that file
each time, overwriting whatever is currently in the database for those client names. Once you've
confirmed the import succeeded, clear the value so subsequent restarts don't clobber changes made
through the API afterward:

```properties
clients.type=db
clients.value=
```

## 4. Verify the import

```shell
curl -H "<your platform auth header>" http://localhost:8085/clients
```

Confirm the count and names match what was in your old config file.

## Managing clients going forward

| Method | Path | Purpose |
|---|---|---|
| `PUT` | `/clients/{name}` | Create or fully replace a client |
| `GET` | `/clients/{name}` | Fetch one client |
| `GET` | `/clients` | List all clients |
| `GET` | `/clients/custodial` | List custodial clients only |
| `GET` | `/clients/non-custodial` | List non-custodial clients only |
| `DELETE` | `/clients/{name}` | Delete a client |
| `POST` | `/clients/{name}/signing-keys/{signingKey}` | Add a signing key |
| `DELETE` | `/clients/{name}/signing-keys/{signingKey}` | Remove a signing key |
| `POST` | `/clients/{name}/destination-accounts/{account}` | Add a destination account |
| `DELETE` | `/clients/{name}/destination-accounts/{account}` | Remove a destination account |

`PUT` example (custodial client):

```shell
curl -X PUT -H "<your platform auth header>" -H "Content-Type: application/json" \
  http://localhost:8085/clients/my-wallet \
  -d '{"type":"custodial","signingKeys":["GABC...XYZ"]}'
```

## Validation rules and constraints

- A custodial client needs at least one signing key; a non-custodial client needs at least one
  domain. Requests violating this are rejected with `400`.
- A signing key or domain can only belong to one client at a time — `client_domain.domain` and
  `client_signing_key.signing_key` are both unique across all clients. Reusing one on a different
  client returns `400`.
- You can't remove the last signing key from a custodial client via `DELETE
  /clients/{name}/signing-keys/{signingKey}` — that also returns `400`.
- Callback URLs, when set, must parse as valid `http`/`https` URLs.

## Rolling back

Deleting client rows isn't required to roll back. Setting `clients.type` back to `file`, `yaml`,
or `json` (with `value` pointed at your old config) reverts to reading clients from that source;
the database rows are simply unused while `type` isn't `db`.

## Troubleshooting

**Startup log shows fewer imported than expected, with no per-client error.** Check for a
duplicate signing key or domain across clients in your source file — the import calls the same
uniqueness-checked upsert the API uses, so a collision there fails the same way a `PUT` would.

**Clients you edited through the API reverted after a restart.** `clients.value` is still set —
see [Stop re-importing on every restart](#3-stop-re-importing-on-every-restart).

**`/clients` returns `404 Not Found` on a client you're sure exists.** Client lookups are by
name and are case-sensitive; confirm the exact `name` used in the original `PUT`.
