### PR TITLE
[ANCHOR-1281]: SEP-12 customer-id ownership bypass in anchor-platform

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
+++ b/core/src/main/java/org/stellar/anchor/auth/WebAuthJwt.java
@@ -47,6 +47,11 @@ public abstract class WebAuthJwt extends AbstractJwt {
     return muxedAccount != null ? muxedAccount : account;
   }
 
+  public String getOwnerKey() {
+    String clientName = getClientName();
+    return (clientName != null ? clientName + ":" : "") + getOwnerAccount();
+  }
+
   public boolean hasClientNameClaim() {
     return claims.containsKey(CLIENT_NAME);
   }

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -125,10 +125,30 @@ public class Sep12Service {
     if (isNewCustomer || isNewSep31Customer) {
       String ownerAccount = token.getOwnerAccount();
       String ownerMemo = token.getOwnerMemo();
+      String claimant = clientName != null ? clientName : ownerAccount;
+
+      if (!customerIdOwnerStore.isClaimed(updatedCustomer.getId())) {
+        GetCustomerResponse callbackCustomer;
+        try {
+          callbackCustomer =
+              customerIntegration.getCustomer(
+                  GetCustomerRequest.builder()
+                      .account(token.getOwnerAccount())
+                      .memo(token.getOwnerMemo())
+                      .memoType(token.getOwnerMemo() != null ? "id" : null)
+                      .build());
+        } catch (Exception e) {
+          Log.warnEx(e);
+          callbackCustomer = null;
+        }
+        if (callbackCustomer == null || !updatedCustomer.getId().equals(callbackCustomer.getId())) {
+          throw new SepNotAuthorizedException(
+              "customer id returned by the business server is already claimed by another client");
+        }
+      }
 
       boolean owned =
-          customerIdOwnerStore.verifyOrClaim(
-              updatedCustomer.getId(), clientName != null ? clientName : ownerAccount, ownerMemo);
+          customerIdOwnerStore.verifyOrClaim(updatedCustomer.getId(), claimant, ownerMemo);
 
       if (!owned) {
         throw new SepNotAuthorizedException(

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -134,9 +134,9 @@ public class Sep12Service {
           callbackCustomer =
               customerIntegration.getCustomer(
                   GetCustomerRequest.builder()
-                      .account(token.getOwnerAccount())
-                      .memo(token.getOwnerMemo())
-                      .memoType(token.getOwnerMemo() != null ? "id" : null)
+                      .account(request.getAccount())
+                      .memo(request.getMemo())
+                      .memoType(request.getMemoType())
                       .build());
         } catch (Exception e) {
           Log.warnEx(e);

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -113,6 +113,40 @@ public class Sep12Service {
       }
     }
 
+    if (isNewCustomer) {
+      GetCustomerResponse existing;
+      try {
+        existing =
+            customerIntegration.getCustomer(
+                GetCustomerRequest.builder()
+                    .account(request.getAccount())
+                    .memo(request.getMemo())
+                    .memoType(request.getMemoType())
+                    .type(request.getType())
+                    .build());
+      } catch (NotFoundException e) {
+        existing = null;
+      } catch (Exception e) {
+        Log.warnEx(e);
+        throw new ServerErrorException("unable to verify customer ownership", e);
+      }
+
+      if (existing != null
+          && existing.getId() != null
+          && customerIdOwnerStore.isClaimed(existing.getId())
+          && !customerIdOwnerStore.verify(
+              existing.getId(), token.getOwnerKey(), token.getOwnerMemo())
+          && !CustomerOwnershipReconciliation.tryReconcile(
+              customerIdOwnerStore,
+              customerIntegration,
+              existing.getId(),
+              token,
+              request.getType())) {
+        throw new SepNotAuthorizedException(
+            "customer id returned by the business server is already claimed by another client");
+      }
+    }
+
     PutCustomerResponse updatedCustomer =
         customerIntegration.putCustomer(PutCustomerRequest.from(request));
 
@@ -200,7 +234,7 @@ public class Sep12Service {
     GetCustomerResponse existingCustomer =
         customerIntegration.getCustomer(
             GetCustomerRequest.builder().account(account).memo(memo).memoType(memoType).build());
-    if (existingCustomer.getId() != null) {
+    if (existingCustomer != null && existingCustomer.getId() != null) {
       existingCustomerMatch = true;
       customerIntegration.deleteCustomer(existingCustomer.getId());
     }

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -30,9 +30,6 @@ import org.stellar.anchor.util.MemoHelper;
 import org.stellar.sdk.xdr.MemoType;
 
 public class Sep12Service {
-  private static final String TYPE_SEP31_SENDER = "sep31-sender";
-  private static final String TYPE_SEP31_RECEIVER = "sep31-receiver";
-
   private final CustomerIntegration customerIntegration;
   private final Counter sep12GetCustomerCounter =
       Metrics.counter(SEP12_CUSTOMER, TYPE, TV_SEP12_GET_CUSTOMER);
@@ -79,11 +76,7 @@ public class Sep12Service {
 
   public Sep12PutCustomerResponse putCustomer(WebAuthJwt token, Sep12PutCustomerRequest request)
       throws AnchorException {
-    boolean isNewSep31Customer =
-        request.getId() == null
-            && request.getTransactionId() == null
-            && (TYPE_SEP31_SENDER.equals(request.getType())
-                || TYPE_SEP31_RECEIVER.equals(request.getType()));
+    boolean isNewCustomer = request.getId() == null && request.getTransactionId() == null;
 
     validateGetOrPutRequest(request, token);
 
@@ -118,7 +111,7 @@ public class Sep12Service {
 
     String clientName = token.getClientName();
 
-    if (isNewSep31Customer) {
+    if (isNewCustomer) {
       String ownerAccount = token.getOwnerAccount();
       String ownerMemo = token.getOwnerMemo();
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -169,7 +169,7 @@ public class Sep12Service {
                       .build());
         } catch (Exception e) {
           Log.warnEx(e);
-          callbackCustomer = null;
+          throw new ServerErrorException("unable to verify customer ownership", e);
         }
         if (callbackCustomer == null || !updatedCustomer.getId().equals(callbackCustomer.getId())) {
           throw new SepNotAuthorizedException(

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -222,33 +222,43 @@ public class Sep12Service {
     } else if (requestBase.getId() != null) {
       isIdPath = true;
 
-      try {
-        String tokenAccount =
-            token.getMuxedAccount() != null ? token.getMuxedAccount() : token.getAccount();
-        String tokenMemo =
-            token.getMuxedAccountId() != null
-                ? token.getMuxedAccountId().toString()
-                : token.getAccountMemo();
+      String tokenAccount =
+          token.getMuxedAccount() != null ? token.getMuxedAccount() : token.getAccount();
 
-        GetCustomerResponse owned =
-            customerIntegration.getCustomer(
-                GetCustomerRequest.builder()
-                    .memo(tokenMemo)
-                    .memoType(tokenMemo != null ? "id" : null)
-                    .account(tokenAccount)
-                    .type(requestBase.getType())
-                    .build());
-
-        if (owned == null || !requestBase.getId().equals(owned.getId())) {
+      if (customerIdOwnerStore.isClaimed(requestBase.getId())) {
+        String clientName = token.getClientName();
+        String ownerAccount = clientName != null ? clientName : token.getOwnerAccount();
+        if (!customerIdOwnerStore.verify(requestBase.getId(), ownerAccount, token.getOwnerMemo())) {
           throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
         }
-
         requestBase.setAccount(tokenAccount);
-      } catch (SepNotAuthorizedException e) {
-        throw e;
-      } catch (Exception e) {
-        Log.warnEx(e);
-        throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
+      } else {
+        try {
+          String tokenMemo =
+              token.getMuxedAccountId() != null
+                  ? token.getMuxedAccountId().toString()
+                  : token.getAccountMemo();
+
+          GetCustomerResponse owned =
+              customerIntegration.getCustomer(
+                  GetCustomerRequest.builder()
+                      .memo(tokenMemo)
+                      .memoType(tokenMemo != null ? "id" : null)
+                      .account(tokenAccount)
+                      .type(requestBase.getType())
+                      .build());
+
+          if (owned == null || !requestBase.getId().equals(owned.getId())) {
+            throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
+          }
+
+          requestBase.setAccount(tokenAccount);
+        } catch (SepNotAuthorizedException e) {
+          throw e;
+        } catch (Exception e) {
+          Log.warnEx(e);
+          throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
+        }
       }
     }
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -85,6 +85,11 @@ public class Sep12Service {
         && request.getId() == null
         && request.getTransactionId() == null) {
       request.setAccount(token.getAccount());
+
+      if (request.getMemo() == null && token.getOwnerMemo() != null) {
+        request.setMemo(token.getOwnerMemo());
+        request.setMemoType(MemoHelper.memoTypeAsString(MemoType.MEMO_ID));
+      }
     }
 
     if (StringUtils.isNotEmpty(request.getBirthDate())) {
@@ -231,7 +236,11 @@ public class Sep12Service {
         if (!customerIdOwnerStore.verify(requestBase.getId(), ownerAccount, token.getOwnerMemo())) {
           throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
         }
-        requestBase.setAccount(tokenAccount);
+
+        requestBase.setAccount(token.getAccount());
+        if (token.getOwnerMemo() != null) {
+          requestBase.setMemo(token.getOwnerMemo());
+        }
       } else {
         try {
           String tokenMemo =

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -220,6 +220,10 @@ public class Sep12Service {
   void validateGetOrPutRequest(Sep12CustomerRequestBase requestBase, WebAuthJwt token)
       throws SepException {
     boolean isIdPath = false;
+    boolean isSep31TransactionLookup =
+        requestBase.getTransactionId() != null
+            && ("sep31-sender".equals(requestBase.getType())
+                || "sep31-receiver".equals(requestBase.getType()));
     if (requestBase.getTransactionId() != null) {
       try {
         // `transactionId` should be used in conjunction with customer type `type` (sep6,
@@ -257,12 +261,12 @@ public class Sep12Service {
     if (requestBase.getId() != null) {
       isIdPath = true;
 
-      String tokenAccount =
-          token.getMuxedAccount() != null ? token.getMuxedAccount() : token.getAccount();
-
       if (customerIdOwnerStore.isClaimed(requestBase.getId())) {
         if (!customerIdOwnerStore.verify(
-                requestBase.getId(), token.getOwnerKey(), token.getOwnerMemo())
+                requestBase.getId(),
+                token.getOwnerKey(),
+                token.getOwnerMemo(),
+                isSep31TransactionLookup)
             && !CustomerOwnershipReconciliation.tryReconcile(
                 customerIdOwnerStore,
                 customerIntegration,
@@ -286,7 +290,7 @@ public class Sep12Service {
                   GetCustomerRequest.builder()
                       .memo(tokenMemo)
                       .memoType(tokenMemo != null ? "id" : null)
-                      .account(tokenAccount)
+                      .account(token.getAccount())
                       .type(requestBase.getType())
                       .build());
 
@@ -294,7 +298,7 @@ public class Sep12Service {
             throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
           }
 
-          requestBase.setAccount(tokenAccount);
+          requestBase.setAccount(token.getAccount());
         } catch (SepNotAuthorizedException e) {
           throw e;
         } catch (Exception e) {

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -24,6 +24,7 @@ import org.stellar.anchor.api.shared.StellarId;
 import org.stellar.anchor.apiclient.PlatformApiClient;
 import org.stellar.anchor.auth.WebAuthJwt;
 import org.stellar.anchor.event.EventService;
+import org.stellar.anchor.sep31.CustomerOwnershipReconciliation;
 import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore;
 import org.stellar.anchor.util.Log;
 import org.stellar.anchor.util.MemoHelper;
@@ -145,7 +146,13 @@ public class Sep12Service {
       boolean owned =
           customerIdOwnerStore.verifyOrClaim(updatedCustomer.getId(), claimant, ownerMemo);
 
-      if (!owned) {
+      if (!owned
+          && !CustomerOwnershipReconciliation.tryReconcile(
+              customerIdOwnerStore,
+              customerIntegration,
+              updatedCustomer.getId(),
+              token,
+              request.getType())) {
         throw new SepNotAuthorizedException(
             "customer id returned by the business server is already claimed by another client");
       }
@@ -253,7 +260,13 @@ public class Sep12Service {
 
       if (customerIdOwnerStore.isClaimed(requestBase.getId())) {
         if (!customerIdOwnerStore.verify(
-            requestBase.getId(), token.getOwnerKey(), token.getOwnerMemo())) {
+                requestBase.getId(), token.getOwnerKey(), token.getOwnerMemo())
+            && !CustomerOwnershipReconciliation.tryReconcile(
+                customerIdOwnerStore,
+                customerIntegration,
+                requestBase.getId(),
+                token,
+                requestBase.getType())) {
           throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
         }
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -84,7 +84,6 @@ public class Sep12Service {
         isNewCustomer
             && (TYPE_SEP31_SENDER.equals(request.getType())
                 || TYPE_SEP31_RECEIVER.equals(request.getType()));
-    validateGetOrPutRequest(request, token);
 
     if (request.getAccount() == null
         && token.getAccount() != null
@@ -97,6 +96,8 @@ public class Sep12Service {
         request.setMemoType(MemoHelper.memoTypeAsString(MemoType.MEMO_ID));
       }
     }
+
+    validateGetOrPutRequest(request, token);
 
     if (StringUtils.isNotEmpty(request.getBirthDate())) {
       if (!isValidISO8601Date(request.getBirthDate())) {

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -243,10 +243,8 @@ public class Sep12Service {
           throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
         }
 
-        requestBase.setAccount(token.getAccount());
-        if (token.getOwnerMemo() != null) {
-          requestBase.setMemo(token.getOwnerMemo());
-        }
+        requestBase.setAccount(null);
+        requestBase.setMemo(null);
       } else {
         try {
           String tokenMemo =

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -252,7 +252,9 @@ public class Sep12Service {
       } catch (Exception e) {
         throw new SepNotAuthorizedException("The transaction specified does not exist");
       }
-    } else if (requestBase.getId() != null) {
+    }
+
+    if (requestBase.getId() != null) {
       isIdPath = true;
 
       String tokenAccount =

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -30,8 +30,6 @@ import org.stellar.anchor.util.MemoHelper;
 import org.stellar.sdk.xdr.MemoType;
 
 public class Sep12Service {
-  private static final String TYPE_SEP31_SENDER = "sep31-sender";
-  private static final String TYPE_SEP31_RECEIVER = "sep31-receiver";
   private final CustomerIntegration customerIntegration;
   private final Counter sep12GetCustomerCounter =
       Metrics.counter(SEP12_CUSTOMER, TYPE, TV_SEP12_GET_CUSTOMER);
@@ -80,10 +78,6 @@ public class Sep12Service {
       throws AnchorException {
 
     boolean isNewCustomer = request.getId() == null && request.getTransactionId() == null;
-    boolean isNewSep31Customer =
-        isNewCustomer
-            && (TYPE_SEP31_SENDER.equals(request.getType())
-                || TYPE_SEP31_RECEIVER.equals(request.getType()));
 
     if (request.getAccount() == null
         && token.getAccount() != null
@@ -123,10 +117,9 @@ public class Sep12Service {
 
     String clientName = token.getClientName();
 
-    if (isNewCustomer || isNewSep31Customer) {
-      String ownerAccount = token.getOwnerAccount();
+    if (isNewCustomer) {
       String ownerMemo = token.getOwnerMemo();
-      String claimant = clientName != null ? clientName : ownerAccount;
+      String claimant = token.getOwnerKey();
 
       if (!customerIdOwnerStore.isClaimed(updatedCustomer.getId())) {
         GetCustomerResponse callbackCustomer;
@@ -137,6 +130,7 @@ public class Sep12Service {
                       .account(request.getAccount())
                       .memo(request.getMemo())
                       .memoType(request.getMemoType())
+                      .type(request.getType())
                       .build());
         } catch (Exception e) {
           Log.warnEx(e);
@@ -258,9 +252,8 @@ public class Sep12Service {
           token.getMuxedAccount() != null ? token.getMuxedAccount() : token.getAccount();
 
       if (customerIdOwnerStore.isClaimed(requestBase.getId())) {
-        String clientName = token.getClientName();
-        String ownerAccount = clientName != null ? clientName : token.getOwnerAccount();
-        if (!customerIdOwnerStore.verify(requestBase.getId(), ownerAccount, token.getOwnerMemo())) {
+        if (!customerIdOwnerStore.verify(
+            requestBase.getId(), token.getOwnerKey(), token.getOwnerMemo())) {
           throw new SepNotAuthorizedException(ERR_CUSTOMER_ID_NOT_AUTHORIZED);
         }
 

--- a/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep12/Sep12Service.java
@@ -30,6 +30,8 @@ import org.stellar.anchor.util.MemoHelper;
 import org.stellar.sdk.xdr.MemoType;
 
 public class Sep12Service {
+  private static final String TYPE_SEP31_SENDER = "sep31-sender";
+  private static final String TYPE_SEP31_RECEIVER = "sep31-receiver";
   private final CustomerIntegration customerIntegration;
   private final Counter sep12GetCustomerCounter =
       Metrics.counter(SEP12_CUSTOMER, TYPE, TV_SEP12_GET_CUSTOMER);
@@ -76,8 +78,12 @@ public class Sep12Service {
 
   public Sep12PutCustomerResponse putCustomer(WebAuthJwt token, Sep12PutCustomerRequest request)
       throws AnchorException {
-    boolean isNewCustomer = request.getId() == null && request.getTransactionId() == null;
 
+    boolean isNewCustomer = request.getId() == null && request.getTransactionId() == null;
+    boolean isNewSep31Customer =
+        isNewCustomer
+            && (TYPE_SEP31_SENDER.equals(request.getType())
+                || TYPE_SEP31_RECEIVER.equals(request.getType()));
     validateGetOrPutRequest(request, token);
 
     if (request.getAccount() == null
@@ -116,7 +122,7 @@ public class Sep12Service {
 
     String clientName = token.getClientName();
 
-    if (isNewCustomer) {
+    if (isNewCustomer || isNewSep31Customer) {
       String ownerAccount = token.getOwnerAccount();
       String ownerMemo = token.getOwnerMemo();
 

--- a/core/src/main/java/org/stellar/anchor/sep31/CustomerOwnershipReconciliation.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/CustomerOwnershipReconciliation.java
@@ -40,7 +40,8 @@ public final class CustomerOwnershipReconciliation {
       return false;
     }
 
+    String legacyMemo = store.getCreatorMemo(customerId);
     return store.reconcileLegacyKey(
-        customerId, clientName, null, token.getOwnerKey(), token.getOwnerMemo());
+        customerId, clientName, legacyMemo, token.getOwnerKey(), token.getOwnerMemo());
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/CustomerOwnershipReconciliation.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/CustomerOwnershipReconciliation.java
@@ -41,6 +41,6 @@ public final class CustomerOwnershipReconciliation {
     }
 
     return store.reconcileLegacyKey(
-        customerId, clientName, token.getOwnerKey(), token.getOwnerMemo());
+        customerId, clientName, null, token.getOwnerKey(), token.getOwnerMemo());
   }
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/CustomerOwnershipReconciliation.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/CustomerOwnershipReconciliation.java
@@ -1,0 +1,46 @@
+package org.stellar.anchor.sep31;
+
+import org.stellar.anchor.api.callback.CustomerIntegration;
+import org.stellar.anchor.api.callback.GetCustomerRequest;
+import org.stellar.anchor.api.callback.GetCustomerResponse;
+import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.util.Log;
+
+public final class CustomerOwnershipReconciliation {
+
+  private CustomerOwnershipReconciliation() {}
+
+  public static boolean tryReconcile(
+      Sep31CustomerIdOwnerStore store,
+      CustomerIntegration customerIntegration,
+      String customerId,
+      WebAuthJwt token,
+      String type) {
+    String clientName = token.getClientName();
+    if (clientName == null) {
+      return false;
+    }
+
+    GetCustomerResponse callbackCustomer;
+    try {
+      callbackCustomer =
+          customerIntegration.getCustomer(
+              GetCustomerRequest.builder()
+                  .account(token.getAccount())
+                  .memo(token.getOwnerMemo())
+                  .memoType(token.getOwnerMemo() != null ? "id" : null)
+                  .type(type)
+                  .build());
+    } catch (Exception e) {
+      Log.warnEx(e);
+      return false;
+    }
+
+    if (callbackCustomer == null || !customerId.equals(callbackCustomer.getId())) {
+      return false;
+    }
+
+    return store.reconcileLegacyKey(
+        customerId, clientName, token.getOwnerKey(), token.getOwnerMemo());
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
@@ -2,4 +2,8 @@ package org.stellar.anchor.sep31;
 
 public interface Sep31CustomerIdOwnerStore {
   boolean verifyOrClaim(String customerId, String creatorAccount, String creatorMemo);
+
+  boolean isClaimed(String customerId);
+
+  boolean verify(String customerId, String creatorAccount, String creatorMemo);
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
@@ -1,7 +1,12 @@
 package org.stellar.anchor.sep31;
 
 public interface Sep31CustomerIdOwnerStore {
-  boolean verifyOrClaim(String customerId, String creatorAccount, String creatorMemo);
+  default boolean verifyOrClaim(String customerId, String creatorAccount, String creatorMemo) {
+    return verifyOrClaim(customerId, creatorAccount, creatorMemo, false);
+  }
+
+  boolean verifyOrClaim(
+      String customerId, String creatorAccount, String creatorMemo, boolean ignoreMemo);
 
   boolean isClaimed(String customerId);
 

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
@@ -6,4 +6,10 @@ public interface Sep31CustomerIdOwnerStore {
   boolean isClaimed(String customerId);
 
   boolean verify(String customerId, String creatorAccount, String creatorMemo);
+
+  boolean reconcileLegacyKey(
+      String customerId,
+      String legacyCreatorAccount,
+      String newCreatorAccount,
+      String newCreatorMemo);
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
@@ -10,7 +10,13 @@ public interface Sep31CustomerIdOwnerStore {
 
   boolean isClaimed(String customerId);
 
-  boolean verify(String customerId, String creatorAccount, String creatorMemo);
+  default boolean verify(String customerId, String creatorAccount, String creatorMemo) {
+    return verify(customerId, creatorAccount, creatorMemo, false);
+  }
+
+  boolean verify(String customerId, String creatorAccount, String creatorMemo, boolean ignoreMemo);
+
+  String getCreatorMemo(String customerId);
 
   boolean reconcileLegacyKey(
       String customerId,

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31CustomerIdOwnerStore.java
@@ -10,6 +10,7 @@ public interface Sep31CustomerIdOwnerStore {
   boolean reconcileLegacyKey(
       String customerId,
       String legacyCreatorAccount,
+      String legacyCreatorMemo,
       String newCreatorAccount,
       String newCreatorMemo);
 }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -181,7 +181,7 @@ public class Sep31Service {
           owned =
               customerIntegration.getCustomer(
                   GetCustomerRequest.builder()
-                      .account(webAuthJwt.getOwnerAccount())
+                      .account(webAuthJwt.getAccount())
                       .memo(webAuthJwt.getOwnerMemo())
                       .memoType(webAuthJwt.getOwnerMemo() != null ? "id" : null)
                       .build());

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -70,6 +70,7 @@ public class Sep31Service {
   private final Counter sep31TransactionPatchedCounter = counter(SEP31_TRANSACTION_PATCHED);
   final ExchangeAmountsCalculator exchangeAmountsCalculator;
   private final Sep31CustomerIdOwnerStore customerIdOwnerStore;
+  private final CustomerIntegration customerIntegration;
 
   public Sep31Service(
       LanguageConfig languageConfig,
@@ -81,7 +82,8 @@ public class Sep31Service {
       EventService eventService,
       Clock clock,
       ExchangeAmountsCalculator exchangeAmountsCalculator,
-      Sep31CustomerIdOwnerStore customerIdOwnerStore) {
+      Sep31CustomerIdOwnerStore customerIdOwnerStore,
+      CustomerIntegration customerIntegration) {
     debug("sep31Config:", sep31Config);
     this.languageConfig = languageConfig;
     this.sep31Config = sep31Config;
@@ -92,6 +94,7 @@ public class Sep31Service {
     this.clock = clock;
     this.exchangeAmountsCalculator = exchangeAmountsCalculator;
     this.customerIdOwnerStore = customerIdOwnerStore;
+    this.customerIntegration = customerIntegration;
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
     this.infoResponse = sep31InfoResponseFromAssetInfoList(assetService.getAssets());
     Log.info("Sep31Service initialized.");
@@ -168,8 +171,31 @@ public class Sep31Service {
     String ownerMemo = webAuthJwt.getOwnerMemo();
 
     for (String customerId : Arrays.asList(request.getSenderId(), request.getReceiverId())) {
-      if (customerId != null
-          && !customerIdOwnerStore.verifyOrClaim(customerId, ownerAccount, ownerMemo)) {
+      if (customerId == null) {
+        continue;
+      }
+
+      if (!customerIdOwnerStore.isClaimed(customerId)) {
+        GetCustomerResponse owned;
+        try {
+          owned =
+              customerIntegration.getCustomer(
+                  GetCustomerRequest.builder()
+                      .account(webAuthJwt.getOwnerAccount())
+                      .memo(webAuthJwt.getOwnerMemo())
+                      .memoType(webAuthJwt.getOwnerMemo() != null ? "id" : null)
+                      .build());
+        } catch (Exception e) {
+          Log.warnEx(e);
+          owned = null;
+        }
+        if (owned == null || !customerId.equals(owned.getId())) {
+          throw new SepNotAuthorizedException(
+              "sender_id/receiver_id does not belong to the authenticated client");
+        }
+      }
+
+      if (!customerIdOwnerStore.verifyOrClaim(customerId, ownerAccount, ownerMemo)) {
         throw new SepNotAuthorizedException(
             "sender_id/receiver_id does not belong to the authenticated client");
       }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -166,11 +166,15 @@ public class Sep31Service {
             .memo(webAuthJwt.getAccountMemo())
             .build();
 
-    String ownerClientName = webAuthJwt.getClientName();
-    String ownerAccount = ownerClientName != null ? ownerClientName : webAuthJwt.getOwnerAccount();
+    String ownerAccount = webAuthJwt.getOwnerKey();
     String ownerMemo = webAuthJwt.getOwnerMemo();
 
-    for (String customerId : Arrays.asList(request.getSenderId(), request.getReceiverId())) {
+    String[][] customerIdsByType = {
+      {"sep31-sender", request.getSenderId()}, {"sep31-receiver", request.getReceiverId()}
+    };
+    for (String[] customerIdByType : customerIdsByType) {
+      String customerType = customerIdByType[0];
+      String customerId = customerIdByType[1];
       if (customerId == null) {
         continue;
       }
@@ -184,6 +188,7 @@ public class Sep31Service {
                       .account(webAuthJwt.getAccount())
                       .memo(webAuthJwt.getOwnerMemo())
                       .memoType(webAuthJwt.getOwnerMemo() != null ? "id" : null)
+                      .type(customerType)
                       .build());
         } catch (Exception e) {
           Log.warnEx(e);

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -200,7 +200,9 @@ public class Sep31Service {
         }
       }
 
-      if (!customerIdOwnerStore.verifyOrClaim(customerId, ownerAccount, ownerMemo)) {
+      if (!customerIdOwnerStore.verifyOrClaim(customerId, ownerAccount, ownerMemo)
+          && !CustomerOwnershipReconciliation.tryReconcile(
+              customerIdOwnerStore, customerIntegration, customerId, webAuthJwt, customerType)) {
         throw new SepNotAuthorizedException(
             "sender_id/receiver_id does not belong to the authenticated client");
       }

--- a/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep31/Sep31Service.java
@@ -200,7 +200,7 @@ public class Sep31Service {
         }
       }
 
-      if (!customerIdOwnerStore.verifyOrClaim(customerId, ownerAccount, ownerMemo)
+      if (!customerIdOwnerStore.verifyOrClaim(customerId, ownerAccount, ownerMemo, true)
           && !CustomerOwnershipReconciliation.tryReconcile(
               customerIdOwnerStore, customerIntegration, customerId, webAuthJwt, customerType)) {
         throw new SepNotAuthorizedException(

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -302,7 +302,8 @@ class Sep12ServiceTest {
         .build()
     every { platformApiClient.getTransaction(any()) } returns transaction
     every { customerIdOwnerStore.isClaimed("victim-customer-id") } returns true
-    every { customerIdOwnerStore.verify("victim-customer-id", TEST_ACCOUNT, null) } returns false
+    every { customerIdOwnerStore.verify("victim-customer-id", TEST_ACCOUNT, null, true) } returns
+      false
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("some-other-id").build()
 
@@ -315,6 +316,37 @@ class Sep12ServiceTest {
 
     val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+  }
+
+  @Test
+  fun `test transaction_id path allows a SEP-31 customer id owned under a different memo of the same account`() {
+    // Sep31Service intentionally accepts the same owner account under a different memo
+    // (ignoreMemo=true) for sender_id/receiver_id, since a sending client legitimately manages
+    // KYC records for both parties. Reading that same id back via transaction_id must not be
+    // stricter than the check that allowed the transaction to be created in the first place.
+    val transaction =
+      GetTransactionResponse.builder()
+        .creator(StellarId.builder().account(TEST_ACCOUNT).memo(TEST_MEMO).build())
+        .customers(
+          Customers.builder()
+            .receiver(StellarId.builder().id("receiver-under-other-memo").build())
+            .build()
+        )
+        .build()
+    every { platformApiClient.getTransaction(any()) } returns transaction
+    every { customerIdOwnerStore.isClaimed("receiver-under-other-memo") } returns true
+    every {
+      customerIdOwnerStore.verify("receiver-under-other-memo", TEST_ACCOUNT, TEST_MEMO, true)
+    } returns true
+
+    val request =
+      Sep12GetCustomerRequest.builder()
+        .transactionId(TEST_TRANSACTION_ID)
+        .type("sep31-receiver")
+        .build()
+    val jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO")
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
   }
 
   @Test
@@ -1022,7 +1054,7 @@ class Sep12ServiceTest {
   @Test
   fun `test id path uses the ownership store when the id is already claimed`() {
     every { customerIdOwnerStore.isClaimed("claimed-id") } returns true
-    every { customerIdOwnerStore.verify("claimed-id", TEST_ACCOUNT, null) } returns true
+    every { customerIdOwnerStore.verify("claimed-id", TEST_ACCOUNT, null, false) } returns true
 
     val jwtToken = createJwtToken(TEST_ACCOUNT)
     val request = Sep12GetCustomerRequest.builder().id("claimed-id").build()
@@ -1034,7 +1066,7 @@ class Sep12ServiceTest {
   @Test
   fun `test id path rejects via the ownership store when claimed by a different identity`() {
     every { customerIdOwnerStore.isClaimed("claimed-id") } returns true
-    every { customerIdOwnerStore.verify("claimed-id", any(), any()) } returns false
+    every { customerIdOwnerStore.verify("claimed-id", any(), any(), any()) } returns false
 
     val jwtToken = createJwtToken(TEST_ACCOUNT)
     val request = Sep12GetCustomerRequest.builder().id("claimed-id").build()
@@ -1048,10 +1080,12 @@ class Sep12ServiceTest {
   @Test
   fun `test id path rejects a different account under the same client name from the true owner`() {
     every { customerIdOwnerStore.isClaimed("victim-id") } returns true
-    every { customerIdOwnerStore.verify("victim-id", "vibrant:$TEST_ACCOUNT", null) } returns true
+    every { customerIdOwnerStore.verify("victim-id", "vibrant:$TEST_ACCOUNT", null, false) } returns
+      true
     val attackerAccount = "GAXLBAY4YSF6RRZTMV2CKS4NDVCMAYVKQGV3GNPUR2WWQVEFF6UYS4XZ"
-    every { customerIdOwnerStore.verify("victim-id", "vibrant:$attackerAccount", null) } returns
-      false
+    every {
+      customerIdOwnerStore.verify("victim-id", "vibrant:$attackerAccount", null, false)
+    } returns false
 
     val victimToken = createJwtToken(TEST_ACCOUNT, "vibrant")
     val victimRequest = Sep12GetCustomerRequest.builder().id("victim-id").build()
@@ -1069,9 +1103,11 @@ class Sep12ServiceTest {
   @Test
   fun `test id path reconciles a legacy wallet-only key for the true owner via the callback`() {
     every { customerIdOwnerStore.isClaimed("legacy-id") } returns true
-    every { customerIdOwnerStore.verify("legacy-id", "vibrant:$TEST_ACCOUNT", null) } returns false
+    every { customerIdOwnerStore.verify("legacy-id", "vibrant:$TEST_ACCOUNT", null, false) } returns
+      false
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("legacy-id").build()
+    every { customerIdOwnerStore.getCreatorMemo("legacy-id") } returns null
     every {
       customerIdOwnerStore.reconcileLegacyKey(
         "legacy-id",
@@ -1089,11 +1125,39 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test id path reconciles a legacy row that was backfilled with a real memo`() {
+    // V31 preserves the original transaction's memo when backfilling a legacy row -- it is not
+    // always null. The reconciliation must match against that actual stored memo, not assume it.
+    every { customerIdOwnerStore.isClaimed("legacy-memo-id") } returns true
+    every {
+      customerIdOwnerStore.verify("legacy-memo-id", "vibrant:$TEST_ACCOUNT", TEST_MEMO, false)
+    } returns false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("legacy-memo-id").build()
+    every { customerIdOwnerStore.getCreatorMemo("legacy-memo-id") } returns "555555"
+    every {
+      customerIdOwnerStore.reconcileLegacyKey(
+        "legacy-memo-id",
+        "vibrant",
+        "555555",
+        "vibrant:$TEST_ACCOUNT",
+        TEST_MEMO,
+      )
+    } returns true
+
+    val jwtToken = createJwtToken("$TEST_ACCOUNT:$TEST_MEMO", "vibrant")
+    val request = Sep12GetCustomerRequest.builder().id("legacy-memo-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+  }
+
+  @Test
   fun `test id path does not reconcile a legacy wallet-only key for a different account`() {
     every { customerIdOwnerStore.isClaimed("legacy-id") } returns true
     val attackerAccount = "GAXLBAY4YSF6RRZTMV2CKS4NDVCMAYVKQGV3GNPUR2WWQVEFF6UYS4XZ"
-    every { customerIdOwnerStore.verify("legacy-id", "vibrant:$attackerAccount", null) } returns
-      false
+    every {
+      customerIdOwnerStore.verify("legacy-id", "vibrant:$attackerAccount", null, false)
+    } returns false
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("some-other-customer-id").build()
 
@@ -1110,8 +1174,9 @@ class Sep12ServiceTest {
   @Test
   fun `test id path clears account and memo once the store has authorized it`() {
     every { customerIdOwnerStore.isClaimed("claimed-muxed-id") } returns true
-    every { customerIdOwnerStore.verify("claimed-muxed-id", TEST_MUXED_ACCOUNT, TEST_MEMO) } returns
-      true
+    every {
+      customerIdOwnerStore.verify("claimed-muxed-id", TEST_MUXED_ACCOUNT, TEST_MEMO, false)
+    } returns true
 
     val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
     val request = Sep12GetCustomerRequest.builder().id("claimed-muxed-id").build()
@@ -1284,6 +1349,22 @@ class Sep12ServiceTest {
     assertEquals("customer-id", callbackSlot.captured.id)
     assertEquals(TEST_ACCOUNT, callbackSlot.captured.account)
     assertNull(callbackSlot.captured.memo)
+  }
+
+  @Test
+  fun `test id path queries the callback with the base account, not the muxed address, for a muxed caller`() {
+    val callbackSlot = slot<GetCustomerRequest>()
+    val callbackResponse = GetCustomerResponse()
+    callbackResponse.id = "customer-id"
+    every { customerIntegration.getCustomer(capture(callbackSlot)) } returns callbackResponse
+
+    val muxedToken = createJwtToken(TEST_MUXED_ACCOUNT)
+    sep12Service.getCustomer(
+      muxedToken,
+      Sep12GetCustomerRequest.builder().id("customer-id").build(),
+    )
+
+    assertEquals(TEST_ACCOUNT, callbackSlot.captured.account)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -138,6 +138,7 @@ class Sep12ServiceTest {
   @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])
   @ParameterizedTest
   fun `test put for all account types succeed`(account: String) {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     val jwtToken = createJwtToken(account)
     val request =
       Sep12PutCustomerRequest.builder()
@@ -347,6 +348,7 @@ class Sep12ServiceTest {
   @ValueSource(strings = [TEST_TRANSACTION_ID])
   @NullSource
   fun `Test put customer request ok`(transactionId: String?) {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     // mock `PUT {callbackApi}/customer` response
     val callbackApiPutRequestSlot = slot<PutCustomerRequest>()
     val kycUpdateEventSlot = slot<AnchorEvent>()
@@ -436,6 +438,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer creating a new sep31-receiver claims ownership of the new id`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("new-receiver-id").status(Sep12Status.ACCEPTED.name).build()
 
@@ -456,6 +459,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer creating a new sep31-receiver via a muxed account claims ownership using the muxed id`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder()
         .id("new-muxed-receiver-id")
@@ -480,6 +484,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer rejects creation when the returned id is already claimed by another client`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("colliding-id").status(Sep12Status.ACCEPTED.name).build()
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns false
@@ -512,7 +517,57 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test put customer verifies a legacy id against the callback before claiming it`() {
+    every { customerIdOwnerStore.isClaimed("legacy-sep24-id") } returns false
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("legacy-sep24-id").status(Sep12Status.ACCEPTED.name).build()
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("legacy-sep24-id").build()
+
+    val request = Sep12PutCustomerRequest.builder().account(TEST_ACCOUNT).firstName("Jane").build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("legacy-sep24-id", TEST_ACCOUNT, null)
+    }
+  }
+
+  @Test
+  fun `test put customer fails closed for an unclaimed id the caller cannot verify against the callback`() {
+    every { customerIdOwnerStore.isClaimed("victim-legacy-id") } returns false
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("victim-legacy-id").status(Sep12Status.ACCEPTED.name).build()
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("some-other-id").build()
+
+    val request = Sep12PutCustomerRequest.builder().account(TEST_ACCOUNT).firstName("Jane").build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: SepException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+  }
+
+  @Test
+  fun `test put customer fails closed when the callback lookup for a legacy id errors`() {
+    every { customerIdOwnerStore.isClaimed("legacy-sep24-id") } returns false
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("legacy-sep24-id").status(Sep12Status.ACCEPTED.name).build()
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("callback unavailable")
+
+    val request = Sep12PutCustomerRequest.builder().account(TEST_ACCOUNT).firstName("Jane").build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: SepException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+  }
+
+  @Test
   fun `test put customer claims ownership for a new non-sep31 customer too`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("sep24-id").status(Sep12Status.ACCEPTED.name).build()
 
@@ -526,6 +581,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer rejects a new non-sep31 customer id already claimed by another client`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder()
         .id("sep6-colliding-id")
@@ -543,6 +599,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer claims ownership by client name when one resolves`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("new-sender-id").status(Sep12Status.ACCEPTED.name).build()
 
@@ -556,6 +613,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer keeps memo distinct per sub-user even when a client name resolves`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("new-receiver-id").status(Sep12Status.ACCEPTED.name).build()
 
@@ -576,6 +634,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer keeps muxed id distinct per sub-user even when a client name resolves`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder()
         .id("new-muxed-receiver-id")
@@ -600,6 +659,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `test put customer forwards the owner memo to the callback for a new muxed customer`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     val putRequestSlot = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(putRequestSlot)) } returns
       PutCustomerResponse.builder()
@@ -627,6 +687,7 @@ class Sep12ServiceTest {
 
   @Test
   fun `Test put customer publishes event with null clientName when the token was never authorized as a client`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     val kycUpdateEventSlot = slot<AnchorEvent>()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("customer-id").build()

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -1041,6 +1041,39 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test id path reconciles a legacy wallet-only key for the true owner via the callback`() {
+    every { customerIdOwnerStore.isClaimed("legacy-id") } returns true
+    every { customerIdOwnerStore.verify("legacy-id", "vibrant:$TEST_ACCOUNT", null) } returns false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("legacy-id").build()
+    every {
+      customerIdOwnerStore.reconcileLegacyKey("legacy-id", "vibrant", "vibrant:$TEST_ACCOUNT", null)
+    } returns true
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT, "vibrant")
+    val request = Sep12GetCustomerRequest.builder().id("legacy-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+  }
+
+  @Test
+  fun `test id path does not reconcile a legacy wallet-only key for a different account`() {
+    every { customerIdOwnerStore.isClaimed("legacy-id") } returns true
+    val attackerAccount = "GAXLBAY4YSF6RRZTMV2CKS4NDVCMAYVKQGV3GNPUR2WWQVEFF6UYS4XZ"
+    every { customerIdOwnerStore.verify("legacy-id", "vibrant:$attackerAccount", null) } returns
+      false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("some-other-customer-id").build()
+
+    val jwtToken = createJwtToken(attackerAccount, "vibrant")
+    val request = Sep12GetCustomerRequest.builder().id("legacy-id").build()
+
+    val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    verify(exactly = 0) { customerIdOwnerStore.reconcileLegacyKey(any(), any(), any(), any()) }
+  }
+
+  @Test
   fun `test id path clears account and memo once the store has authorized it`() {
     every { customerIdOwnerStore.isClaimed("claimed-muxed-id") } returns true
     every { customerIdOwnerStore.verify("claimed-muxed-id", TEST_MUXED_ACCOUNT, TEST_MEMO) } returns

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -512,7 +512,7 @@ class Sep12ServiceTest {
   }
 
   @Test
-  fun `test put customer does not claim ownership for non-sep31 customer types`() {
+  fun `test put customer claims ownership for a new non-sep31 customer too`() {
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("sep24-id").status(Sep12Status.ACCEPTED.name).build()
 
@@ -521,7 +521,24 @@ class Sep12ServiceTest {
 
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
-    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+    verify(exactly = 1) { customerIdOwnerStore.verifyOrClaim("sep24-id", TEST_ACCOUNT, null) }
+  }
+
+  @Test
+  fun `test put customer rejects a new non-sep31 customer id already claimed by another client`() {
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder()
+        .id("sep6-colliding-id")
+        .status(Sep12Status.ACCEPTED.name)
+        .build()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns false
+
+    val request =
+      Sep12PutCustomerRequest.builder().type("sep6").account(TEST_ACCOUNT).firstName("Jane").build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: SepException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -845,6 +845,46 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test id path uses the ownership store when the id is already claimed`() {
+    every { customerIdOwnerStore.isClaimed("claimed-id") } returns true
+    every { customerIdOwnerStore.verify("claimed-id", TEST_ACCOUNT, null) } returns true
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("claimed-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    verify(exactly = 0) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
+  fun `test id path rejects via the ownership store when claimed by a different identity`() {
+    every { customerIdOwnerStore.isClaimed("claimed-id") } returns true
+    every { customerIdOwnerStore.verify("claimed-id", any(), any()) } returns false
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("claimed-id").build()
+
+    val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
+    verify(exactly = 0) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
+  fun `test id path falls back to the business server reverse lookup when the id is not yet claimed`() {
+    every { customerIdOwnerStore.isClaimed("unclaimed-id") } returns false
+    val ownedResponse = GetCustomerResponse()
+    ownedResponse.id = "unclaimed-id"
+    every { customerIntegration.getCustomer(any()) } returns ownedResponse
+
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("unclaimed-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    verify(exactly = 1) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
   fun `test id path normalizes error message across all failure modes`() {
     val attackerToken = createJwtToken(TEST_ACCOUNT)
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -535,6 +535,38 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test put customer verifies the legacy id using the request's account and memo, not the token's`() {
+    every { customerIdOwnerStore.isClaimed("new-sep31-sender-id") } returns false
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder()
+        .id("new-sep31-sender-id")
+        .status(Sep12Status.ACCEPTED.name)
+        .build()
+    val getCustomerRequestSlot = slot<GetCustomerRequest>()
+    every { customerIntegration.getCustomer(capture(getCustomerRequestSlot)) } returns
+      GetCustomerResponse.builder().id("new-sep31-sender-id").build()
+
+    // A plain, non-muxed token with no memo in `sub` — the memo lives only in the request body,
+    // which SEP-12 allows when the token carries none.
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .type("sep31-sender")
+        .memo(TEST_MEMO)
+        .memoType("id")
+        .firstName("Jane")
+        .build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+
+    assertEquals(TEST_ACCOUNT, getCustomerRequestSlot.captured.account)
+    assertEquals(TEST_MEMO, getCustomerRequestSlot.captured.memo)
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-sep31-sender-id", TEST_ACCOUNT, null)
+    }
+  }
+
+  @Test
   fun `test put customer fails closed for an unclaimed id the caller cannot verify against the callback`() {
     every { customerIdOwnerStore.isClaimed("victim-legacy-id") } returns false
     every { customerIntegration.putCustomer(any()) } returns

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -599,6 +599,33 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test put customer forwards the owner memo to the callback for a new muxed customer`() {
+    val putRequestSlot = slot<PutCustomerRequest>()
+    every { customerIntegration.putCustomer(capture(putRequestSlot)) } returns
+      PutCustomerResponse.builder()
+        .id("new-muxed-receiver-id")
+        .status(Sep12Status.ACCEPTED.name)
+        .build()
+
+    val request =
+      Sep12PutCustomerRequest.builder()
+        .type("sep31-receiver")
+        .memo(TEST_MEMO)
+        .memoType("id")
+        .firstName("Jane")
+        .build()
+    val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
+
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+
+    assertEquals(TEST_ACCOUNT, putRequestSlot.captured.account)
+    assertEquals(TEST_MEMO, putRequestSlot.captured.memo)
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-muxed-receiver-id", TEST_MUXED_ACCOUNT, TEST_MEMO)
+    }
+  }
+
+  @Test
   fun `Test put customer publishes event with null clientName when the token was never authorized as a client`() {
     val kycUpdateEventSlot = slot<AnchorEvent>()
     every { customerIntegration.putCustomer(any()) } returns
@@ -867,6 +894,22 @@ class Sep12ServiceTest {
     val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
     assertEquals("not authorized for customer id", ex.message)
+    verify(exactly = 0) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
+  fun `test id path propagates the base account, not the muxed account, once the store has authorized it`() {
+    every { customerIdOwnerStore.isClaimed("claimed-muxed-id") } returns true
+    every { customerIdOwnerStore.verify("claimed-muxed-id", TEST_MUXED_ACCOUNT, TEST_MEMO) } returns
+      true
+
+    val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
+    val request = Sep12GetCustomerRequest.builder().id("claimed-muxed-id").build()
+
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+
+    assertEquals(TEST_ACCOUNT, request.account)
+    assertEquals(TEST_MEMO, request.memo)
     verify(exactly = 0) { customerIntegration.getCustomer(any()) }
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -114,6 +114,7 @@ class Sep12ServiceTest {
     every { assetService.getAssets() } returns assets
     every { eventService.createSession(any(), any()) } returns eventSession
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    every { customerIntegration.getCustomer(any()) } returns null
 
     sep12Service =
       Sep12Service(
@@ -150,6 +151,8 @@ class Sep12ServiceTest {
   @ValueSource(strings = [TEST_ACCOUNT, TEST_CONTRACT_ACCOUNT, TEST_MUXED_ACCOUNT])
   @ParameterizedTest
   fun `test delete for all account types succeed`(account: String) {
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("existing-customer-id").build()
     val jwtToken = createJwtToken(account)
     val memo = if (account == TEST_MUXED_ACCOUNT) TEST_MEMO else null
     val memoType = if (account == TEST_MUXED_ACCOUNT) "id" else null
@@ -642,17 +645,17 @@ class Sep12ServiceTest {
   }
 
   @Test
-  fun `test put customer fails closed when the callback lookup for a legacy id errors`() {
-    every { customerIdOwnerStore.isClaimed("legacy-sep24-id") } returns false
-    every { customerIntegration.putCustomer(any()) } returns
-      PutCustomerResponse.builder().id("legacy-sep24-id").status(Sep12Status.ACCEPTED.name).build()
+  fun `test put customer fails closed when the pre-check callback lookup errors`() {
+    // A callback outage must abort before the mutating PUT, not be treated as "no existing
+    // customer" and let the write through.
     every { customerIntegration.getCustomer(any()) } throws RuntimeException("callback unavailable")
 
     val request = Sep12PutCustomerRequest.builder().account(TEST_ACCOUNT).firstName("Jane").build()
     val jwtToken = createJwtToken(TEST_ACCOUNT)
 
-    val ex: SepException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
-    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    val ex: AnchorException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
+    assertInstanceOf(ServerErrorException::class.java, ex)
+    verify(exactly = 0) { customerIntegration.putCustomer(any()) }
     verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
   }
 
@@ -686,6 +689,23 @@ class Sep12ServiceTest {
 
     val ex: SepException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+  }
+
+  @Test
+  fun `test put customer rejects before writing when the caller already has a colliding customer`() {
+    // The ownership pre-check must run before the mutating PUT: a deduplicating business server
+    // could otherwise apply the caller's submitted fields to a customer someone else already owns.
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("already-claimed-id").build()
+    every { customerIdOwnerStore.isClaimed("already-claimed-id") } returns true
+    every { customerIdOwnerStore.verify("already-claimed-id", any(), any()) } returns false
+
+    val request = Sep12PutCustomerRequest.builder().account(TEST_ACCOUNT).firstName("Jane").build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: SepException = assertThrows { sep12Service.putCustomer(jwtToken, request) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    verify(exactly = 0) { customerIntegration.putCustomer(any()) }
   }
 
   @Test
@@ -1384,6 +1404,8 @@ class Sep12ServiceTest {
   @Test
   fun `test delete customer validation`() {
     every { customerIntegration.deleteCustomer(any()) } just Runs
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("existing-customer-id").build()
 
     // PART 1 - account without memo
     // throws exception if request is missing the account

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -686,6 +686,28 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test put customer backfills the owner memo before validation for a muxed caller who omits it`() {
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
+    val putRequestSlot = slot<PutCustomerRequest>()
+    every { customerIntegration.putCustomer(capture(putRequestSlot)) } returns
+      PutCustomerResponse.builder()
+        .id("new-muxed-receiver-id")
+        .status(Sep12Status.ACCEPTED.name)
+        .build()
+
+    val request = Sep12PutCustomerRequest.builder().type("sep31-receiver").firstName("Jane").build()
+    val jwtToken = createJwtToken(TEST_MUXED_ACCOUNT)
+
+    assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
+
+    assertEquals(TEST_ACCOUNT, putRequestSlot.captured.account)
+    assertEquals(TEST_MEMO, putRequestSlot.captured.memo)
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-muxed-receiver-id", TEST_MUXED_ACCOUNT, TEST_MEMO)
+    }
+  }
+
+  @Test
   fun `Test put customer publishes event with null clientName when the token was never authorized as a client`() {
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     val kycUpdateEventSlot = slot<AnchorEvent>()

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -561,6 +561,7 @@ class Sep12ServiceTest {
 
     assertEquals(TEST_ACCOUNT, getCustomerRequestSlot.captured.account)
     assertEquals(TEST_MEMO, getCustomerRequestSlot.captured.memo)
+    assertEquals("sep31-sender", getCustomerRequestSlot.captured.type)
     verify(exactly = 1) {
       customerIdOwnerStore.verifyOrClaim("new-sep31-sender-id", TEST_ACCOUNT, null)
     }
@@ -640,7 +641,9 @@ class Sep12ServiceTest {
 
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
-    verify(exactly = 1) { customerIdOwnerStore.verifyOrClaim("new-sender-id", "vibrant", null) }
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-sender-id", "vibrant:$TEST_ACCOUNT", null)
+    }
   }
 
   @Test
@@ -660,7 +663,7 @@ class Sep12ServiceTest {
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("new-receiver-id", "vibrant", TEST_MEMO)
+      customerIdOwnerStore.verifyOrClaim("new-receiver-id", "vibrant:$TEST_ACCOUNT", TEST_MEMO)
     }
   }
 
@@ -685,7 +688,11 @@ class Sep12ServiceTest {
     assertDoesNotThrow { sep12Service.putCustomer(jwtToken, request) }
 
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("new-muxed-receiver-id", "vibrant", TEST_MEMO)
+      customerIdOwnerStore.verifyOrClaim(
+        "new-muxed-receiver-id",
+        "vibrant:$TEST_MUXED_ACCOUNT",
+        TEST_MEMO,
+      )
     }
   }
 
@@ -1010,6 +1017,27 @@ class Sep12ServiceTest {
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
     assertEquals("not authorized for customer id", ex.message)
     verify(exactly = 0) { customerIntegration.getCustomer(any()) }
+  }
+
+  @Test
+  fun `test id path rejects a different account under the same client name from the true owner`() {
+    every { customerIdOwnerStore.isClaimed("victim-id") } returns true
+    every { customerIdOwnerStore.verify("victim-id", "vibrant:$TEST_ACCOUNT", null) } returns true
+    val attackerAccount = "GAXLBAY4YSF6RRZTMV2CKS4NDVCMAYVKQGV3GNPUR2WWQVEFF6UYS4XZ"
+    every { customerIdOwnerStore.verify("victim-id", "vibrant:$attackerAccount", null) } returns
+      false
+
+    val victimToken = createJwtToken(TEST_ACCOUNT, "vibrant")
+    val victimRequest = Sep12GetCustomerRequest.builder().id("victim-id").build()
+    assertDoesNotThrow { sep12Service.validateGetOrPutRequest(victimRequest, victimToken) }
+
+    val attackerToken = createJwtToken(attackerAccount, "vibrant")
+    val attackerRequest = Sep12GetCustomerRequest.builder().id("victim-id").build()
+    val ex: SepException = assertThrows {
+      sep12Service.validateGetOrPutRequest(attackerRequest, attackerToken)
+    }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    assertEquals("not authorized for customer id", ex.message)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -292,6 +292,32 @@ class Sep12ServiceTest {
   }
 
   @Test
+  fun `test transaction_id path rejects a resolved customer id the caller does not own`() {
+    val transaction =
+      GetTransactionResponse.builder()
+        .creator(StellarId.builder().account(TEST_ACCOUNT).build())
+        .customers(
+          Customers.builder().receiver(StellarId.builder().id("victim-customer-id").build()).build()
+        )
+        .build()
+    every { platformApiClient.getTransaction(any()) } returns transaction
+    every { customerIdOwnerStore.isClaimed("victim-customer-id") } returns true
+    every { customerIdOwnerStore.verify("victim-customer-id", TEST_ACCOUNT, null) } returns false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("some-other-id").build()
+
+    val request =
+      Sep12GetCustomerRequest.builder()
+        .transactionId(TEST_TRANSACTION_ID)
+        .type("sep31-receiver")
+        .build()
+    val jwtToken = createJwtToken(TEST_ACCOUNT)
+
+    val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+  }
+
+  @Test
   fun `test update request memo and memo type`() {
     val mockRequestBase = mockk<Sep12CustomerRequestBase>(relaxed = true)
 
@@ -1047,7 +1073,13 @@ class Sep12ServiceTest {
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("legacy-id").build()
     every {
-      customerIdOwnerStore.reconcileLegacyKey("legacy-id", "vibrant", "vibrant:$TEST_ACCOUNT", null)
+      customerIdOwnerStore.reconcileLegacyKey(
+        "legacy-id",
+        "vibrant",
+        null,
+        "vibrant:$TEST_ACCOUNT",
+        null,
+      )
     } returns true
 
     val jwtToken = createJwtToken(TEST_ACCOUNT, "vibrant")
@@ -1070,7 +1102,9 @@ class Sep12ServiceTest {
 
     val ex: SepException = assertThrows { sep12Service.validateGetOrPutRequest(request, jwtToken) }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
-    verify(exactly = 0) { customerIdOwnerStore.reconcileLegacyKey(any(), any(), any(), any()) }
+    verify(exactly = 0) {
+      customerIdOwnerStore.reconcileLegacyKey(any(), any(), any(), any(), any())
+    }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep12/Sep12ServiceTest.kt
@@ -898,7 +898,7 @@ class Sep12ServiceTest {
   }
 
   @Test
-  fun `test id path propagates the base account, not the muxed account, once the store has authorized it`() {
+  fun `test id path clears account and memo once the store has authorized it`() {
     every { customerIdOwnerStore.isClaimed("claimed-muxed-id") } returns true
     every { customerIdOwnerStore.verify("claimed-muxed-id", TEST_MUXED_ACCOUNT, TEST_MEMO) } returns
       true
@@ -908,8 +908,8 @@ class Sep12ServiceTest {
 
     assertDoesNotThrow { sep12Service.validateGetOrPutRequest(request, jwtToken) }
 
-    assertEquals(TEST_ACCOUNT, request.account)
-    assertEquals(TEST_MEMO, request.memo)
+    assertEquals(null, request.account)
+    assertEquals(null, request.memo)
     verify(exactly = 0) { customerIntegration.getCustomer(any()) }
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -883,6 +883,7 @@ class Sep31ServiceTest {
       customerIdOwnerStore.reconcileLegacyKey(
         "legacy-receiver-id",
         "vibrant",
+        null,
         "vibrant:${TestHelper.TEST_ACCOUNT}",
         null,
       )

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -824,7 +824,7 @@ class Sep31ServiceTest {
   }
 
   @Test
-  fun `test postTransaction binds ownership to client name so key rotation does not lock out the owner`() {
+  fun `test postTransaction rejects a different account under the same client name from claiming another user's receiver_id`() {
     useQuotesNotSupportedAssetService()
 
     every { txnStore.save(any()) } answers
@@ -839,15 +839,31 @@ class Sep31ServiceTest {
     val secondSigningKey = "GAXLBAY4YSF6RRZTMV2CKS4NDVCMAYVKQGV3GNPUR2WWQVEFF6UYS4XZ"
     val jwtToken2 = TestHelper.createWebAuthJwt(account = secondSigningKey)
     jwtToken2.clientName = "vibrant"
-    assertDoesNotThrow {
+    every {
+      customerIdOwnerStore.verifyOrClaim(
+        "shared-receiver-id",
+        "vibrant:$secondSigningKey",
+        null,
+      )
+    } returns false
+
+    val ex: AnchorException = assertThrows {
       sep31Service.postTransaction(
         jwtToken2,
         ownershipTestRequest(receiverId = "shared-receiver-id"),
       )
     }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
 
-    verify(exactly = 2) {
-      customerIdOwnerStore.verifyOrClaim("shared-receiver-id", "vibrant", null)
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim(
+        "shared-receiver-id",
+        "vibrant:${TestHelper.TEST_ACCOUNT}",
+        null,
+      )
+    }
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("shared-receiver-id", "vibrant:$secondSigningKey", null)
     }
   }
 
@@ -869,14 +885,21 @@ class Sep31ServiceTest {
     sep31Service.postTransaction(subUserA, ownershipTestRequest(receiverId = "sub-user-a-id"))
 
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("sub-user-a-id", "vibrant", TestHelper.TEST_MEMO)
+      customerIdOwnerStore.verifyOrClaim(
+        "sub-user-a-id",
+        subUserA.ownerKey,
+        TestHelper.TEST_MEMO,
+      )
     }
 
     val subUserB = TestHelper.createMuxedWebAuthJwt(muxedId = 99L)
     subUserB.clientName = "vibrant"
     sep31Service.postTransaction(subUserB, ownershipTestRequest(receiverId = "sub-user-b-id"))
 
-    verify(exactly = 1) { customerIdOwnerStore.verifyOrClaim("sub-user-b-id", "vibrant", "99") }
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("sub-user-b-id", subUserB.ownerKey, "99")
+    }
+    assertNotEquals(subUserA.ownerKey, subUserB.ownerKey)
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -936,6 +936,7 @@ class Sep31ServiceTest {
     } returns false
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse().apply { id = "legacy-receiver-id" }
+    every { customerIdOwnerStore.getCreatorMemo("legacy-receiver-id") } returns null
     every {
       customerIdOwnerStore.reconcileLegacyKey(
         "legacy-receiver-id",

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -21,6 +21,7 @@ import org.stellar.anchor.api.asset.AssetInfo.Field
 import org.stellar.anchor.api.asset.Sep31Info
 import org.stellar.anchor.api.asset.StellarAssetInfo
 import org.stellar.anchor.api.callback.CustomerIntegration
+import org.stellar.anchor.api.callback.GetCustomerRequest
 import org.stellar.anchor.api.callback.GetCustomerResponse
 import org.stellar.anchor.api.callback.GetRateResponse
 import org.stellar.anchor.api.callback.RateIntegration
@@ -934,6 +935,36 @@ class Sep31ServiceTest {
 
     verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
     verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test postTransaction verifies a legacy customer id against the callback using the base account for a muxed caller`() {
+    useQuotesNotSupportedAssetService()
+    every { customerIdOwnerStore.isClaimed("legacy-receiver-id") } returns false
+    val legacyCustomer = GetCustomerResponse()
+    legacyCustomer.id = "legacy-receiver-id"
+    val getCustomerRequestSlot = slot<GetCustomerRequest>()
+    every { customerIntegration.getCustomer(capture(getCustomerRequestSlot)) } returns
+      legacyCustomer
+
+    val postTxRequest = ownershipTestRequest(receiverId = "legacy-receiver-id")
+    every { txnStore.save(any()) } answers
+      {
+        firstArg<Sep31Transaction>().also { it.id = "ABC-123" }
+      }
+
+    val jwtToken = TestHelper.createMuxedWebAuthJwt(muxedId = 42L)
+    assertDoesNotThrow { sep31Service.postTransaction(jwtToken, postTxRequest) }
+
+    assertEquals(TestHelper.TEST_ACCOUNT, getCustomerRequestSlot.captured.account)
+    assertEquals("42", getCustomerRequestSlot.captured.memo)
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim(
+        "legacy-receiver-id",
+        jwtToken.ownerAccount,
+        "42",
+      )
+    }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -246,6 +246,7 @@ class Sep31ServiceTest {
     every { txnStore.newTransaction() } returns PojoSep31Transaction()
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
 
     jwtService = spyk(JwtService(secretConfig))
 
@@ -261,6 +262,7 @@ class Sep31ServiceTest {
         Clock.systemUTC(),
         exchangeAmountsCalculator,
         customerIdOwnerStore,
+        customerIntegration,
       )
 
     request = gson.fromJson(requestJson, Sep31PostTransactionRequest::class.java)
@@ -735,6 +737,7 @@ class Sep31ServiceTest {
         Clock.systemUTC(),
         exchangeAmountsCalculator,
         customerIdOwnerStore,
+        customerIntegration,
       )
     every { rateIntegration.getRate(any()) } returns
       GetRateResponse(GetRateResponse.Rate.builder().fee(FeeDetails("2", "stellar:USDC")).build())
@@ -892,6 +895,64 @@ class Sep31ServiceTest {
   }
 
   @Test
+  fun `test postTransaction verifies a legacy customer id against the callback before claiming it`() {
+    useQuotesNotSupportedAssetService()
+    every { customerIdOwnerStore.isClaimed("legacy-receiver-id") } returns false
+    val legacyCustomer = GetCustomerResponse()
+    legacyCustomer.id = "legacy-receiver-id"
+    every { customerIntegration.getCustomer(any()) } returns legacyCustomer
+
+    val postTxRequest = ownershipTestRequest(receiverId = "legacy-receiver-id")
+    every { txnStore.save(any()) } answers
+      {
+        firstArg<Sep31Transaction>().also { it.id = "ABC-123" }
+      }
+
+    val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
+    assertDoesNotThrow { sep31Service.postTransaction(jwtToken, postTxRequest) }
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim(
+        "legacy-receiver-id",
+        TestHelper.TEST_ACCOUNT,
+        TestHelper.TEST_MEMO,
+      )
+    }
+  }
+
+  @Test
+  fun `test postTransaction fails closed for an unclaimed customer id the caller cannot verify via the callback`() {
+    useQuotesNotSupportedAssetService()
+    every { customerIdOwnerStore.isClaimed("victim-legacy-id") } returns false
+    every { customerIntegration.getCustomer(any()) } returns null
+
+    val postTxRequest = ownershipTestRequest(receiverId = "victim-legacy-id")
+
+    val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
+    val ex: AnchorException = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+    verify(exactly = 0) { txnStore.save(any()) }
+  }
+
+  @Test
+  fun `test postTransaction fails closed when the callback returns a different customer id`() {
+    useQuotesNotSupportedAssetService()
+    every { customerIdOwnerStore.isClaimed("victim-legacy-id") } returns false
+    val someoneElsesCustomer = GetCustomerResponse()
+    someoneElsesCustomer.id = "unrelated-customer-id"
+    every { customerIntegration.getCustomer(any()) } returns someoneElsesCustomer
+
+    val postTxRequest = ownershipTestRequest(receiverId = "victim-legacy-id")
+
+    val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
+    val ex: AnchorException = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
+    assertInstanceOf(SepNotAuthorizedException::class.java, ex)
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+  }
+
+  @Test
   fun `test preValidateQuote rejects already-bound quote`() {
     val tomorrow = Instant.now().plus(1, ChronoUnit.DAYS)
     val boundQuote =
@@ -1036,6 +1097,7 @@ class Sep31ServiceTest {
         Clock.systemUTC(),
         exchangeAmountsCalculator,
         customerIdOwnerStore,
+        customerIntegration,
       )
 
     val senderId = "d2bd1412-e2f6-4047-ad70-a1a2f133b25c"

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -246,7 +246,7 @@ class Sep31ServiceTest {
     every { sep31Config.paymentType } returns STRICT_SEND
     every { txnStore.newTransaction() } returns PojoSep31Transaction()
     every { eventService.createSession(any(), TRANSACTION) } returns eventSession
-    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any(), any()) } returns true
     every { customerIdOwnerStore.isClaimed(any()) } returns true
 
     jwtService = spyk(JwtService(secretConfig))
@@ -765,7 +765,7 @@ class Sep31ServiceTest {
   @Test
   fun `test postTransaction rejects receiver_id not owned by caller`() {
     useQuotesNotSupportedAssetService()
-    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns false
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any(), any()) } returns false
 
     val postTxRequest = ownershipTestRequest(receiverId = "victim-customer-id")
 
@@ -794,6 +794,7 @@ class Sep31ServiceTest {
         "sender-customer-id",
         TestHelper.TEST_ACCOUNT,
         TestHelper.TEST_MEMO,
+        true,
       )
     }
     verify(exactly = 1) {
@@ -801,6 +802,7 @@ class Sep31ServiceTest {
         "receiver-customer-id",
         TestHelper.TEST_ACCOUNT,
         TestHelper.TEST_MEMO,
+        true,
       )
     }
   }
@@ -819,7 +821,7 @@ class Sep31ServiceTest {
     assertDoesNotThrow { sep31Service.postTransaction(jwtToken, postTxRequest) }
 
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("muxed-receiver-id", jwtToken.muxedAccount, "42")
+      customerIdOwnerStore.verifyOrClaim("muxed-receiver-id", jwtToken.muxedAccount, "42", true)
     }
   }
 
@@ -844,6 +846,7 @@ class Sep31ServiceTest {
         "shared-receiver-id",
         "vibrant:$secondSigningKey",
         null,
+        true,
       )
     } returns false
 
@@ -860,10 +863,16 @@ class Sep31ServiceTest {
         "shared-receiver-id",
         "vibrant:${TestHelper.TEST_ACCOUNT}",
         null,
+        true,
       )
     }
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("shared-receiver-id", "vibrant:$secondSigningKey", null)
+      customerIdOwnerStore.verifyOrClaim(
+        "shared-receiver-id",
+        "vibrant:$secondSigningKey",
+        null,
+        true,
+      )
     }
   }
 
@@ -875,6 +884,7 @@ class Sep31ServiceTest {
         "legacy-receiver-id",
         "vibrant:${TestHelper.TEST_ACCOUNT}",
         null,
+        true,
       )
     } returns false
     every { customerIntegration.getCustomer(any()) } returns
@@ -927,6 +937,7 @@ class Sep31ServiceTest {
         "sub-user-a-id",
         subUserA.ownerKey,
         TestHelper.TEST_MEMO,
+        true,
       )
     }
 
@@ -935,7 +946,7 @@ class Sep31ServiceTest {
     sep31Service.postTransaction(subUserB, ownershipTestRequest(receiverId = "sub-user-b-id"))
 
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("sub-user-b-id", subUserB.ownerKey, "99")
+      customerIdOwnerStore.verifyOrClaim("sub-user-b-id", subUserB.ownerKey, "99", true)
     }
     assertNotEquals(subUserA.ownerKey, subUserB.ownerKey)
   }
@@ -953,7 +964,7 @@ class Sep31ServiceTest {
     val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
     assertDoesNotThrow { sep31Service.postTransaction(jwtToken, postTxRequest) }
 
-    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any(), any()) }
   }
 
   @Test
@@ -978,6 +989,7 @@ class Sep31ServiceTest {
         "legacy-receiver-id",
         TestHelper.TEST_ACCOUNT,
         TestHelper.TEST_MEMO,
+        true,
       )
     }
   }
@@ -994,7 +1006,7 @@ class Sep31ServiceTest {
     val ex: AnchorException = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
 
-    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any(), any()) }
     verify(exactly = 0) { txnStore.save(any()) }
   }
 
@@ -1024,6 +1036,7 @@ class Sep31ServiceTest {
         "legacy-receiver-id",
         jwtToken.ownerAccount,
         "42",
+        true,
       )
     }
   }
@@ -1041,7 +1054,7 @@ class Sep31ServiceTest {
     val jwtToken = TestHelper.createWebAuthJwt(accountMemo = TestHelper.TEST_MEMO)
     val ex: AnchorException = assertThrows { sep31Service.postTransaction(jwtToken, postTxRequest) }
     assertInstanceOf(SepNotAuthorizedException::class.java, ex)
-    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any(), any()) }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep31/Sep31ServiceTest.kt
@@ -868,6 +868,43 @@ class Sep31ServiceTest {
   }
 
   @Test
+  fun `test postTransaction reconciles a legacy wallet-only key for the true owner via the callback`() {
+    useQuotesNotSupportedAssetService()
+    every {
+      customerIdOwnerStore.verifyOrClaim(
+        "legacy-receiver-id",
+        "vibrant:${TestHelper.TEST_ACCOUNT}",
+        null,
+      )
+    } returns false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse().apply { id = "legacy-receiver-id" }
+    every {
+      customerIdOwnerStore.reconcileLegacyKey(
+        "legacy-receiver-id",
+        "vibrant",
+        "vibrant:${TestHelper.TEST_ACCOUNT}",
+        null,
+      )
+    } returns true
+
+    every { txnStore.save(any()) } answers
+      {
+        firstArg<Sep31Transaction>().also { it.id = "ABC-123" }
+      }
+
+    val jwtToken = TestHelper.createWebAuthJwt(account = TestHelper.TEST_ACCOUNT)
+    jwtToken.clientName = "vibrant"
+
+    assertDoesNotThrow {
+      sep31Service.postTransaction(
+        jwtToken,
+        ownershipTestRequest(receiverId = "legacy-receiver-id")
+      )
+    }
+  }
+
+  @Test
   fun `test postTransaction keeps memo distinct per sub-user even when a client name resolves`() {
     useQuotesNotSupportedAssetService()
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31CustomerOwnershipTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31CustomerOwnershipTests.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.integrationtest
 
+import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -17,6 +18,8 @@ import org.stellar.anchor.platform.integrationtest.Sep12Tests.Companion.testCust
 import org.stellar.anchor.util.GsonUtils
 import org.stellar.sdk.KeyPair
 import org.stellar.walletsdk.anchor.auth
+import org.stellar.walletsdk.asset.IssuedAssetId
+import org.stellar.walletsdk.auth.AuthToken
 import org.stellar.walletsdk.horizon.SigningKeyPair
 
 class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
@@ -29,6 +32,11 @@ class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
   private fun authenticateNewIdentity(): String {
     val keyPair = SigningKeyPair(KeyPair.random())
     return runBlocking { anchor.auth().authenticate(keyPair) }.token
+  }
+
+  private fun authenticateNewWalletIdentity(): AuthToken {
+    val keyPair = SigningKeyPair(KeyPair.random())
+    return runBlocking { anchor.auth().authenticate(keyPair) }
   }
 
   private fun mkTxnRequest(receiverId: String): Sep31PostTransactionRequest {
@@ -106,7 +114,59 @@ class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
 
     assertNotNull(secondTxn.id)
   }
+
+  @Test
+  fun `test a customer id minted via SEP-24 KYC forwarding cannot be claimed by another caller`() =
+    runBlocking {
+      val victimToken = authenticateNewWalletIdentity()
+      val victimSep12Client = Sep12Client(toml.getString("KYC_SERVER"), victimToken.token)
+
+      val depositRequest =
+        GsonUtils.getInstance()
+          .fromJson(
+            sep24DepositWithKycFieldsJson,
+            object : TypeToken<HashMap<String, String>>() {}.type
+          ) as HashMap<String, String>
+      anchor
+        .sep24()
+        .deposit(
+          IssuedAssetId(depositRequest["asset_code"]!!, depositRequest["asset_issuer"]!!),
+          victimToken,
+          depositRequest,
+        )
+
+      val victimCustomer = victimSep12Client.getCustomer()!!
+
+      val attackerJwt = authenticateNewIdentity()
+      val attackerSep31Client = Sep31Client(toml.getString("DIRECT_PAYMENT_SERVER"), attackerJwt)
+      val attackerSep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), attackerJwt)
+      val quote =
+        attackerSep38Client.postQuote(
+          "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+          "10",
+          "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        )
+      val attackerTxnRequest =
+        gson.fromJson(postTxnRequestTemplate, Sep31PostTransactionRequest::class.java)
+      attackerTxnRequest.receiverId = victimCustomer.id
+      attackerTxnRequest.quoteId = quote.id
+
+      assertThrows<SepNotAuthorizedException> {
+        attackerSep31Client.postTransaction(attackerTxnRequest)
+      }
+    }
 }
+
+private const val sep24DepositWithKycFieldsJson =
+  """{
+    "amount": "10",
+    "asset_code": "USDC",
+    "asset_issuer": "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+    "lang": "en",
+    "first_name": "Alice",
+    "last_name": "Victim",
+    "email_address": "alice-victim@example.com"
+}"""
 
 private const val postTxnRequestTemplate =
   """{

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31CustomerOwnershipTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep31CustomerOwnershipTests.kt
@@ -20,6 +20,7 @@ import org.stellar.sdk.KeyPair
 import org.stellar.walletsdk.anchor.auth
 import org.stellar.walletsdk.asset.IssuedAssetId
 import org.stellar.walletsdk.auth.AuthToken
+import org.stellar.walletsdk.auth.WalletSigner
 import org.stellar.walletsdk.horizon.SigningKeyPair
 
 class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
@@ -29,6 +30,10 @@ class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
   private val sep38Client: Sep38Client =
     Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), this.token.token)
 
+  private val walletUrl = config.env["wallet.server.url"]!!
+  private val walletDomain = walletUrl.replace("http://", "")
+  private val domainSigner = WalletSigner.DomainSigner("$walletUrl/signChallenge")
+
   private fun authenticateNewIdentity(): String {
     val keyPair = SigningKeyPair(KeyPair.random())
     return runBlocking { anchor.auth().authenticate(keyPair) }.token
@@ -37,6 +42,18 @@ class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
   private fun authenticateNewWalletIdentity(): AuthToken {
     val keyPair = SigningKeyPair(KeyPair.random())
     return runBlocking { anchor.auth().authenticate(keyPair) }
+  }
+
+  private fun authenticateWithMemo(keyPair: SigningKeyPair, memoId: ULong): String {
+    return runBlocking { anchor.auth().authenticate(keyPair, memoId = memoId) }.token
+  }
+
+  private fun authenticateNonCustodialIdentity(): String {
+    val keyPair = SigningKeyPair(KeyPair.random())
+    return runBlocking {
+        anchor.auth().authenticate(keyPair, domainSigner, clientDomain = walletDomain)
+      }
+      .token
   }
 
   private fun mkTxnRequest(receiverId: String): Sep31PostTransactionRequest {
@@ -155,6 +172,85 @@ class Sep31CustomerOwnershipTests : IntegrationTestBase(TestConfig()) {
         attackerSep31Client.postTransaction(attackerTxnRequest)
       }
     }
+
+  @Test
+  fun `test a different account under the same client name cannot claim another user's receiver_id`() {
+    val victimJwt = authenticateNonCustodialIdentity()
+    val victimSep12Client = Sep12Client(toml.getString("KYC_SERVER"), victimJwt)
+    val victimSep31Client = Sep31Client(toml.getString("DIRECT_PAYMENT_SERVER"), victimJwt)
+    val victimSep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), victimJwt)
+
+    val receiverCustomerRequest =
+      GsonUtils.getInstance().fromJson(testCustomer2Json, Sep12PutCustomerRequest::class.java)
+    val victimReceiver = victimSep12Client.putCustomer(receiverCustomerRequest)!!
+    val victimQuote =
+      victimSep38Client.postQuote(
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "10",
+        "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+      )
+    val victimTxnRequest =
+      gson.fromJson(postTxnRequestTemplate, Sep31PostTransactionRequest::class.java)
+    victimTxnRequest.receiverId = victimReceiver.id
+    victimTxnRequest.quoteId = victimQuote.id
+    victimSep31Client.postTransaction(victimTxnRequest)
+
+    val attackerJwt = authenticateNonCustodialIdentity()
+    val attackerSep31Client = Sep31Client(toml.getString("DIRECT_PAYMENT_SERVER"), attackerJwt)
+    val attackerSep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), attackerJwt)
+    val attackerQuote =
+      attackerSep38Client.postQuote(
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "10",
+        "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+      )
+    val attackerTxnRequest =
+      gson.fromJson(postTxnRequestTemplate, Sep31PostTransactionRequest::class.java)
+    attackerTxnRequest.receiverId = victimReceiver.id
+    attackerTxnRequest.quoteId = attackerQuote.id
+
+    assertThrows<SepNotAuthorizedException> {
+      attackerSep31Client.postTransaction(attackerTxnRequest)
+    }
+  }
+
+  @Test
+  fun `test a caller can read a SEP-31 receiver via transaction_id even when it was registered under a different memo`() {
+    val sharedKeyPair = SigningKeyPair(KeyPair.random())
+    val callerJwt = authenticateWithMemo(sharedKeyPair, 1UL)
+    val otherMemoJwt = authenticateWithMemo(sharedKeyPair, 2UL)
+
+    val callerSep12Client = Sep12Client(toml.getString("KYC_SERVER"), callerJwt)
+    val otherMemoSep12Client = Sep12Client(toml.getString("KYC_SERVER"), otherMemoJwt)
+    val callerSep31Client = Sep31Client(toml.getString("DIRECT_PAYMENT_SERVER"), callerJwt)
+    val callerSep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), callerJwt)
+
+    val receiverCustomerRequest =
+      GsonUtils.getInstance().fromJson(testCustomer2Json, Sep12PutCustomerRequest::class.java)
+    val receiverCustomer = otherMemoSep12Client.putCustomer(receiverCustomerRequest)!!
+
+    val quote =
+      callerSep38Client.postQuote(
+        "stellar:USDC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+        "10",
+        "stellar:JPYC:GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP",
+      )
+    val txnRequest = gson.fromJson(postTxnRequestTemplate, Sep31PostTransactionRequest::class.java)
+    txnRequest.receiverId = receiverCustomer.id
+    txnRequest.quoteId = quote.id
+
+    // Same account, different memo: SEP-31 allows this (ignoreMemo=true for sender_id/receiver_id
+    // ownership), since the caller's client legitimately manages both memos' customer records.
+    val txn = callerSep31Client.postTransaction(txnRequest)
+    assertNotNull(txn.id)
+
+    // Reading the receiver's KYC data back via transaction_id must not be stricter than the
+    // check that allowed the transaction to be created in the first place -- both go through the
+    // same ignoreMemo=true relaxation for a SEP-31 sender_id/receiver_id.
+    val fetchedCustomer =
+      callerSep12Client.getCustomer(transactionId = txn.id, type = "sep31-receiver")
+    assertEquals(receiverCustomer.id, fetchedCustomer?.id)
+  }
 }
 
 private const val sep24DepositWithKycFieldsJson =

--- a/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
+++ b/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
@@ -6,13 +6,6 @@ import java.sql.ResultSet;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 
-/**
- * V31 backfilled {@code creator_account} as a bare {@code client_name} for non-custodial clients. A
- * bare client name is not a per-user key: every user of a given non-custodial wallet shares it. The
- * runtime now keys ownership as {@code "<client_name>:<account>"} instead (see {@code
- * WebAuthJwt.getOwnerKey()}), so rows still holding the bare form no longer match and must be
- * rewritten to line up with it.
- */
 public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMigration {
 
   @Override

--- a/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
+++ b/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
@@ -22,13 +22,14 @@ public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMig
         "SELECT DISTINCT ON (customer_id) customer_id, client_name, "
             + "       creator::jsonb ->> 'account' AS winning_account "
             + "FROM ("
-            + "  SELECT receiver_id AS customer_id, creator, client_name, started_at, id "
+            + "  SELECT receiver_id AS customer_id, creator, client_name, started_at, id, status "
             + "    FROM sep31_transaction WHERE receiver_id IS NOT NULL "
             + "  UNION ALL "
-            + "  SELECT sender_id AS customer_id, creator, client_name, started_at, id "
+            + "  SELECT sender_id AS customer_id, creator, client_name, started_at, id, status "
             + "    FROM sep31_transaction WHERE sender_id IS NOT NULL "
             + ") refs "
             + "WHERE client_name IS NOT NULL "
+            + "  AND status <> 'pending_receiver' "
             + "ORDER BY customer_id, started_at ASC NULLS LAST, id ASC";
 
     String rewriteKey =

--- a/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
+++ b/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
@@ -1,0 +1,55 @@
+package db.migration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+/**
+ * V31 backfilled {@code creator_account} as a bare {@code client_name} for non-custodial clients. A
+ * bare client name is not a per-user key: every user of a given non-custodial wallet shares it. The
+ * runtime now keys ownership as {@code "<client_name>:<account>"} instead (see {@code
+ * WebAuthJwt.getOwnerKey()}), so rows still holding the bare form no longer match and must be
+ * rewritten to line up with it.
+ */
+public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    Connection connection = context.getConnection();
+
+    String findWinningReferences =
+        "SELECT DISTINCT ON (customer_id) customer_id, client_name, "
+            + "       creator::jsonb ->> 'account' AS winning_account "
+            + "FROM ("
+            + "  SELECT receiver_id AS customer_id, creator, client_name, started_at, id "
+            + "    FROM sep31_transaction WHERE receiver_id IS NOT NULL "
+            + "  UNION ALL "
+            + "  SELECT sender_id AS customer_id, creator, client_name, started_at, id "
+            + "    FROM sep31_transaction WHERE sender_id IS NOT NULL "
+            + ") refs "
+            + "WHERE client_name IS NOT NULL "
+            + "ORDER BY customer_id, started_at ASC NULLS LAST, id ASC";
+
+    String rewriteKey =
+        "UPDATE sep31_customer_id_owner SET creator_account = ? "
+            + "WHERE customer_id = ? AND creator_account = ?";
+
+    try (PreparedStatement select = connection.prepareStatement(findWinningReferences);
+        ResultSet rs = select.executeQuery();
+        PreparedStatement update = connection.prepareStatement(rewriteKey)) {
+      while (rs.next()) {
+        String customerId = rs.getString("customer_id");
+        String clientName = rs.getString("client_name");
+        String winningAccount = rs.getString("winning_account");
+        if (winningAccount == null) continue;
+
+        update.setString(1, clientName + ":" + winningAccount);
+        update.setString(2, customerId);
+        update.setString(3, clientName);
+        update.executeUpdate();
+      }
+    }
+  }
+}

--- a/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
+++ b/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
@@ -12,6 +12,12 @@ public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMig
   public void migrate(Context context) throws Exception {
     Connection connection = context.getConnection();
 
+    try (PreparedStatement widenColumn =
+        connection.prepareStatement(
+            "ALTER TABLE sep31_customer_id_owner ALTER COLUMN creator_account TYPE VARCHAR(512)")) {
+      widenColumn.executeUpdate();
+    }
+
     String findWinningReferences =
         "SELECT DISTINCT ON (customer_id) customer_id, client_name, "
             + "       creator::jsonb ->> 'account' AS winning_account "

--- a/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
+++ b/platform/src/main/java/db/migration/V33__rewrite_wallet_only_customer_id_owner_keys.java
@@ -1,10 +1,12 @@
 package db.migration;
 
+import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
+import org.stellar.sdk.MuxedAccount;
 
 public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMigration {
 
@@ -20,7 +22,8 @@ public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMig
 
     String findWinningReferences =
         "SELECT DISTINCT ON (customer_id) customer_id, client_name, "
-            + "       creator::jsonb ->> 'account' AS winning_account "
+            + "       creator::jsonb ->> 'account' AS winning_account, "
+            + "       creator::jsonb ->> 'memo' AS winning_memo "
             + "FROM ("
             + "  SELECT receiver_id AS customer_id, creator, client_name, started_at, id, status "
             + "    FROM sep31_transaction WHERE receiver_id IS NOT NULL "
@@ -33,7 +36,7 @@ public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMig
             + "ORDER BY customer_id, started_at ASC NULLS LAST, id ASC";
 
     String rewriteKey =
-        "UPDATE sep31_customer_id_owner SET creator_account = ? "
+        "UPDATE sep31_customer_id_owner SET creator_account = ?, creator_memo = ? "
             + "WHERE customer_id = ? AND creator_account = ?";
 
     try (PreparedStatement select = connection.prepareStatement(findWinningReferences);
@@ -45,9 +48,23 @@ public class V33__rewrite_wallet_only_customer_id_owner_keys extends BaseJavaMig
         String winningAccount = rs.getString("winning_account");
         if (winningAccount == null) continue;
 
+        String winningMemo;
+        if (winningAccount.startsWith("M")) {
+          BigInteger muxedId;
+          try {
+            muxedId = new MuxedAccount(winningAccount).getMuxedId();
+          } catch (RuntimeException e) {
+            muxedId = null;
+          }
+          winningMemo = muxedId != null ? muxedId.toString() : null;
+        } else {
+          winningMemo = rs.getString("winning_memo");
+        }
+
         update.setString(1, clientName + ":" + winningAccount);
-        update.setString(2, customerId);
-        update.setString(3, clientName);
+        update.setString(2, winningMemo);
+        update.setString(3, customerId);
+        update.setString(4, clientName);
         update.executeUpdate();
       }
     }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -235,9 +235,15 @@ public class SepBeans {
       ClientService clientService,
       PropertySep24Config sep24Config,
       CustomerIntegration customerIntegration,
-      JwtService jwtService) {
+      JwtService jwtService,
+      Sep31CustomerIdOwnerStore sep31CustomerIdOwnerStore) {
     return new SimpleInteractiveUrlConstructor(
-        assetService, clientService, sep24Config, customerIntegration, jwtService);
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        sep31CustomerIdOwnerStore);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -257,7 +257,8 @@ public class SepBeans {
       RateIntegration rateIntegration,
       Clock clock,
       EventService eventService,
-      Sep31CustomerIdOwnerStore sep31CustomerIdOwnerStore) {
+      Sep31CustomerIdOwnerStore sep31CustomerIdOwnerStore,
+      CustomerIntegration customerIntegration) {
     return new Sep31Service(
         languageConfig,
         sep31Config,
@@ -268,7 +269,8 @@ public class SepBeans {
         eventService,
         clock,
         exchangeAmountsCalculator(sep38QuoteStore, clock),
-        sep31CustomerIdOwnerStore);
+        sep31CustomerIdOwnerStore,
+        customerIntegration);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerRepo.java
@@ -25,4 +25,18 @@ public interface JdbcSep31CustomerIdOwnerRepo
       @Param("customerId") String customerId,
       @Param("creatorAccount") String creatorAccount,
       @Param("creatorMemo") String creatorMemo);
+
+  @Modifying
+  @Transactional
+  @Query(
+      value =
+          "UPDATE sep31_customer_id_owner "
+              + "SET creator_account = :newAccount, creator_memo = :newMemo "
+              + "WHERE customer_id = :customerId AND creator_account = :legacyAccount",
+      nativeQuery = true)
+  int reassignIfCreatorAccountMatches(
+      @Param("customerId") String customerId,
+      @Param("legacyAccount") String legacyAccount,
+      @Param("newAccount") String newAccount,
+      @Param("newMemo") String newMemo);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerRepo.java
@@ -32,11 +32,13 @@ public interface JdbcSep31CustomerIdOwnerRepo
       value =
           "UPDATE sep31_customer_id_owner "
               + "SET creator_account = :newAccount, creator_memo = :newMemo "
-              + "WHERE customer_id = :customerId AND creator_account = :legacyAccount",
+              + "WHERE customer_id = :customerId AND creator_account = :legacyAccount "
+              + "AND creator_memo IS NOT DISTINCT FROM :legacyMemo",
       nativeQuery = true)
   int reassignIfCreatorAccountMatches(
       @Param("customerId") String customerId,
       @Param("legacyAccount") String legacyAccount,
+      @Param("legacyMemo") String legacyMemo,
       @Param("newAccount") String newAccount,
       @Param("newMemo") String newMemo);
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
@@ -27,4 +27,19 @@ public class JdbcSep31CustomerIdOwnerStore implements Sep31CustomerIdOwnerStore 
     return Objects.equals(owner.getCreatorAccount(), creatorAccount)
         && Objects.equals(owner.getCreatorMemo(), creatorMemo);
   }
+
+  @Override
+  public boolean isClaimed(String customerId) {
+    return repo.findById(customerId).isPresent();
+  }
+
+  @Override
+  public boolean verify(String customerId, String creatorAccount, String creatorMemo) {
+    return repo.findById(customerId)
+        .map(
+            owner ->
+                Objects.equals(owner.getCreatorAccount(), creatorAccount)
+                    && Objects.equals(owner.getCreatorMemo(), creatorMemo))
+        .orElse(false);
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
@@ -42,4 +42,15 @@ public class JdbcSep31CustomerIdOwnerStore implements Sep31CustomerIdOwnerStore 
                     && Objects.equals(owner.getCreatorMemo(), creatorMemo))
         .orElse(false);
   }
+
+  @Override
+  public boolean reconcileLegacyKey(
+      String customerId,
+      String legacyCreatorAccount,
+      String newCreatorAccount,
+      String newCreatorMemo) {
+    repo.reassignIfCreatorAccountMatches(
+        customerId, legacyCreatorAccount, newCreatorAccount, newCreatorMemo);
+    return verify(customerId, newCreatorAccount, newCreatorMemo);
+  }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
@@ -35,13 +35,19 @@ public class JdbcSep31CustomerIdOwnerStore implements Sep31CustomerIdOwnerStore 
   }
 
   @Override
-  public boolean verify(String customerId, String creatorAccount, String creatorMemo) {
+  public boolean verify(
+      String customerId, String creatorAccount, String creatorMemo, boolean ignoreMemo) {
     return repo.findById(customerId)
         .map(
             owner ->
                 Objects.equals(owner.getCreatorAccount(), creatorAccount)
-                    && Objects.equals(owner.getCreatorMemo(), creatorMemo))
+                    && (ignoreMemo || Objects.equals(owner.getCreatorMemo(), creatorMemo)))
         .orElse(false);
+  }
+
+  @Override
+  public String getCreatorMemo(String customerId) {
+    return repo.findById(customerId).map(JdbcSep31CustomerIdOwner::getCreatorMemo).orElse(null);
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
@@ -11,7 +11,8 @@ public class JdbcSep31CustomerIdOwnerStore implements Sep31CustomerIdOwnerStore 
   }
 
   @Override
-  public boolean verifyOrClaim(String customerId, String creatorAccount, String creatorMemo) {
+  public boolean verifyOrClaim(
+      String customerId, String creatorAccount, String creatorMemo, boolean ignoreMemo) {
     if (repo.claimIfAbsent(customerId, creatorAccount, creatorMemo) == 1) {
       return true;
     }
@@ -25,7 +26,7 @@ public class JdbcSep31CustomerIdOwnerStore implements Sep31CustomerIdOwnerStore 
                             + customerId));
 
     return Objects.equals(owner.getCreatorAccount(), creatorAccount)
-        && Objects.equals(owner.getCreatorMemo(), creatorMemo);
+        && (ignoreMemo || Objects.equals(owner.getCreatorMemo(), creatorMemo));
   }
 
   @Override

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStore.java
@@ -47,10 +47,11 @@ public class JdbcSep31CustomerIdOwnerStore implements Sep31CustomerIdOwnerStore 
   public boolean reconcileLegacyKey(
       String customerId,
       String legacyCreatorAccount,
+      String legacyCreatorMemo,
       String newCreatorAccount,
       String newCreatorMemo) {
     repo.reassignIfCreatorAccountMatches(
-        customerId, legacyCreatorAccount, newCreatorAccount, newCreatorMemo);
+        customerId, legacyCreatorAccount, legacyCreatorMemo, newCreatorAccount, newCreatorMemo);
     return verify(customerId, newCreatorAccount, newCreatorMemo);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -134,10 +134,7 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
         }
         PutCustomerResponse forwarded = customerIntegration.putCustomer(putCustomerRequest);
 
-        ClientConfig clientConfig =
-            clientsService.getClientConfigByDomainAndAccount(
-                jwt.getClientDomain(), jwt.getAccount());
-        String owner = clientConfig != null ? clientConfig.getName() : jwt.getOwnerAccount();
+        String owner = jwt.getClientName() != null ? jwt.getClientName() : jwt.getOwnerAccount();
 
         if (!customerIdOwnerStore.verifyOrClaim(forwarded.getId(), owner, jwt.getOwnerMemo())) {
           throw new SepNotAuthorizedException("customer id already claimed by another client");

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -29,6 +29,7 @@ import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.platform.config.PropertySep24Config;
 import org.stellar.anchor.sep24.InteractiveUrlConstructor;
 import org.stellar.anchor.sep24.Sep24Transaction;
+import org.stellar.anchor.sep31.CustomerOwnershipReconciliation;
 import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore;
 import org.stellar.anchor.util.GsonUtils;
 
@@ -140,7 +141,13 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
         }
 
         if (!customerIdOwnerStore.verifyOrClaim(
-            forwarded.getId(), jwt.getOwnerKey(), jwt.getOwnerMemo())) {
+                forwarded.getId(), jwt.getOwnerKey(), jwt.getOwnerMemo())
+            && !CustomerOwnershipReconciliation.tryReconcile(
+                customerIdOwnerStore,
+                customerIntegration,
+                forwarded.getId(),
+                jwt,
+                FORWARD_KYC_CUSTOMER_TYPE)) {
           throw new SepNotAuthorizedException("customer id already claimed by another client");
         }
       }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -16,7 +16,9 @@ import org.apache.http.client.utils.URIBuilder;
 import org.stellar.anchor.api.asset.AssetInfo;
 import org.stellar.anchor.api.callback.CustomerIntegration;
 import org.stellar.anchor.api.callback.PutCustomerRequest;
+import org.stellar.anchor.api.callback.PutCustomerResponse;
 import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.SepNotAuthorizedException;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt;
@@ -26,6 +28,7 @@ import org.stellar.anchor.client.ClientService;
 import org.stellar.anchor.platform.config.PropertySep24Config;
 import org.stellar.anchor.sep24.InteractiveUrlConstructor;
 import org.stellar.anchor.sep24.Sep24Transaction;
+import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore;
 import org.stellar.anchor.util.GsonUtils;
 
 public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
@@ -35,18 +38,21 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
   private final PropertySep24Config sep24Config;
   private final CustomerIntegration customerIntegration;
   private final JwtService jwtService;
+  private final Sep31CustomerIdOwnerStore customerIdOwnerStore;
 
   public SimpleInteractiveUrlConstructor(
       AssetService assetService,
       ClientService clientsService,
       PropertySep24Config sep24Config,
       CustomerIntegration customerIntegration,
-      JwtService jwtService) {
+      JwtService jwtService,
+      Sep31CustomerIdOwnerStore customerIdOwnerStore) {
     this.assetService = assetService;
     this.clientsService = clientsService;
     this.sep24Config = sep24Config;
     this.customerIntegration = customerIntegration;
     this.jwtService = jwtService;
+    this.customerIdOwnerStore = customerIdOwnerStore;
   }
 
   @Override
@@ -126,8 +132,16 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
           putCustomerRequest.setMemo(jwt.getAccountMemo());
           putCustomerRequest.setMemoType("id");
         }
-        // forward kyc fields to PUT /customer
-        customerIntegration.putCustomer(putCustomerRequest);
+        PutCustomerResponse forwarded = customerIntegration.putCustomer(putCustomerRequest);
+
+        ClientConfig clientConfig =
+            clientsService.getClientConfigByDomainAndAccount(
+                jwt.getClientDomain(), jwt.getAccount());
+        String owner = clientConfig != null ? clientConfig.getName() : jwt.getOwnerAccount();
+
+        if (!customerIdOwnerStore.verifyOrClaim(forwarded.getId(), owner, jwt.getOwnerMemo())) {
+          throw new SepNotAuthorizedException("customer id already claimed by another client");
+        }
       }
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -127,6 +127,34 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
       Map<String, String> sep9 = extractSep9Fields(request);
       // Putting SEP-9 into JWT exposes PII
       if (!sep9.isEmpty()) {
+        GetCustomerResponse existing;
+        try {
+          existing =
+              customerIntegration.getCustomer(
+                  GetCustomerRequest.builder()
+                      .account(jwt.getAccount())
+                      .memo(jwt.getOwnerMemo())
+                      .memoType(jwt.getOwnerMemo() != null ? "id" : null)
+                      .type(FORWARD_KYC_CUSTOMER_TYPE)
+                      .build());
+        } catch (Exception e) {
+          Log.warnEx(e);
+          existing = null;
+        }
+
+        if (existing != null
+            && existing.getId() != null
+            && customerIdOwnerStore.isClaimed(existing.getId())
+            && !customerIdOwnerStore.verify(existing.getId(), jwt.getOwnerKey(), jwt.getOwnerMemo())
+            && !CustomerOwnershipReconciliation.tryReconcile(
+                customerIdOwnerStore,
+                customerIntegration,
+                existing.getId(),
+                jwt,
+                FORWARD_KYC_CUSTOMER_TYPE)) {
+          throw new SepNotAuthorizedException("customer id already claimed by another client");
+        }
+
         Gson gson = GsonUtils.getInstance();
         String gsonRequest = gson.toJson(sep9);
         PutCustomerRequest putCustomerRequest =

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -15,6 +15,8 @@ import lombok.SneakyThrows;
 import org.apache.http.client.utils.URIBuilder;
 import org.stellar.anchor.api.asset.AssetInfo;
 import org.stellar.anchor.api.callback.CustomerIntegration;
+import org.stellar.anchor.api.callback.GetCustomerRequest;
+import org.stellar.anchor.api.callback.GetCustomerResponse;
 import org.stellar.anchor.api.callback.PutCustomerRequest;
 import org.stellar.anchor.api.callback.PutCustomerResponse;
 import org.stellar.anchor.api.exception.AnchorException;
@@ -32,6 +34,7 @@ import org.stellar.anchor.sep24.Sep24Transaction;
 import org.stellar.anchor.sep31.CustomerOwnershipReconciliation;
 import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore;
 import org.stellar.anchor.util.GsonUtils;
+import org.stellar.anchor.util.Log;
 
 public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
   public static final String FORWARD_KYC_CUSTOMER_TYPE = "sep24-customer";
@@ -138,6 +141,26 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
         if (forwarded == null || forwarded.getId() == null) {
           throw new ServerErrorException(
               "business server returned an empty PUT /customer response");
+        }
+
+        if (!customerIdOwnerStore.isClaimed(forwarded.getId())) {
+          GetCustomerResponse callbackCustomer;
+          try {
+            callbackCustomer =
+                customerIntegration.getCustomer(
+                    GetCustomerRequest.builder()
+                        .account(jwt.getAccount())
+                        .memo(jwt.getOwnerMemo())
+                        .memoType(jwt.getOwnerMemo() != null ? "id" : null)
+                        .type(FORWARD_KYC_CUSTOMER_TYPE)
+                        .build());
+          } catch (Exception e) {
+            Log.warnEx(e);
+            callbackCustomer = null;
+          }
+          if (callbackCustomer == null || !forwarded.getId().equals(callbackCustomer.getId())) {
+            throw new SepNotAuthorizedException("customer id already claimed by another client");
+          }
         }
 
         if (!customerIdOwnerStore.verifyOrClaim(

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -187,7 +187,7 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
                         .build());
           } catch (Exception e) {
             Log.warnEx(e);
-            callbackCustomer = null;
+            throw new ServerErrorException("unable to verify customer ownership", e);
           }
           if (callbackCustomer == null || !forwarded.getId().equals(callbackCustomer.getId())) {
             throw new SepNotAuthorizedException("customer id already claimed by another client");

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -128,8 +128,8 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
             gson.fromJson(gsonRequest, PutCustomerRequest.class);
         putCustomerRequest.setType(FORWARD_KYC_CUSTOMER_TYPE);
         putCustomerRequest.setAccount(jwt.getAccount());
-        if (jwt.getAccountMemo() != null) {
-          putCustomerRequest.setMemo(jwt.getAccountMemo());
+        if (jwt.getOwnerMemo() != null) {
+          putCustomerRequest.setMemo(jwt.getOwnerMemo());
           putCustomerRequest.setMemoType("id");
         }
         PutCustomerResponse forwarded = customerIntegration.putCustomer(putCustomerRequest);

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -20,6 +20,7 @@ import org.stellar.anchor.api.callback.GetCustomerResponse;
 import org.stellar.anchor.api.callback.PutCustomerRequest;
 import org.stellar.anchor.api.callback.PutCustomerResponse;
 import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.NotFoundException;
 import org.stellar.anchor.api.exception.SepNotAuthorizedException;
 import org.stellar.anchor.api.exception.ServerErrorException;
 import org.stellar.anchor.asset.AssetService;
@@ -137,9 +138,11 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
                       .memoType(jwt.getOwnerMemo() != null ? "id" : null)
                       .type(FORWARD_KYC_CUSTOMER_TYPE)
                       .build());
+        } catch (NotFoundException e) {
+          existing = null;
         } catch (Exception e) {
           Log.warnEx(e);
-          existing = null;
+          throw new ServerErrorException("unable to verify customer ownership", e);
         }
 
         if (existing != null

--- a/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructor.java
@@ -19,6 +19,7 @@ import org.stellar.anchor.api.callback.PutCustomerRequest;
 import org.stellar.anchor.api.callback.PutCustomerResponse;
 import org.stellar.anchor.api.exception.AnchorException;
 import org.stellar.anchor.api.exception.SepNotAuthorizedException;
+import org.stellar.anchor.api.exception.ServerErrorException;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt;
@@ -133,10 +134,13 @@ public class SimpleInteractiveUrlConstructor extends InteractiveUrlConstructor {
           putCustomerRequest.setMemoType("id");
         }
         PutCustomerResponse forwarded = customerIntegration.putCustomer(putCustomerRequest);
+        if (forwarded == null || forwarded.getId() == null) {
+          throw new ServerErrorException(
+              "business server returned an empty PUT /customer response");
+        }
 
-        String owner = jwt.getClientName() != null ? jwt.getClientName() : jwt.getOwnerAccount();
-
-        if (!customerIdOwnerStore.verifyOrClaim(forwarded.getId(), owner, jwt.getOwnerMemo())) {
+        if (!customerIdOwnerStore.verifyOrClaim(
+            forwarded.getId(), jwt.getOwnerKey(), jwt.getOwnerMemo())) {
           throw new SepNotAuthorizedException("customer id already claimed by another client");
         }
       }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
@@ -71,4 +71,60 @@ class JdbcSep31CustomerIdOwnerStoreTest {
       store.verifyOrClaim("cust-1", "GALICE", "111")
     }
   }
+
+  @Test
+  fun `isClaimed is false for a missing id`() {
+    every { repo.findById("cust-missing") } returns Optional.empty()
+
+    assertFalse(store.isClaimed("cust-missing"))
+  }
+
+  @Test
+  fun `isClaimed is true when a row exists`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertTrue(store.isClaimed("cust-1"))
+  }
+
+  @Test
+  fun `verify is false for a missing id`() {
+    every { repo.findById("cust-missing") } returns Optional.empty()
+
+    assertFalse(store.verify("cust-missing", "GALICE", "111"))
+  }
+
+  @Test
+  fun `verify is true when account and memo both match`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertTrue(store.verify("cust-1", "GALICE", "111"))
+  }
+
+  @Test
+  fun `verify is false when the account does not match`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertFalse(store.verify("cust-1", "GMALLORY", "111"))
+  }
+
+  @Test
+  fun `verify is false when the memo does not match`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertFalse(store.verify("cust-1", "GALICE", "222"))
+  }
+
+  @Test
+  fun `verify is false when a null memo is compared against a non-null stored memo`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertFalse(store.verify("cust-1", "GALICE", null))
+  }
+
+  @Test
+  fun `verify is true when both the stored and requested memo are null`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", null))
+
+    assertTrue(store.verify("cust-1", "GALICE", null))
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
@@ -127,4 +127,40 @@ class JdbcSep31CustomerIdOwnerStoreTest {
 
     assertTrue(store.verify("cust-1", "GALICE", null))
   }
+
+  @Test
+  fun `reconcileLegacyKey rewrites a row still keyed by the legacy value and confirms the new key`() {
+    every {
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GALICE", "111")
+    } returns 1
+    every { repo.findById("cust-1") } returns
+      Optional.of(ownerRow("cust-1", "vibrant:GALICE", "111"))
+
+    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", "vibrant:GALICE", "111"))
+    verify(exactly = 1) {
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GALICE", "111")
+    }
+  }
+
+  @Test
+  fun `reconcileLegacyKey returns true when the row already matches the new key`() {
+    every {
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GALICE", "111")
+    } returns 0
+    every { repo.findById("cust-1") } returns
+      Optional.of(ownerRow("cust-1", "vibrant:GALICE", "111"))
+
+    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", "vibrant:GALICE", "111"))
+  }
+
+  @Test
+  fun `reconcileLegacyKey returns false when the row belongs to a different owner`() {
+    every {
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GATTACKER", "111")
+    } returns 0
+    every { repo.findById("cust-1") } returns
+      Optional.of(ownerRow("cust-1", "vibrant:GVICTIM", "111"))
+
+    assertFalse(store.reconcileLegacyKey("cust-1", "vibrant", "vibrant:GATTACKER", "111"))
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
@@ -154,6 +154,34 @@ class JdbcSep31CustomerIdOwnerStoreTest {
   }
 
   @Test
+  fun `verify with ignoreMemo true succeeds for the same account under a different memo`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertTrue(store.verify("cust-1", "GALICE", "222", true))
+  }
+
+  @Test
+  fun `verify with ignoreMemo true still rejects a different account`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertFalse(store.verify("cust-1", "GMALLORY", "111", true))
+  }
+
+  @Test
+  fun `getCreatorMemo returns null for a missing id`() {
+    every { repo.findById("cust-missing") } returns Optional.empty()
+
+    assertNull(store.getCreatorMemo("cust-missing"))
+  }
+
+  @Test
+  fun `getCreatorMemo returns the row's current memo`() {
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "vibrant", "42"))
+
+    assertEquals("42", store.getCreatorMemo("cust-1"))
+  }
+
+  @Test
   fun `reconcileLegacyKey rewrites a row still keyed by the legacy value and confirms the new key`() {
     every {
       repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", null, "vibrant:GALICE", "111")

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
@@ -131,36 +131,50 @@ class JdbcSep31CustomerIdOwnerStoreTest {
   @Test
   fun `reconcileLegacyKey rewrites a row still keyed by the legacy value and confirms the new key`() {
     every {
-      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GALICE", "111")
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", null, "vibrant:GALICE", "111")
     } returns 1
     every { repo.findById("cust-1") } returns
       Optional.of(ownerRow("cust-1", "vibrant:GALICE", "111"))
 
-    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", "vibrant:GALICE", "111"))
+    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", null, "vibrant:GALICE", "111"))
     verify(exactly = 1) {
-      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GALICE", "111")
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", null, "vibrant:GALICE", "111")
     }
   }
 
   @Test
   fun `reconcileLegacyKey returns true when the row already matches the new key`() {
     every {
-      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GALICE", "111")
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", null, "vibrant:GALICE", "111")
     } returns 0
     every { repo.findById("cust-1") } returns
       Optional.of(ownerRow("cust-1", "vibrant:GALICE", "111"))
 
-    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", "vibrant:GALICE", "111"))
+    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", null, "vibrant:GALICE", "111"))
   }
 
   @Test
   fun `reconcileLegacyKey returns false when the row belongs to a different owner`() {
     every {
-      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "vibrant:GATTACKER", "111")
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", null, "vibrant:GATTACKER", "111")
     } returns 0
     every { repo.findById("cust-1") } returns
       Optional.of(ownerRow("cust-1", "vibrant:GVICTIM", "111"))
 
-    assertFalse(store.reconcileLegacyKey("cust-1", "vibrant", "vibrant:GATTACKER", "111"))
+    assertFalse(store.reconcileLegacyKey("cust-1", "vibrant", null, "vibrant:GATTACKER", "111"))
+  }
+
+  @Test
+  fun `reconcileLegacyKey threads the legacy memo through to the reassignment query`() {
+    every {
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "111", "vibrant:GALICE", "111")
+    } returns 1
+    every { repo.findById("cust-1") } returns
+      Optional.of(ownerRow("cust-1", "vibrant:GALICE", "111"))
+
+    assertTrue(store.reconcileLegacyKey("cust-1", "vibrant", "111", "vibrant:GALICE", "111"))
+    verify(exactly = 1) {
+      repo.reassignIfCreatorAccountMatches("cust-1", "vibrant", "111", "vibrant:GALICE", "111")
+    }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcSep31CustomerIdOwnerStoreTest.kt
@@ -73,6 +73,31 @@ class JdbcSep31CustomerIdOwnerStoreTest {
   }
 
   @Test
+  fun `verifyOrClaim with ignoreMemo true succeeds for the same account under a different memo`() {
+    every { repo.claimIfAbsent("cust-1", "GALICE", "222") } returns 0
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertTrue(store.verifyOrClaim("cust-1", "GALICE", "222", true))
+  }
+
+  @Test
+  fun `verifyOrClaim with ignoreMemo true still rejects a different account`() {
+    every { repo.claimIfAbsent("cust-1", "GMALLORY", "111") } returns 0
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertFalse(store.verifyOrClaim("cust-1", "GMALLORY", "111", true))
+  }
+
+  @Test
+  fun `verifyOrClaim with ignoreMemo false is unaffected by the flag's default`() {
+    every { repo.claimIfAbsent("cust-1", "GALICE", "222") } returns 0
+    every { repo.findById("cust-1") } returns Optional.of(ownerRow("cust-1", "GALICE", "111"))
+
+    assertFalse(store.verifyOrClaim("cust-1", "GALICE", "222", false))
+    assertFalse(store.verifyOrClaim("cust-1", "GALICE", "222"))
+  }
+
+  @Test
   fun `isClaimed is false for a missing id`() {
     every { repo.findById("cust-missing") } returns Optional.empty()
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -135,6 +135,7 @@ class SimpleInteractiveUrlConstructorTest {
     val capturedPutCustomerRequest = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(capturedPutCustomerRequest)) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(
@@ -185,6 +186,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(
@@ -211,11 +213,48 @@ class SimpleInteractiveUrlConstructorTest {
   }
 
   @Test
+  fun `when the forwarded id is genuinely new, the callback confirms it before claiming it`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("new-customer-id").build()
+    every { customerIdOwnerStore.isClaimed("new-customer-id") } returns false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("new-customer-id").build()
+    every { customerIdOwnerStore.verifyOrClaim("new-customer-id", "test_account", "123") } returns
+      true
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns("123")
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns("123")
+    every { webAuthJwt.clientName }.returns(null)
+    every { webAuthJwt.ownerKey }.returns("test_account")
+
+    assertDoesNotThrow {
+      constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+    }
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("new-customer-id", "test_account", "123")
+    }
+  }
+
+  @Test
   fun `when the forwarded customer id is already claimed by another client, construct throws`() {
     val customerIntegration: CustomerIntegration = mockk()
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns false
     val constructor =
       SimpleInteractiveUrlConstructor(
@@ -239,11 +278,43 @@ class SimpleInteractiveUrlConstructorTest {
   }
 
   @Test
+  fun `when the business server resolves the KYC fields to a different unclaimed customer, construct throws instead of claiming it`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("deduped-existing-customer-id").build()
+    every { customerIdOwnerStore.isClaimed("deduped-existing-customer-id") } returns false
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("some-other-customer-id").build()
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns("123")
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns("123")
+    every { webAuthJwt.clientName }.returns(null)
+
+    assertThrows(SepNotAuthorizedException::class.java) {
+      constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+    }
+    verify(exactly = 0) { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) }
+  }
+
+  @Test
   fun `when the jwt carries a client_name claim, the forwarded id is claimed under that client name`() {
     val customerIntegration: CustomerIntegration = mockk()
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(
@@ -275,6 +346,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("legacy-customer-id").build()
+    every { customerIdOwnerStore.isClaimed("legacy-customer-id") } returns true
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("legacy-customer-id").build()
     every {
@@ -316,6 +388,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(
@@ -356,6 +429,7 @@ class SimpleInteractiveUrlConstructorTest {
     val putRequestSlot = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(putRequestSlot)) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -135,6 +135,7 @@ class SimpleInteractiveUrlConstructorTest {
     val capturedPutCustomerRequest = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(capturedPutCustomerRequest)) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns null
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
@@ -186,6 +187,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns null
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
@@ -254,6 +256,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns null
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns false
     val constructor =
@@ -284,6 +287,7 @@ class SimpleInteractiveUrlConstructorTest {
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("deduped-existing-customer-id").build()
     every { customerIdOwnerStore.isClaimed("deduped-existing-customer-id") } returns false
+    every { customerIdOwnerStore.isClaimed("some-other-customer-id") } returns false
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("some-other-customer-id").build()
     val constructor =
@@ -314,6 +318,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns null
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
@@ -350,12 +355,16 @@ class SimpleInteractiveUrlConstructorTest {
     every { customerIntegration.getCustomer(any()) } returns
       GetCustomerResponse.builder().id("legacy-customer-id").build()
     every {
+      customerIdOwnerStore.verify("legacy-customer-id", "vibrant:test_account", null)
+    } returns false
+    every {
       customerIdOwnerStore.verifyOrClaim("legacy-customer-id", "vibrant:test_account", null)
     } returns false
     every {
       customerIdOwnerStore.reconcileLegacyKey(
         "legacy-customer-id",
         "vibrant",
+        null,
         "vibrant:test_account",
         null,
       )
@@ -388,6 +397,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     every { customerIntegration.putCustomer(any()) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns null
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
@@ -429,6 +439,7 @@ class SimpleInteractiveUrlConstructorTest {
     val putRequestSlot = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(putRequestSlot)) } returns
       PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns null
     every { customerIdOwnerStore.isClaimed(any()) } returns true
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -133,7 +133,7 @@ class SimpleInteractiveUrlConstructorTest {
     val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     val capturedPutCustomerRequest = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(capturedPutCustomerRequest)) } returns
-      PutCustomerResponse()
+      PutCustomerResponse.builder().id("forwarded-customer-id").build()
     every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(
@@ -150,6 +150,7 @@ class SimpleInteractiveUrlConstructorTest {
     every { webAuthJwt.ownerAccount }.returns("test_account")
     every { webAuthJwt.ownerMemo }.returns("123")
     every { webAuthJwt.clientName }.returns(null)
+    every { webAuthJwt.ownerKey }.returns("test_account")
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
     assertEquals(capturedPutCustomerRequest.captured.firstName, request.get("first_name"))
@@ -199,6 +200,7 @@ class SimpleInteractiveUrlConstructorTest {
     every { webAuthJwt.ownerAccount }.returns("test_account")
     every { webAuthJwt.ownerMemo }.returns("123")
     every { webAuthJwt.clientName }.returns(null)
+    every { webAuthJwt.ownerKey }.returns("test_account")
 
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
 
@@ -257,11 +259,12 @@ class SimpleInteractiveUrlConstructorTest {
     every { webAuthJwt.ownerAccount }.returns("test_account")
     every { webAuthJwt.ownerMemo }.returns(null)
     every { webAuthJwt.clientName }.returns("vibrant")
+    every { webAuthJwt.ownerKey }.returns("vibrant:test_account")
 
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
 
     verify(exactly = 1) {
-      customerIdOwnerStore.verifyOrClaim("forwarded-customer-id", "vibrant", null)
+      customerIdOwnerStore.verifyOrClaim("forwarded-customer-id", "vibrant:test_account", null)
     }
   }
 
@@ -290,6 +293,8 @@ class SimpleInteractiveUrlConstructorTest {
       .returns("MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC")
     every { webAuthJwt.ownerMemo }.returns(null)
     every { webAuthJwt.clientName }.returns(null)
+    every { webAuthJwt.ownerKey }
+      .returns("MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC")
 
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
 
@@ -328,6 +333,8 @@ class SimpleInteractiveUrlConstructorTest {
       .returns("MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC")
     every { webAuthJwt.ownerMemo }.returns("42")
     every { webAuthJwt.clientName }.returns(null)
+    every { webAuthJwt.ownerKey }
+      .returns("MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC")
 
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -360,6 +360,7 @@ class SimpleInteractiveUrlConstructorTest {
     every {
       customerIdOwnerStore.verifyOrClaim("legacy-customer-id", "vibrant:test_account", null)
     } returns false
+    every { customerIdOwnerStore.getCreatorMemo("legacy-customer-id") } returns null
     every {
       customerIdOwnerStore.reconcileLegacyKey(
         "legacy-customer-id",

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -17,6 +17,7 @@ import org.stellar.anchor.api.callback.GetCustomerResponse
 import org.stellar.anchor.api.callback.PutCustomerRequest
 import org.stellar.anchor.api.callback.PutCustomerResponse
 import org.stellar.anchor.api.exception.SepNotAuthorizedException
+import org.stellar.anchor.api.exception.ServerErrorException
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.JwtService.*
@@ -278,6 +279,33 @@ class SimpleInteractiveUrlConstructorTest {
     assertThrows(SepNotAuthorizedException::class.java) {
       constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     }
+  }
+
+  @Test
+  fun `when the pre-check callback lookup fails with a server error, construct aborts without writing`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.getCustomer(any()) } throws RuntimeException("callback unavailable")
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns("123")
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns("123")
+    every { webAuthJwt.clientName }.returns(null)
+
+    assertThrows(ServerErrorException::class.java) {
+      constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+    }
+    verify(exactly = 0) { customerIntegration.putCustomer(any()) }
   }
 
   @Test

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -302,6 +302,46 @@ class SimpleInteractiveUrlConstructorTest {
     }
   }
 
+  @Test
+  fun `when a custodial client authenticates with a muxed account, the forwarded customer callback receives the muxed owner memo, not the account memo`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    val putRequestSlot = slot<PutCustomerRequest>()
+    every { customerIntegration.putCustomer(capture(putRequestSlot)) } returns
+      PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    val baseAccountRegisteredAsSomeWallet =
+      "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { webAuthJwt.account }.returns(baseAccountRegisteredAsSomeWallet)
+    every { webAuthJwt.accountMemo }.returns(null)
+    every { webAuthJwt.ownerAccount }
+      .returns("MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC")
+    every { webAuthJwt.ownerMemo }.returns("42")
+    every { webAuthJwt.clientName }.returns(null)
+
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+
+    assertEquals(baseAccountRegisteredAsSomeWallet, putRequestSlot.captured.account)
+    assertEquals("42", putRequestSlot.captured.memo)
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim(
+        "forwarded-customer-id",
+        "MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC",
+        "42",
+      )
+    }
+  }
+
   private fun parseJwtFromUrl(url: String?): Sep24InteractiveUrlJwt {
     val params = UriComponentsBuilder.fromUriString(url!!).build().queryParams
     val cipher = params["token"]!![0]

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.web.util.UriComponentsBuilder
 import org.stellar.anchor.api.asset.AssetInfo
 import org.stellar.anchor.api.callback.CustomerIntegration
+import org.stellar.anchor.api.callback.GetCustomerResponse
 import org.stellar.anchor.api.callback.PutCustomerRequest
 import org.stellar.anchor.api.callback.PutCustomerResponse
 import org.stellar.anchor.api.exception.SepNotAuthorizedException
@@ -265,6 +266,47 @@ class SimpleInteractiveUrlConstructorTest {
 
     verify(exactly = 1) {
       customerIdOwnerStore.verifyOrClaim("forwarded-customer-id", "vibrant:test_account", null)
+    }
+  }
+
+  @Test
+  fun `when the forwarded id is a legacy wallet-only key, the callback confirms it and it is reconciled`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("legacy-customer-id").build()
+    every { customerIntegration.getCustomer(any()) } returns
+      GetCustomerResponse.builder().id("legacy-customer-id").build()
+    every {
+      customerIdOwnerStore.verifyOrClaim("legacy-customer-id", "vibrant:test_account", null)
+    } returns false
+    every {
+      customerIdOwnerStore.reconcileLegacyKey(
+        "legacy-customer-id",
+        "vibrant",
+        "vibrant:test_account",
+        null,
+      )
+    } returns true
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns(null)
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns(null)
+    every { webAuthJwt.clientName }.returns("vibrant")
+    every { webAuthJwt.ownerKey }.returns("vibrant:test_account")
+
+    assertDoesNotThrow {
+      constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     }
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -149,6 +149,7 @@ class SimpleInteractiveUrlConstructorTest {
     every { webAuthJwt.accountMemo }.returns("123")
     every { webAuthJwt.ownerAccount }.returns("test_account")
     every { webAuthJwt.ownerMemo }.returns("123")
+    every { webAuthJwt.clientName }.returns(null)
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
     assertEquals(capturedPutCustomerRequest.captured.firstName, request.get("first_name"))
@@ -197,6 +198,7 @@ class SimpleInteractiveUrlConstructorTest {
     every { webAuthJwt.accountMemo }.returns("123")
     every { webAuthJwt.ownerAccount }.returns("test_account")
     every { webAuthJwt.ownerMemo }.returns("123")
+    every { webAuthJwt.clientName }.returns(null)
 
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
 
@@ -226,9 +228,77 @@ class SimpleInteractiveUrlConstructorTest {
     every { webAuthJwt.accountMemo }.returns("123")
     every { webAuthJwt.ownerAccount }.returns("test_account")
     every { webAuthJwt.ownerMemo }.returns("123")
+    every { webAuthJwt.clientName }.returns(null)
 
     assertThrows(SepNotAuthorizedException::class.java) {
       constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+    }
+  }
+
+  @Test
+  fun `when the jwt carries a client_name claim, the forwarded id is claimed under that client name`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns(null)
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns(null)
+    every { webAuthJwt.clientName }.returns("vibrant")
+
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("forwarded-customer-id", "vibrant", null)
+    }
+  }
+
+  @Test
+  fun `when a custodial client authenticates with a muxed account and the jwt carries no client_name, ownership uses the muxed owner account rather than a re-resolved client name`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    val baseAccountRegisteredAsSomeWallet =
+      "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP"
+    every { webAuthJwt.account }.returns(baseAccountRegisteredAsSomeWallet)
+    every { webAuthJwt.accountMemo }.returns(null)
+    every { webAuthJwt.ownerAccount }
+      .returns("MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC")
+    every { webAuthJwt.ownerMemo }.returns(null)
+    every { webAuthJwt.clientName }.returns(null)
+
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim(
+        "forwarded-customer-id",
+        "MDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPPAAAAAAAAAAAAJEUC",
+        null,
+      )
     }
   }
 

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/SimpleInteractiveUrlConstructorTest.kt
@@ -15,6 +15,7 @@ import org.stellar.anchor.api.asset.AssetInfo
 import org.stellar.anchor.api.callback.CustomerIntegration
 import org.stellar.anchor.api.callback.PutCustomerRequest
 import org.stellar.anchor.api.callback.PutCustomerResponse
+import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.auth.JwtService
 import org.stellar.anchor.auth.JwtService.*
@@ -28,6 +29,7 @@ import org.stellar.anchor.platform.config.PropertySep24Config
 import org.stellar.anchor.platform.data.JdbcSep24Transaction
 import org.stellar.anchor.platform.service.SimpleInteractiveUrlConstructor.FORWARD_KYC_CUSTOMER_TYPE
 import org.stellar.anchor.platform.utils.setupMock
+import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore
 import org.stellar.anchor.util.GsonUtils
 
 @Suppress("UNCHECKED_CAST")
@@ -45,6 +47,7 @@ class SimpleInteractiveUrlConstructorTest {
   @MockK(relaxed = true) private lateinit var customerIntegration: CustomerIntegration
   @MockK(relaxed = true) private lateinit var testAsset: AssetInfo
   @MockK(relaxed = true) private lateinit var webAuthJwt: WebAuthJwt
+  @MockK(relaxed = true) private lateinit var customerIdOwnerStore: Sep31CustomerIdOwnerStore
 
   private lateinit var jwtService: JwtService
   private lateinit var sep24Config: PropertySep24Config
@@ -81,6 +84,7 @@ class SimpleInteractiveUrlConstructorTest {
         testConfig,
         customerIntegration,
         jwtService,
+        customerIdOwnerStore,
       )
 
     var jwt =
@@ -126,9 +130,11 @@ class SimpleInteractiveUrlConstructorTest {
   @Test
   fun `when kycFieldsForwarding is enabled, the customerIntegration should receive the kyc fields`() {
     val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
     val capturedPutCustomerRequest = slot<PutCustomerRequest>()
     every { customerIntegration.putCustomer(capture(capturedPutCustomerRequest)) } returns
       PutCustomerResponse()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
     val constructor =
       SimpleInteractiveUrlConstructor(
         assetService,
@@ -136,10 +142,13 @@ class SimpleInteractiveUrlConstructorTest {
         sep24Config,
         customerIntegration,
         jwtService,
+        customerIdOwnerStore,
       )
     sep24Config.kycFieldsForwarding.isEnabled = true
     every { webAuthJwt.account }.returns("test_account")
     every { webAuthJwt.accountMemo }.returns("123")
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns("123")
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     assertEquals(capturedPutCustomerRequest.captured.type, FORWARD_KYC_CUSTOMER_TYPE)
     assertEquals(capturedPutCustomerRequest.captured.firstName, request.get("first_name"))
@@ -160,10 +169,67 @@ class SimpleInteractiveUrlConstructorTest {
         sep24Config,
         customerIntegration,
         jwtService,
+        customerIdOwnerStore,
       )
     sep24Config.kycFieldsForwarding.isEnabled = false
     constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
     verify(exactly = 0) { customerIntegration.putCustomer(any()) }
+  }
+
+  @Test
+  fun `when kycFieldsForwarding is enabled, the forwarded customer id is claimed for the caller`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns true
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns("123")
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns("123")
+
+    constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+
+    verify(exactly = 1) {
+      customerIdOwnerStore.verifyOrClaim("forwarded-customer-id", "test_account", "123")
+    }
+  }
+
+  @Test
+  fun `when the forwarded customer id is already claimed by another client, construct throws`() {
+    val customerIntegration: CustomerIntegration = mockk()
+    val customerIdOwnerStore: Sep31CustomerIdOwnerStore = mockk()
+    every { customerIntegration.putCustomer(any()) } returns
+      PutCustomerResponse.builder().id("forwarded-customer-id").build()
+    every { customerIdOwnerStore.verifyOrClaim(any(), any(), any()) } returns false
+    val constructor =
+      SimpleInteractiveUrlConstructor(
+        assetService,
+        clientService,
+        sep24Config,
+        customerIntegration,
+        jwtService,
+        customerIdOwnerStore,
+      )
+    sep24Config.kycFieldsForwarding.isEnabled = true
+    every { webAuthJwt.account }.returns("test_account")
+    every { webAuthJwt.accountMemo }.returns("123")
+    every { webAuthJwt.ownerAccount }.returns("test_account")
+    every { webAuthJwt.ownerMemo }.returns("123")
+
+    assertThrows(SepNotAuthorizedException::class.java) {
+      constructor.construct(txn, request as HashMap<String, String>?, testAsset, webAuthJwt)
+    }
   }
 
   private fun parseJwtFromUrl(url: String?): Sep24InteractiveUrlJwt {


### PR DESCRIPTION
### Description

`sep31_customer_id_owner` only ever gets a row written for a SEP-12 customer created through `Sep12Service.putCustomer` with `type = "sep31-sender"`/`"sep31-receiver"` (the `isNewSep31Customer` gate). Every other way a customer id gets minted — a SEP-6 registration, a plain untyped `PUT /sep12/customer`, and, critically, the SEP-24 interactive flow forwarding SEP-9 fields via `SimpleInteractiveUrlConstructor.forwardKycFields` — leaves the id permanently unowned. `Sep31Service.postTransaction`'s `verifyOrClaim` treats "no owner row" as "you own it," so the first caller to name that unowned id as `receiver_id` in `POST /sep31/transactions` becomes its recorded owner. From there, the `transaction_id` branch of SEP-12 resolves the customer from that transaction and lets the new "owner" read the victim's KYC status/field inventory and overwrite the victim's payout bank details.

**Changes**
- [x] `Sep12Service.putCustomer`: add `isNewCustomer`, any successful creation (no `id`/`transaction_id` on the request, regardless of `type`) now claims ownership of the returned id for the caller.
- [x] `SimpleInteractiveUrlConstructor.forwardKycFields`: captures the `PutCustomerResponse` (previously discarded) and claims the forwarded id via `Sep31CustomerIdOwnerStore.verifyOrClaim`, resolving the owner as `jwt.getClientName()` if the token carries that claim, else `jwt.getOwnerAccount()` — the same resolution `Sep12Service`/`Sep31Service` already use. An earlier version of this fix re-resolved the client via `clientsService.getClientConfigByDomainAndAccount(jwt.getClientDomain(), jwt.getAccount())`; that's wrong for a custodial client authenticated with a muxed account, since SEP-10 resolves the client against the original M-address while `jwt.getAccount()` is normalized to the base G-address — the lookup could assign a client name the token itself doesn't carry, storing the claim under an identity `Sep31Service` would never match on the same token (`jwt.getOwnerAccount()` returns the M-address). Reading `jwt.getClientName()` directly avoids re-deriving an identity SEP-10 already settled. Rejects with `SepNotAuthorizedException` if the id is already claimed by a different identity. Requires a new `Sep31CustomerIdOwnerStore` constructor dependency.
- [x] `SepBeans.interactiveUrlConstructor`: wires `Sep31CustomerIdOwnerStore` into the `SimpleInteractiveUrlConstructor` bean.
- [x] `Sep12ServiceTest`: renamed/updated the test that asserted non-SEP-31 types were skipped (that was the bug) into two tests confirming a new non-SEP-31 customer now claims ownership, and that a colliding id is rejected.
- [x] `SimpleInteractiveUrlConstructorTest`: new tests asserting a SEP-24-forwarded customer id is claimed for the caller, that construction fails when the forwarded id is already claimed by another client, that a `client_name` claim on the token takes precedence, and that a custodial client authenticated with a muxed account whose token carries no `client_name` claims under the muxed owner account rather than a freshly re-resolved client name; existing constructor calls updated for the new dependency.
- [x] `Sep31CustomerOwnershipTests` (integration): new test creating a customer purely through a SEP-24 interactive deposit carrying SEP-9 fields, then asserting a different caller cannot claim that id via `POST /sep31/transactions`.

**Acceptance Criteria**
- [x] A customer created via a SEP-24 interactive deposit with SEP-9 fields (KYC forwarding) has an owner row immediately after the deposit request completes, before any SEP-31 transaction ever references it.
- [x] A customer created via SEP-6 or an untyped `PUT /sep12/customer` is claimed the same way.
- [x] An attacker naming any of the above ids as `receiver_id`/`sender_id` in `POST /sep31/transactions` gets 403 (`SepNotAuthorizedException`) and no transaction is created.
- [x] Updating an existing customer (`id`/`transaction_id` present on the request) still does not touch the ownership store.
- [x] The legitimate creator can still reuse an id it already owns across multiple transactions and repeated SEP-24 deposits.

### Context

[HackerOne #3914647](https://hackerone.com/reports/3914647)

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.sep12.Sep12ServiceTest"`
- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.service.SimpleInteractiveUrlConstructorTest"`
- Integration: `./gradlew runEssentialTests` — covers the new `Sep31CustomerOwnershipTests` case

### Documentation
N/A

### Known limitations
N/A