### PR TITLE
chore(release): bump version to 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://badgen.net/badge/license/Apache%202/blue?icon=github&label=License)](https://github.com/stellar/anchor-platform/blob/develop/LICENSE)
 [![GitHub Version](https://badgen.net/github/release/stellar/anchor-platform?icon=github&label=Latest%20release)](https://github.com/stellar/anchor-platform/releases)
-[![Docker](https://badgen.net/badge/Latest%20Release/v4.6.2/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=4.6.2)
+[![Docker](https://badgen.net/badge/Latest%20Release/v4.7.0/blue?icon=docker)](https://hub.docker.com/r/stellar/anchor-platform/tags?page=1&name=4.7.0)
 ![Develop Branch](https://github.com/stellar/anchor-platform/actions/workflows/on_push_to_develop.yml/badge.svg?branch=develop)
 
 <div style="text-align: center">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,7 +213,7 @@ subprojects {
 
 allprojects {
   group = "org.stellar.anchor-sdk"
-  version = "4.6.2"
+  version = "4.7.0"
 
   tasks.jar {
     manifest {

--- a/service-runner/src/main/resources/version-info.properties
+++ b/service-runner/src/main/resources/version-info.properties
@@ -1,1 +1,1 @@
-version=4.6.2
+version=4.7.0


### PR DESCRIPTION
### Description

This bumps the version to 4.7.0

### Context

Release

### Testing

`./gradlew test`

### Documentation

N/A

### Known limitations

N/A

