### PR TITLE
[ANCHOR-1294]: Add SEP-10 replay protection

### DIFF
--- a/core/src/main/java/org/stellar/anchor/auth/NonceCollisionException.java
+++ b/core/src/main/java/org/stellar/anchor/auth/NonceCollisionException.java
@@ -1,0 +1,8 @@
+package org.stellar.anchor.auth;
+
+/** Thrown when a nonce id is already in use, so a new nonce could not be created for it. */
+public class NonceCollisionException extends RuntimeException {
+  public NonceCollisionException(String id) {
+    super("Duplicate nonce id: " + id);
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/auth/NonceManager.java
+++ b/core/src/main/java/org/stellar/anchor/auth/NonceManager.java
@@ -38,10 +38,6 @@ public class NonceManager {
    * @return the nonce
    */
   public Nonce createWithId(String id, int expiresIn) {
-    if (nonceStore.findById(id) != null) {
-      throw new RuntimeException("Duplicate nonce id");
-    }
-
     Nonce nonce =
         new NonceBuilder(nonceStore)
             .id(id)
@@ -49,7 +45,14 @@ public class NonceManager {
             .expiresAt(clock.instant().plus(Duration.ofSeconds(expiresIn)))
             .build();
 
-    return nonceStore.save(nonce);
+    // A single atomic insert-if-absent, rather than findById() followed by save(): the latter is
+    // a check-then-act race between concurrent callers, since JdbcNonce's assigned (non-generated)
+    // id means Spring Data's save() can merge/overwrite an existing row instead of failing.
+    if (!nonceStore.insertIfAbsent(nonce)) {
+      throw new RuntimeException("Duplicate nonce id");
+    }
+
+    return nonce;
   }
 
   /**

--- a/core/src/main/java/org/stellar/anchor/auth/NonceManager.java
+++ b/core/src/main/java/org/stellar/anchor/auth/NonceManager.java
@@ -25,7 +25,19 @@ public class NonceManager {
    * @return the nonce
    */
   public Nonce create(int expiresIn) {
-    String id = UUID.randomUUID().toString();
+    return createWithId(UUID.randomUUID().toString(), expiresIn);
+  }
+
+  /**
+   * Create a new nonce with a caller-supplied id that expires in expiresIn seconds. Use this when
+   * the id must be derivable by both the issuer and the verifier of the nonce, e.g. a SEP-10
+   * challenge transaction hash, instead of an opaque random id.
+   *
+   * @param id the nonce id
+   * @param expiresIn the number of seconds until the nonce expires
+   * @return the nonce
+   */
+  public Nonce createWithId(String id, int expiresIn) {
     if (nonceStore.findById(id) != null) {
       throw new RuntimeException("Duplicate nonce id");
     }

--- a/core/src/main/java/org/stellar/anchor/auth/NonceManager.java
+++ b/core/src/main/java/org/stellar/anchor/auth/NonceManager.java
@@ -49,7 +49,7 @@ public class NonceManager {
     // a check-then-act race between concurrent callers, since JdbcNonce's assigned (non-generated)
     // id means Spring Data's save() can merge/overwrite an existing row instead of failing.
     if (!nonceStore.insertIfAbsent(nonce)) {
-      throw new RuntimeException("Duplicate nonce id");
+      throw new NonceCollisionException(id);
     }
 
     return nonce;

--- a/core/src/main/java/org/stellar/anchor/auth/NonceStore.java
+++ b/core/src/main/java/org/stellar/anchor/auth/NonceStore.java
@@ -9,6 +9,16 @@ public interface NonceStore {
 
   Nonce save(Nonce nonce);
 
+  /**
+   * Atomically insert a nonce only if its id doesn't already exist. Unlike {@link
+   * #findById(String)} followed by {@link #save(Nonce)}, this is a single atomic database operation
+   * with no check-then-act race between concurrent callers.
+   *
+   * @param nonce the nonce to insert
+   * @return true if the nonce was inserted, false if an id conflict already existed
+   */
+  boolean insertIfAbsent(Nonce nonce);
+
   void deleteExpiredNonces();
 
   int markAsUsed(String id, Instant now);

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -563,15 +563,6 @@ public class Sep10Service implements ISep10Service {
 
   String generateWebAuthJwt(ChallengeTransaction challenge, String clientDomain, String homeDomain)
       throws SepException {
-    // Consume the challenge's nonce only now, immediately before minting a JWT for it -- not
-    // earlier in validateChallenge(). All other validation (home domain, account, signers,
-    // threshold) must succeed first, so that a submission that fails validation for an unrelated
-    // reason doesn't burn the nonce and cause a subsequent, correctly signed retry of the same
-    // challenge to be wrongly rejected as a replay.
-    if (!nonceManager.verifyAndUse(challenge.getTransaction().hashHex())) {
-      throw new SepValidationException("Challenge has already been used or has expired.");
-    }
-
     long issuedAt = challenge.getTransaction().getTimeBounds().getMinTime().longValue();
     Memo memo = challenge.getTransaction().getMemo();
     Sep10Jwt webAuthJwt =
@@ -586,8 +577,19 @@ public class Sep10Service implements ISep10Service {
             clientDomain,
             homeDomain);
 
+    // Resolve the client name (which itself can fail authorization, e.g. SepNotAuthorizedException)
+    // before consuming the nonce below.
     webAuthJwt.setClientName(
         clientFinder.getClientName(clientDomain, challenge.getClientAccountId()));
+
+    // Consume the challenge's nonce only now, immediately before minting/encoding the JWT -- not
+    // earlier in this method or in validateChallenge(). Everything above (home domain, account,
+    // signers, threshold, and client name resolution) must succeed first, so that a submission
+    // that fails for an unrelated reason doesn't burn the nonce and cause a subsequent, correctly
+    // signed retry of the same challenge to be wrongly rejected as a replay.
+    if (!nonceManager.verifyAndUse(challenge.getTransaction().hashHex())) {
+      throw new SepValidationException("Challenge has already been used or has expired.");
+    }
 
     debug("jwtToken:", webAuthJwt);
     return jwtService.encode(webAuthJwt);

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -28,6 +28,7 @@ import org.stellar.anchor.api.sep.sep10.ChallengeResponse;
 import org.stellar.anchor.api.sep.sep10.ValidationRequest;
 import org.stellar.anchor.api.sep.sep10.ValidationResponse;
 import org.stellar.anchor.auth.JwtService;
+import org.stellar.anchor.auth.NonceManager;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.client.ClientFinder;
 import org.stellar.anchor.config.SecretConfig;
@@ -50,6 +51,7 @@ public class Sep10Service implements ISep10Service {
   final LedgerClient ledgerClient;
   final JwtService jwtService;
   final ClientFinder clientFinder;
+  final NonceManager nonceManager;
   final String serverAccountId;
   final Counter sep10ChallengeCreatedCounter = Metrics.counter(SEP10_CHALLENGE_CREATED);
   final Counter sep10ChallengeValidatedCounter = Metrics.counter(SEP10_CHALLENGE_VALIDATED);
@@ -60,7 +62,8 @@ public class Sep10Service implements ISep10Service {
       Sep10Config sep10Config,
       LedgerClient ledgerClient,
       JwtService jwtService,
-      ClientFinder clientFinder) {
+      ClientFinder clientFinder,
+      NonceManager nonceManager) {
     debug("appConfig:", stellarNetworkConfig);
     debug("sep10Config:", sep10Config);
     this.stellarNetworkConfig = stellarNetworkConfig;
@@ -69,6 +72,7 @@ public class Sep10Service implements ISep10Service {
     this.ledgerClient = ledgerClient;
     this.jwtService = jwtService;
     this.clientFinder = clientFinder;
+    this.nonceManager = nonceManager;
     this.serverAccountId =
         KeyPair.fromSecretSeed(secretConfig.getSep10SigningSeed()).getAccountId();
     Log.info("Sep10Service initialized.");
@@ -121,6 +125,14 @@ public class Sep10Service implements ISep10Service {
     info("Validating SEP-10 challenge.");
 
     ChallengeTransaction challenge = parseChallenge(request);
+
+    // Reject the challenge if its nonce has already been consumed (replay of a previously
+    // validated challenge) or was never issued by this server / has expired. This must run
+    // before a JWT can be generated below.
+    if (!nonceManager.verifyAndUse(challenge.getTransaction().hashHex())) {
+      throw new SepValidationException("Challenge has already been used or has expired.");
+    }
+
     // pre validation to be defined by the anchor
     preValidateRequestValidation(request, challenge);
 
@@ -166,6 +178,11 @@ public class Sep10Service implements ISep10Service {
     try {
       // create challenge transaction
       Transaction txn = newChallenge(request, clientSigningKey, memo);
+
+      // Register a nonce keyed by the challenge's transaction hash so it can only be redeemed
+      // for a JWT once, before it expires. The hash excludes signatures, so it is unaffected by
+      // the client (and, for non-custodial wallets, client_domain) signatures added later.
+      nonceManager.createWithId(txn.hashHex(), sep10Config.getAuthTimeout());
 
       // Convert the challenge to response
       trace("SEP-10 challenge txn:", txn);

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -28,6 +28,7 @@ import org.stellar.anchor.api.sep.sep10.ChallengeResponse;
 import org.stellar.anchor.api.sep.sep10.ValidationRequest;
 import org.stellar.anchor.api.sep.sep10.ValidationResponse;
 import org.stellar.anchor.auth.JwtService;
+import org.stellar.anchor.auth.NonceCollisionException;
 import org.stellar.anchor.auth.NonceManager;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.client.ClientFinder;
@@ -184,7 +185,7 @@ public class Sep10Service implements ISep10Service {
               txn.toEnvelopeXdrBase64(), stellarNetworkConfig.getStellarNetworkPassphrase());
       trace("challengeResponse:", challengeResponse);
       return challengeResponse;
-    } catch (InvalidSep10ChallengeException ex) {
+    } catch (InvalidSep10ChallengeException | NonceCollisionException ex) {
       warnEx(ex);
       throw new SepException("Failed to create the sep-10 challenge.", ex);
     }

--- a/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep10/Sep10Service.java
@@ -126,13 +126,6 @@ public class Sep10Service implements ISep10Service {
 
     ChallengeTransaction challenge = parseChallenge(request);
 
-    // Reject the challenge if its nonce has already been consumed (replay of a previously
-    // validated challenge) or was never issued by this server / has expired. This must run
-    // before a JWT can be generated below.
-    if (!nonceManager.verifyAndUse(challenge.getTransaction().hashHex())) {
-      throw new SepValidationException("Challenge has already been used or has expired.");
-    }
-
     // pre validation to be defined by the anchor
     preValidateRequestValidation(request, challenge);
 
@@ -569,6 +562,15 @@ public class Sep10Service implements ISep10Service {
 
   String generateWebAuthJwt(ChallengeTransaction challenge, String clientDomain, String homeDomain)
       throws SepException {
+    // Consume the challenge's nonce only now, immediately before minting a JWT for it -- not
+    // earlier in validateChallenge(). All other validation (home domain, account, signers,
+    // threshold) must succeed first, so that a submission that fails validation for an unrelated
+    // reason doesn't burn the nonce and cause a subsequent, correctly signed retry of the same
+    // challenge to be wrongly rejected as a replay.
+    if (!nonceManager.verifyAndUse(challenge.getTransaction().hashHex())) {
+      throw new SepValidationException("Challenge has already been used or has expired.");
+    }
+
     long issuedAt = challenge.getTransaction().getTimeBounds().getMinTime().longValue();
     Memo memo = challenge.getTransaction().getMemo();
     Sep10Jwt webAuthJwt =

--- a/core/src/test/kotlin/org/stellar/anchor/auth/NonceManagerTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/NonceManagerTest.kt
@@ -3,7 +3,6 @@ package org.stellar.anchor.auth
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.slot
 import io.mockk.verify
 import java.time.Clock
 import java.time.Instant
@@ -25,9 +24,7 @@ class NonceManagerTest {
     clock = Clock.fixed(Instant.EPOCH, Clock.systemUTC().zone)
 
     every { nonceStore.newInstance() } answers { PojoNonce() }
-    every { nonceStore.findById(any()) } returns null
-    val nonce = slot<Nonce>()
-    every { nonceStore.save(capture(nonce)) } answers { nonce.captured }
+    every { nonceStore.insertIfAbsent(any()) } returns true
 
     nonceManager = NonceManager(nonceStore, clock)
   }
@@ -40,7 +37,7 @@ class NonceManagerTest {
     assertFalse(nonce.used)
     assert(nonce.expiresAt == Instant.EPOCH.plusSeconds(300))
 
-    verify(exactly = 1) { nonceStore.save(nonce) }
+    verify(exactly = 1) { nonceStore.insertIfAbsent(nonce) }
   }
 
   @Test
@@ -53,13 +50,9 @@ class NonceManagerTest {
 
   @Test
   fun testDuplicateNonceExists() {
-    val nonce = PojoNonce()
-    every { nonceStore.findById(any()) } returns nonce
+    every { nonceStore.insertIfAbsent(any()) } returns false
 
     assertThrows<RuntimeException> { nonceManager.create(300) }
-
-    verify(exactly = 1) { nonceStore.findById(any()) }
-    verify(exactly = 0) { nonceStore.save(any()) }
   }
 
   @Test
@@ -70,17 +63,14 @@ class NonceManagerTest {
     assertFalse(nonce.used)
     assert(nonce.expiresAt == Instant.EPOCH.plusSeconds(300))
 
-    verify(exactly = 1) { nonceStore.save(nonce) }
+    verify(exactly = 1) { nonceStore.insertIfAbsent(nonce) }
   }
 
   @Test
   fun testCreateWithIdRejectsDuplicateId() {
-    val nonce = PojoNonce()
-    every { nonceStore.findById("challenge-hash-1") } returns nonce
+    every { nonceStore.insertIfAbsent(any()) } returns false
 
     assertThrows<RuntimeException> { nonceManager.createWithId("challenge-hash-1", 300) }
-
-    verify(exactly = 0) { nonceStore.save(any()) }
   }
 
   @Test

--- a/core/src/test/kotlin/org/stellar/anchor/auth/NonceManagerTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/auth/NonceManagerTest.kt
@@ -63,6 +63,27 @@ class NonceManagerTest {
   }
 
   @Test
+  fun testCreateWithId() {
+    val nonce = nonceManager.createWithId("challenge-hash-1", 300)
+
+    assertEquals("challenge-hash-1", nonce.id)
+    assertFalse(nonce.used)
+    assert(nonce.expiresAt == Instant.EPOCH.plusSeconds(300))
+
+    verify(exactly = 1) { nonceStore.save(nonce) }
+  }
+
+  @Test
+  fun testCreateWithIdRejectsDuplicateId() {
+    val nonce = PojoNonce()
+    every { nonceStore.findById("challenge-hash-1") } returns nonce
+
+    assertThrows<RuntimeException> { nonceManager.createWithId("challenge-hash-1", 300) }
+
+    verify(exactly = 0) { nonceStore.save(any()) }
+  }
+
+  @Test
   fun testVerifyAndUseSuccess() {
     every { nonceStore.markAsUsed("nonce-1", Instant.EPOCH) } returns 1
     assertTrue(nonceManager.verifyAndUse("nonce-1"))

--- a/core/src/test/kotlin/org/stellar/anchor/ledger/Sep10RpcThresholdSignExtensionTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/ledger/Sep10RpcThresholdSignExtensionTest.kt
@@ -14,6 +14,7 @@ import org.stellar.anchor.TestConstants.Companion.TEST_SIGNING_SEED
 import org.stellar.anchor.TestConstants.Companion.TEST_WEB_AUTH_DOMAIN
 import org.stellar.anchor.api.sep.sep10.ValidationRequest
 import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.NonceManager
 import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.config.Sep10Config
@@ -64,6 +65,8 @@ class Sep10RpcThresholdSignExtensionTest {
 
     val clientFinder = mockk<ClientFinder>(relaxed = true)
     val jwtService = JwtService(secretConfig)
+    val nonceManager = mockk<NonceManager>(relaxed = true)
+    every { nonceManager.verifyAndUse(any()) } returns true
 
     return Sep10Service(
       stellarNetworkConfig,
@@ -71,7 +74,8 @@ class Sep10RpcThresholdSignExtensionTest {
       sep10Config,
       stellarRpc,
       jwtService,
-      clientFinder
+      clientFinder,
+      nonceManager
     )
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -252,6 +252,37 @@ internal class Sep10ServiceTest {
   }
 
   @Test
+  fun `test validate challenge does not consume the nonce when validation fails for an unrelated reason`() {
+    val vr = ValidationRequest()
+    vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)
+
+    // First attempt fails for a reason unrelated to replay protection (a transient ledger
+    // error). The nonce must not be touched at all for this attempt to fail.
+    every { ledgerClient.getAccount(ofType(String::class)) } answers
+      {
+        throw LedgerException("rpc unavailable")
+      }
+    assertThrows<SepValidationException> { sep10Service.validateChallenge(vr) }
+    verify(exactly = 0) { nonceManager.verifyAndUse(any()) }
+
+    // Retrying the exact same challenge once the transient failure clears must succeed --
+    // proving the earlier failed attempt didn't burn the nonce.
+    val mockSigners =
+      listOf(TestSigner(clientKeyPair.accountId, "SIGNER_KEY_TYPE_ED25519", 1, "").toSigner())
+    val accountResponse =
+      mockk<LedgerClient.Account> {
+        every { accountId } returns clientKeyPair.accountId
+        every { sequenceNumber } returns 1
+        every { signers } returns mockSigners
+        every { thresholds.medium } returns 1
+      }
+    every { ledgerClient.getAccount(any()) } returns accountResponse
+
+    assertDoesNotThrow { sep10Service.validateChallenge(vr) }
+    verify(exactly = 1) { nonceManager.verifyAndUse(any()) }
+  }
+
+  @Test
   fun `test validate challenge stamps client_name resolved by ClientFinder onto the jwt`() {
     val vr = ValidationRequest()
     vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -39,6 +39,7 @@ import org.stellar.anchor.api.sep.sep10.ChallengeRequest
 import org.stellar.anchor.api.sep.sep10.ChallengeResponse
 import org.stellar.anchor.api.sep.sep10.ValidationRequest
 import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.NonceCollisionException
 import org.stellar.anchor.auth.NonceManager
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.client.ClientFinder
@@ -247,6 +248,27 @@ internal class Sep10ServiceTest {
 
     // Replaying the exact same challenge transaction must be rejected, even though its signature
     // and time bounds are still otherwise valid.
+    every { nonceManager.verifyAndUse(any()) } returns false
+    assertThrows<SepValidationException> { sep10Service.validateChallenge(vr) }
+  }
+
+  @Test
+  fun `test validate challenge rejects a replayed challenge when the account does not exist on the ledger`() {
+    val vr = ValidationRequest()
+    vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)
+
+    every { ledgerClient.getAccount(ofType(String::class)) } answers
+      {
+        throw AccountNotFoundException(clientKeyPair.accountId)
+      }
+
+    // First validation of this challenge succeeds (via the account-not-found branch) and
+    // consumes its nonce.
+    every { nonceManager.verifyAndUse(any()) } returns true
+    sep10Service.validateChallenge(vr)
+
+    // Replaying the exact same challenge transaction must be rejected -- this branch shares
+    // generateWebAuthJwt (and therefore the nonce check) with the account-exists branch.
     every { nonceManager.verifyAndUse(any()) } returns false
     assertThrows<SepValidationException> { sep10Service.validateChallenge(vr) }
   }
@@ -649,6 +671,47 @@ internal class Sep10ServiceTest {
         )
       }
     // Then
+    assertTrue(sepex.message!!.startsWith("Failed to create the sep-10 challenge"))
+  }
+
+  @Test
+  fun `test createChallengeResponse() registers a nonce for the challenge`() {
+    val response =
+      sep10Service.createChallengeResponse(
+        ChallengeRequest.builder()
+          .account(TEST_ACCOUNT)
+          .memo(TEST_MEMO)
+          .homeDomain(TEST_HOME_DOMAIN)
+          .clientDomain(null)
+          .build(),
+        MemoId(1234567890),
+        null,
+      )
+
+    val txn = Transaction.fromEnvelopeXdr(response.transaction, TESTNET) as Transaction
+    val expectedHash = txn.hashHex()
+    val expectedTimeout = 900
+    verify(exactly = 1) { nonceManager.createWithId(expectedHash, expectedTimeout) }
+  }
+
+  @Test
+  fun `test createChallengeResponse() wraps a nonce collision into a SepException`() {
+    every { nonceManager.createWithId(any(), any()) } throws NonceCollisionException("dup")
+
+    val sepex =
+      assertThrows<SepException> {
+        sep10Service.createChallengeResponse(
+          ChallengeRequest.builder()
+            .account(TEST_ACCOUNT)
+            .memo(TEST_MEMO)
+            .homeDomain(TEST_HOME_DOMAIN)
+            .clientDomain(null)
+            .build(),
+          MemoId(1234567890),
+          null,
+        )
+      }
+
     assertTrue(sepex.message!!.startsWith("Failed to create the sep-10 challenge"))
   }
 

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -343,6 +343,30 @@ internal class Sep10ServiceTest {
   }
 
   @Test
+  fun `test validate challenge does not consume the nonce when client name resolution fails`() {
+    val vr = ValidationRequest()
+    vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)
+
+    every { ledgerClient.getAccount(ofType(String::class)) } answers
+      {
+        throw AccountNotFoundException(clientKeyPair.accountId)
+      }
+
+    // First attempt fails during client name resolution -- part of client authorization, and
+    // the last thing that can fail before the nonce is consumed. The nonce must not be touched.
+    every { clientFinder.getClientName(any(), any()) } throws
+      SepNotAuthorizedException("Client not found")
+    assertThrows<SepNotAuthorizedException> { sep10Service.validateChallenge(vr) }
+    verify(exactly = 0) { nonceManager.verifyAndUse(any()) }
+
+    // Retrying the exact same challenge once client name resolution succeeds must succeed --
+    // proving the earlier failure didn't burn the nonce.
+    every { clientFinder.getClientName(any(), any()) } returns null
+    assertDoesNotThrow { sep10Service.validateChallenge(vr) }
+    verify(exactly = 1) { nonceManager.verifyAndUse(any()) }
+  }
+
+  @Test
   @LockAndMockStatic([Sep10Challenge::class])
   fun `test validate challenge with client domain`() {
     val mockSigners =

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -226,6 +226,32 @@ internal class Sep10ServiceTest {
   }
 
   @Test
+  fun `test validate challenge rejects a replayed challenge`() {
+    val vr = ValidationRequest()
+    vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)
+
+    val mockSigners =
+      listOf(TestSigner(clientKeyPair.accountId, "SIGNER_KEY_TYPE_ED25519", 1, "").toSigner())
+    val accountResponse =
+      mockk<LedgerClient.Account> {
+        every { accountId } returns clientKeyPair.accountId
+        every { sequenceNumber } returns 1
+        every { signers } returns mockSigners
+        every { thresholds.medium } returns 1
+      }
+    every { ledgerClient.getAccount(any()) } returns accountResponse
+
+    // First validation of this challenge succeeds and consumes its nonce.
+    every { nonceManager.verifyAndUse(any()) } returns true
+    sep10Service.validateChallenge(vr)
+
+    // Replaying the exact same challenge transaction must be rejected, even though its signature
+    // and time bounds are still otherwise valid.
+    every { nonceManager.verifyAndUse(any()) } returns false
+    assertThrows<SepValidationException> { sep10Service.validateChallenge(vr) }
+  }
+
+  @Test
   fun `test validate challenge stamps client_name resolved by ClientFinder onto the jwt`() {
     val vr = ValidationRequest()
     vr.transaction = createTestChallenge("", TEST_HOME_DOMAIN, false)

--- a/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep10/Sep10ServiceTest.kt
@@ -39,6 +39,7 @@ import org.stellar.anchor.api.sep.sep10.ChallengeRequest
 import org.stellar.anchor.api.sep.sep10.ChallengeResponse
 import org.stellar.anchor.api.sep.sep10.ValidationRequest
 import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.NonceManager
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.config.SecretConfig
@@ -94,6 +95,7 @@ internal class Sep10ServiceTest {
   @MockK(relaxed = true) lateinit var sep10Config: Sep10Config
   @MockK(relaxed = true) lateinit var ledgerClient: LedgerClient
   @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
+  @MockK(relaxed = true) lateinit var nonceManager: NonceManager
 
   private lateinit var jwtService: JwtService
   private lateinit var sep10Service: Sep10Service
@@ -113,6 +115,10 @@ internal class Sep10ServiceTest {
 
     secretConfig.setupMock()
 
+    // Default to "not a replay" so existing tests that don't exercise replay protection keep
+    // passing; tests that specifically test replay protection override this.
+    every { nonceManager.verifyAndUse(any()) } returns true
+
     this.jwtService = spyk(JwtService(secretConfig))
     this.sep10Service =
       Sep10Service(
@@ -121,7 +127,8 @@ internal class Sep10ServiceTest {
         sep10Config,
         ledgerClient,
         jwtService,
-        clientFinder
+        clientFinder,
+        nonceManager
       )
   }
 

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10ServiceIntegrationTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10ServiceIntegrationTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.stellar.anchor.api.sep.sep10.ValidationRequest
 import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.NonceManager
 import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.config.Sep10Config
@@ -73,6 +74,7 @@ class Sep10ServiceIntegrationTests : IntegrationTestBase(TestConfig()) {
   @MockK(relaxed = true) lateinit var sep10Config: Sep10Config
   @MockK(relaxed = true) lateinit var ledgerClient: LedgerClient
   @MockK(relaxed = true) lateinit var clientFinder: ClientFinder
+  @MockK(relaxed = true) lateinit var nonceManager: NonceManager
 
   private lateinit var jwtService: JwtService
   private lateinit var sep10Service: Sep10Service
@@ -86,6 +88,7 @@ class Sep10ServiceIntegrationTests : IntegrationTestBase(TestConfig()) {
     every { sep10Config.jwtTimeout } returns 900
     every { sep10Config.homeDomains } returns listOf(TEST_HOME_DOMAIN, "*.wildcard.stellar.org")
     every { stellarNetworkConfig.stellarNetworkPassphrase } returns TESTNET.networkPassphrase
+    every { nonceManager.verifyAndUse(any()) } returns true
 
     secretConfig.setupMock()
     this.jwtService = spyk(JwtService(secretConfig))
@@ -96,7 +99,8 @@ class Sep10ServiceIntegrationTests : IntegrationTestBase(TestConfig()) {
         sep10Config,
         ledgerClient,
         jwtService,
-        clientFinder
+        clientFinder,
+        nonceManager
       )
     this.httpClient = `create httpClient`()
   }
@@ -189,7 +193,8 @@ class Sep10ServiceIntegrationTests : IntegrationTestBase(TestConfig()) {
         sep10Config,
         ledgerClient,
         jwtService,
-        clientFinder
+        clientFinder,
+        nonceManager
       )
 
     // 3 ------ Run tests
@@ -278,7 +283,8 @@ class Sep10ServiceIntegrationTests : IntegrationTestBase(TestConfig()) {
         sep10Config,
         ledgerClient,
         jwtService,
-        clientFinder
+        clientFinder,
+        nonceManager
       )
 
     // 3 ------ Run tests
@@ -363,7 +369,8 @@ class Sep10ServiceIntegrationTests : IntegrationTestBase(TestConfig()) {
         sep10Config,
         ledgerClient,
         jwtService,
-        clientFinder
+        clientFinder,
+        nonceManager
       )
 
     // 3 ------ Setup multisig

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
@@ -105,6 +105,37 @@ class Sep10Tests : IntegrationTestBase(TestConfig()) {
     )
   }
 
+  /** Signs a fresh SEP-10 challenge with the client wallet key, without submitting it. */
+  private fun signedChallengeXdr(homeDomain: String): String {
+    val challenge = sep10Client.challenge(homeDomain)
+    val challengeTransaction =
+      Sep10Challenge.readChallengeTransaction(
+        challenge.transaction,
+        toml.getString("SIGNING_KEY"),
+        Network(challenge.networkPassphrase),
+        homeDomain,
+        webAuthDomain,
+      )
+    challengeTransaction.transaction.sign(KeyPair.fromSecretSeed(CLIENT_WALLET_SECRET))
+    return challengeTransaction.transaction.toEnvelopeXdrBase64()
+  }
+
+  @Test
+  fun testAuthReplayRejected() {
+    val signedXdr = signedChallengeXdr(webAuthDomain)
+
+    // The first validation of a signed challenge must succeed and consume its nonce.
+    val token = sep10Client.validate(ValidationRequest.of(signedXdr))
+    assertEquals(true, !token?.token.isNullOrEmpty())
+
+    // Replaying the exact same signed challenge a second time must be rejected, even though the
+    // signature and time bounds are still otherwise valid.
+    assertFailsWith(
+      exceptionClass = SepNotAuthorizedException::class,
+      block = { sep10Client.validate(ValidationRequest.of(signedXdr)) },
+    )
+  }
+
   @Test
   fun testCustodial() = runBlocking {
     val rnd = wallet.stellar().account().createKeyPair()

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import java.io.IOException
 import java.util.*
 import java.util.Base64
+import java.util.concurrent.Executors
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
@@ -134,6 +135,36 @@ class Sep10Tests : IntegrationTestBase(TestConfig()) {
       exceptionClass = SepNotAuthorizedException::class,
       block = { sep10Client.validate(ValidationRequest.of(signedXdr)) },
     )
+  }
+
+  @Test
+  fun testAuthReplayRejectedConcurrently() {
+    val signedXdr = signedChallengeXdr(webAuthDomain)
+
+    // Submit the exact same signed challenge from two threads at once. The nonce is consumed via
+    // a single atomic SQL UPDATE (JdbcNonceRepo.markAsUsed), so exactly one submission must win,
+    // regardless of request ordering/timing.
+    val executor = Executors.newFixedThreadPool(2)
+    val futures =
+      (1..2).map {
+        executor.submit<Exception?> {
+          try {
+            sep10Client.validate(ValidationRequest.of(signedXdr))
+            null
+          } catch (e: SepNotAuthorizedException) {
+            e
+          }
+        }
+      }
+
+    val exceptions = futures.map { it.get() }
+    executor.shutdown()
+
+    val successCount = exceptions.count { it == null }
+    val failureCount = exceptions.count { it != null }
+
+    assertEquals(1, successCount, "Expected exactly 1 successful validation, got $successCount")
+    assertEquals(1, failureCount, "Expected exactly 1 rejected validation, got $failureCount")
   }
 
   @Test

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep10Tests.kt
@@ -157,8 +157,12 @@ class Sep10Tests : IntegrationTestBase(TestConfig()) {
         }
       }
 
-    val exceptions = futures.map { it.get() }
-    executor.shutdown()
+    val exceptions =
+      try {
+        futures.map { it.get() }
+      } finally {
+        executor.shutdown()
+      }
 
     val successCount = exceptions.count { it == null }
     val failureCount = exceptions.count { it != null }

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -141,7 +141,7 @@ public class SepBeans {
   }
 
   @Bean
-  @OnAnySepsEnabled(seps = {"sep45"})
+  @OnAnySepsEnabled(seps = {"sep10", "sep45"})
   NonceManager nonceService(NonceStore nonceStore, Clock clock) {
     return new NonceManager(nonceStore, clock);
   }
@@ -177,9 +177,16 @@ public class SepBeans {
       Sep10Config sep10Config,
       LedgerClient ledgerClient,
       JwtService jwtService,
-      ClientFinder clientFinder) {
+      ClientFinder clientFinder,
+      NonceManager nonceManager) {
     return new Sep10Service(
-        stellarNetworkConfig, secretConfig, sep10Config, ledgerClient, jwtService, clientFinder);
+        stellarNetworkConfig,
+        secretConfig,
+        sep10Config,
+        ledgerClient,
+        jwtService,
+        clientFinder,
+        nonceManager);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceRepo.java
@@ -9,6 +9,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface JdbcNonceRepo extends CrudRepository<JdbcNonce, String> {
 
+  @Transactional
+  @Modifying
+  @Query(
+      value =
+          "INSERT INTO nonce (id, used, expires_at) VALUES (:id, false, :expiresAt) "
+              + "ON CONFLICT (id) DO NOTHING",
+      nativeQuery = true)
+  int insertIfAbsent(@Param("id") String id, @Param("expiresAt") Instant expiresAt);
+
   @Query("SELECT COUNT(n) FROM JdbcNonce n WHERE n.expiresAt < CURRENT_TIMESTAMP")
   int countExpired();
 

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcNonceStore.java
@@ -22,6 +22,11 @@ public class JdbcNonceStore implements NonceStore {
     return jdbcNonceRepo.save((JdbcNonce) nonce);
   }
 
+  public boolean insertIfAbsent(Nonce nonce) {
+    JdbcNonce jdbcNonce = (JdbcNonce) nonce;
+    return jdbcNonceRepo.insertIfAbsent(jdbcNonce.getId(), jdbcNonce.getExpiresAt()) == 1;
+  }
+
   public void deleteExpiredNonces() {
     int expired = jdbcNonceRepo.countExpired();
     jdbcNonceRepo.deleteAllExpired();

--- a/platform/src/main/java/org/stellar/anchor/platform/job/NonceCleanupJob.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/job/NonceCleanupJob.java
@@ -9,7 +9,10 @@ import org.stellar.anchor.util.Log;
 public class NonceCleanupJob {
   private final NonceStore nonceStore;
 
-  @Scheduled(fixedRate = 1000 * 60 * 60) // 1 hour
+  // Runs every 15 minutes rather than hourly: the nonce table is now shared with SEP-10, whose
+  // /auth traffic is expected to be far higher-volume than SEP-45's (the original, lower-volume
+  // consumer this schedule was tuned for), so expired/used rows should be reaped more often.
+  @Scheduled(fixedRate = 1000 * 60 * 15)
   public void cleanup() {
     Log.info("Cleaning up expired nonces");
     nonceStore.deleteExpiredNonces();

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/component/SepBeansConditionalRegistrationTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/component/SepBeansConditionalRegistrationTest.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.component
 
+import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
 import java.util.function.Supplier
@@ -14,6 +15,8 @@ import org.stellar.anchor.api.callback.CustomerIntegration
 import org.stellar.anchor.api.callback.RateIntegration
 import org.stellar.anchor.asset.AssetService
 import org.stellar.anchor.auth.JwtService
+import org.stellar.anchor.auth.NonceManager
+import org.stellar.anchor.auth.NonceStore
 import org.stellar.anchor.client.ClientFinder
 import org.stellar.anchor.client.ClientService
 import org.stellar.anchor.config.LanguageConfig
@@ -21,10 +24,12 @@ import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.config.Sep6Config
 import org.stellar.anchor.config.StellarNetworkConfig
 import org.stellar.anchor.event.EventService
+import org.stellar.anchor.ledger.LedgerClient
 import org.stellar.anchor.platform.component.sep.SepBeans
 import org.stellar.anchor.platform.config.CallbackApiConfig
 import org.stellar.anchor.platform.config.PropertySep24Config
 import org.stellar.anchor.platform.config.PropertySep31Config
+import org.stellar.anchor.sep10.Sep10Service
 import org.stellar.anchor.sep24.Sep24TransactionStore
 import org.stellar.anchor.sep31.Sep31CustomerIdOwnerStore
 import org.stellar.anchor.sep31.Sep31TransactionStore
@@ -54,7 +59,18 @@ class SepBeansConditionalRegistrationTest {
         StellarNetworkConfig::class.java,
         Supplier { mockk<StellarNetworkConfig>(relaxed = true) },
       )
-      .withBean(SecretConfig::class.java, Supplier { mockk<SecretConfig>(relaxed = true) })
+      .withBean(
+        SecretConfig::class.java,
+        Supplier {
+          mockk<SecretConfig>(relaxed = true) {
+            // Valid enough to satisfy PropertySep10Config/PropertySep45Config's validation when
+            // sep10/sep45 are enabled; unused (and irrelevant) when they're disabled.
+            every { sep10SigningSeed } returns
+              "SBVEOFAHGJCKGR4AAM7RTDRCP6RMYYV5YUV32ZK7ZD3VPDGGHYLXTZRZ"
+            every { sep10JwtSecretKey } returns "sep10_jwt_secret_key_for_tests_only_______"
+          }
+        },
+      )
       .withBean(ClientService::class.java, Supplier { mockk<ClientService>(relaxed = true) })
       .withBean(
         CallbackApiConfig::class.java,
@@ -154,6 +170,30 @@ class SepBeansConditionalRegistrationTest {
         }
         assert(context.getBeanNamesForType(SepRequestValidator::class.java).isEmpty()) {
           "expected no SepRequestValidator bean when sep6/sep24 are both disabled"
+        }
+      }
+  }
+
+  @Test
+  fun `context exposes NonceManager and Sep10Service when only sep10 is enabled`() {
+    baseRunner()
+      .withBean(LedgerClient::class.java, Supplier { mockk<LedgerClient>(relaxed = true) })
+      .withBean(NonceStore::class.java, Supplier { mockk<NonceStore>(relaxed = true) })
+      .withPropertyValues(
+        "sep6.enabled=false",
+        "sep24.enabled=false",
+        "sep31.enabled=false",
+        "sep10.enabled=true",
+      )
+      .run { context ->
+        assert(context.startupFailure == null) {
+          "context failed to start with only sep10 enabled: ${context.startupFailure}"
+        }
+        assert(context.getBeanNamesForType(NonceManager::class.java).size == 1) {
+          "expected exactly one NonceManager bean when only sep10 is enabled"
+        }
+        assert(context.getBeanNamesForType(Sep10Service::class.java).size == 1) {
+          "expected exactly one Sep10Service bean when only sep10 is enabled"
         }
       }
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcNonceStoreTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/JdbcNonceStoreTest.kt
@@ -1,0 +1,48 @@
+package org.stellar.anchor.platform.data
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JdbcNonceStoreTest {
+
+  @MockK(relaxed = true) private lateinit var repo: JdbcNonceRepo
+
+  private lateinit var store: JdbcNonceStore
+
+  @BeforeEach
+  fun setUp() {
+    MockKAnnotations.init(this, relaxUnitFun = true)
+    store = JdbcNonceStore(repo)
+  }
+
+  private fun nonce(id: String, expiresAt: Instant) =
+    JdbcNonce().apply {
+      this.id = id
+      this.expiresAt = expiresAt
+    }
+
+  @Test
+  fun `insertIfAbsent returns true when the row is newly inserted`() {
+    val expiresAt = Instant.parse("2026-08-27T00:00:00Z")
+    every { repo.insertIfAbsent("nonce-1", expiresAt) } returns 1
+
+    assertTrue(store.insertIfAbsent(nonce("nonce-1", expiresAt)))
+    verify(exactly = 1) { repo.insertIfAbsent("nonce-1", expiresAt) }
+  }
+
+  @Test
+  fun `insertIfAbsent returns false when the id already exists`() {
+    val expiresAt = Instant.parse("2026-08-27T00:00:00Z")
+    every { repo.insertIfAbsent("nonce-1", expiresAt) } returns 0
+
+    assertFalse(store.insertIfAbsent(nonce("nonce-1", expiresAt)))
+    verify(exactly = 1) { repo.insertIfAbsent("nonce-1", expiresAt) }
+  }
+}


### PR DESCRIPTION
### Description

Adds replay protection to SEP-10 challenge validation. Previously, the same signed SEP-10 challenge transaction could be POSTed to `/auth` more than once, minting a new valid JWT each time before the challenge expired. This reuses the existing `Nonce`/`NonceManager`/`JdbcNonceStore` infrastructure (already used by SEP-45) instead of introducing new storage: the challenge's transaction hash (already used as the JWT's `jti`) is registered as a nonce when the challenge is created, and atomically consumed (`UPDATE ... WHERE used = false`) when it's validated, so it's safe across multiple AP instances behind a load balancer.

Also fixes a latent bug found while wiring this up: the `NonceManager` Spring bean was only created when SEP-45 was enabled (`@OnAnySepsEnabled(seps = {"sep45"})`). Since SEP-10 now depends on it too, this would have broken any deployment running SEP-10 without SEP-45 enabled. Widened to `{"sep10", "sep45"}`.

### Context

Finding from the ANCHOR-1279 SEP-compliance coverage audit ([docs/audits/ANCHOR-1279-recommendation.md](../docs/audits/ANCHOR-1279-recommendation.md)). The single most concerning gap identified: neither AP's own test suite nor `stellar-anchor-tests` verified that a SEP-10 challenge could only be redeemed once. Tracked in [ANCHOR-1294](https://stellarorg.atlassian.net/browse/ANCHOR-1294), part of the phased gap-closing plan under the parent ticket [ANCHOR-1279](https://stellarorg.atlassian.net/browse/ANCHOR-1279).

### Testing

- `./gradlew test`
- Added `NonceManagerTest.testCreateWithId` / `testCreateWithIdRejectsDuplicateId`
- Added `Sep10ServiceTest.`` `test validate challenge rejects a replayed challenge` ``: validates the same challenge twice, asserts the second call throws `SepValidationException`
- Added `Sep10Tests.testAuthReplayRejected` (integration): signs one challenge, POSTs it to `/auth` twice, asserts the second is rejected. **Not run locally** (needs the full AP/Docker stack): needs to pass in CI before merge.
- Existing `Sep10RpcThresholdSignExtensionTest` regression suite still green (12/12)

### Documentation

N/A
Internal security fix, no new config or public-facing behavior change.

### Known limitations

The remaining SEP-10 Tier 1 gaps from the audit (challenge not signed by `SIGNING_KEY` never rejected, signature weight below medium threshold untested, duplicate-signer double-counting untested) are **not** covered by this PR.
Tracked separately as `test/anchor-1294-sep10-coverage` under the same [ANCHOR-1294](https://stellarorg.atlassian.net/browse/ANCHOR-1294) ticket.

[ANCHOR-1294]: https://stellarorg.atlassian.net/browse/ANCHOR-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ