### PR TITLE
[ANCHOR-1290]: SEP-10 client_domain SSRF: ANCHOR-1236 blocklist omits NAT64 (64:ff9b::/96) and 6to4 (2002::/16), re-reaching internal IPv4 on mainnet

### DIFF
--- a/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
@@ -237,6 +237,7 @@ public class ClientDomainHelper {
         || isBenchmarkingRange(unwrapped)
         || isThisNetwork(unwrapped)
         || isNat64WellKnown(address)
+        || isNat64LocalUse(address)
         || is6to4(address);
   }
 
@@ -284,6 +285,20 @@ public class ClientDomainHelper {
       return false;
     }
     byte[] prefix = {0, 0x64, (byte) 0xff, (byte) 0x9b, 0, 0, 0, 0, 0, 0, 0, 0};
+    for (int i = 0; i < prefix.length; i++) {
+      if (a[i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isNat64LocalUse(InetAddress address) {
+    byte[] a = address.getAddress();
+    if (a.length != 16) {
+      return false;
+    }
+    byte[] prefix = {0, 0x64, (byte) 0xff, (byte) 0x9b, 0, 1};
     for (int i = 0; i < prefix.length; i++) {
       if (a[i] != prefix[i]) {
         return false;

--- a/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
@@ -226,14 +226,75 @@ public class ClientDomainHelper {
   }
 
   private static boolean isNonPublicAddress(InetAddress address) {
-    return address.isLoopbackAddress()
-        || address.isSiteLocalAddress()
-        || address.isLinkLocalAddress()
-        || address.isAnyLocalAddress()
-        || isCarrierGradeNat(address)
-        || isIpv6UniqueLocal(address)
-        || isIetfProtocolAssignment(address)
-        || isBenchmarkingRange(address);
+    InetAddress unwrapped = unwrapEmbeddedIPv4(address);
+    return unwrapped.isLoopbackAddress()
+        || unwrapped.isSiteLocalAddress()
+        || unwrapped.isLinkLocalAddress()
+        || unwrapped.isAnyLocalAddress()
+        || isCarrierGradeNat(unwrapped)
+        || isIpv6UniqueLocal(unwrapped)
+        || isIetfProtocolAssignment(unwrapped)
+        || isBenchmarkingRange(unwrapped)
+        || isThisNetwork(unwrapped)
+        || isNat64WellKnown(address)
+        || is6to4(address);
+  }
+
+  private static InetAddress unwrapEmbeddedIPv4(InetAddress address) {
+    byte[] a = address.getAddress();
+    if (a.length != 16) {
+      return address;
+    }
+
+    byte[] embedded;
+    if (isNat64WellKnown(address)) {
+      embedded = new byte[] {a[12], a[13], a[14], a[15]};
+    } else if (is6to4(address)) {
+      embedded = new byte[] {a[2], a[3], a[4], a[5]};
+    } else if (isIpv4Compatible(a)) {
+      embedded = new byte[] {a[12], a[13], a[14], a[15]};
+    } else {
+      return address;
+    }
+
+    try {
+      return InetAddress.getByAddress(embedded);
+    } catch (UnknownHostException e) {
+      return address;
+    }
+  }
+
+  private static boolean isIpv4Compatible(byte[] a) {
+    for (int i = 0; i < 10; i++) {
+      if (a[i] != 0) {
+        return false;
+      }
+    }
+    return (a[10] & 0xFF) != 0xFF || (a[11] & 0xFF) != 0xFF;
+  }
+
+  private static boolean isThisNetwork(InetAddress address) {
+    byte[] a = address.getAddress();
+    return a.length == 4 && (a[0] & 0xFF) == 0;
+  }
+
+  private static boolean isNat64WellKnown(InetAddress address) {
+    byte[] a = address.getAddress();
+    if (a.length != 16) {
+      return false;
+    }
+    byte[] prefix = {0, 0x64, (byte) 0xff, (byte) 0x9b, 0, 0, 0, 0, 0, 0, 0, 0};
+    for (int i = 0; i < prefix.length; i++) {
+      if (a[i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean is6to4(InetAddress address) {
+    byte[] a = address.getAddress();
+    return a.length == 16 && (a[0] & 0xFF) == 0x20 && (a[1] & 0xFF) == 0x02;
   }
 
   private static boolean isCarrierGradeNat(InetAddress address) {

--- a/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
+++ b/core/src/main/java/org/stellar/anchor/util/ClientDomainHelper.java
@@ -270,7 +270,7 @@ public class ClientDomainHelper {
         return false;
       }
     }
-    return (a[10] & 0xFF) != 0xFF || (a[11] & 0xFF) != 0xFF;
+    return a[10] == 0 && a[11] == 0;
   }
 
   private static boolean isThisNetwork(InetAddress address) {

--- a/core/src/test/kotlin/org/stellar/anchor/util/SsrfBlocklistBypassTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/SsrfBlocklistBypassTest.kt
@@ -1,0 +1,60 @@
+package org.stellar.anchor.util
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.exception.SepException
+
+class SsrfBlocklistBypassTest {
+  private fun guardBlocks(host: String): Boolean =
+    try {
+      ClientDomainHelper.validateDomainNotPrivateNetwork(host)
+      false
+    } catch (e: SepException) {
+      e.message?.contains("non-public") == true
+    }
+
+  @Test
+  fun `CONTROL - standard private and reserved ranges are correctly blocked`() {
+    for (h in
+      listOf(
+        "127.0.0.1",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.1",
+        "169.254.169.254",
+        "100.64.0.1",
+        "::1",
+        "fc00::1",
+        "fd00::1",
+        "::ffff:10.0.0.1",
+        "::ffff:169.254.169.254"
+      )) {
+      assertTrue(guardBlocks(h), "$h must be blocked by the private-network guard")
+    }
+  }
+
+  @Test
+  fun `BYPASS - NAT64 (64_ff9b__96) addresses embedding internal IPv4 are now blocked`() {
+    for (h in listOf("64:ff9b::a9fe:a9fe", "64:ff9b::a00:1", "64:ff9b::7f00:1")) {
+      assertTrue(
+        guardBlocks(h),
+        "$h reaches an internal IPv4 through a NAT64 gateway and must be blocked"
+      )
+    }
+  }
+
+  @Test
+  fun `BYPASS - 6to4 (2002__16) addresses embedding internal IPv4 are now blocked`() {
+    for (h in listOf("2002:a00:1::", "2002:7f00:1::")) {
+      assertTrue(
+        guardBlocks(h),
+        "$h reaches an internal IPv4 through a 6to4 relay and must be blocked"
+      )
+    }
+  }
+
+  @Test
+  fun `additional - 0_0_0_0_8 range is blocked`() {
+    assertTrue(guardBlocks("0.1.2.3"), "0.1.2.3 is in 0.0.0.0/8 and must be blocked")
+  }
+}

--- a/core/src/test/kotlin/org/stellar/anchor/util/SsrfBlocklistBypassTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/SsrfBlocklistBypassTest.kt
@@ -56,6 +56,14 @@ class SsrfBlocklistBypassTest {
   }
 
   @Test
+  fun `additional - NAT64 local-use prefix (64_ff9b_1__48, RFC 8215) is blocked`() {
+    assertTrue(
+      guardBlocks("64:ff9b:1::a00:1"),
+      "64:ff9b:1::/48 is the RFC 8215 local-use NAT64 prefix and must be blocked outright"
+    )
+  }
+
+  @Test
   fun `additional - 0_0_0_0_8 range is blocked`() {
     assertTrue(guardBlocks("0.1.2.3"), "0.1.2.3 is in 0.0.0.0/8 and must be blocked")
   }

--- a/core/src/test/kotlin/org/stellar/anchor/util/SsrfBlocklistBypassTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/util/SsrfBlocklistBypassTest.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.util
 
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.stellar.anchor.api.exception.SepException
@@ -27,7 +28,8 @@ class SsrfBlocklistBypassTest {
         "fc00::1",
         "fd00::1",
         "::ffff:10.0.0.1",
-        "::ffff:169.254.169.254"
+        "::ffff:169.254.169.254",
+        "::10.0.0.1"
       )) {
       assertTrue(guardBlocks(h), "$h must be blocked by the private-network guard")
     }
@@ -56,5 +58,14 @@ class SsrfBlocklistBypassTest {
   @Test
   fun `additional - 0_0_0_0_8 range is blocked`() {
     assertTrue(guardBlocks("0.1.2.3"), "0.1.2.3 is in 0.0.0.0/8 and must be blocked")
+  }
+
+  @Test
+  fun `additional - ordinary IPv6 addresses outside __96 are not misclassified as IPv4-compatible`() {
+    assertFalse(
+      guardBlocks("::1:a00:1"),
+      "::1:a00:1 is an ordinary global IPv6 address, not an IPv4-compatible literal, even though" +
+        " its last 32 bits look like a private IPv4 address; it must not be blocked"
+    )
   }
 }


### PR DESCRIPTION
### Description

ANCHOR-1236 added `ClientDomainHelper.isNonPublicAddress` as a private-network guard so the unauthenticated `GET /auth` (and SEP-45 equivalent) `client_domain` fetch can't be pointed at an internal host. That guard blocks IPv4 private ranges, loopback, link-local, `fc00::/7`, and IPv4-mapped IPv6 (`::ffff:a.b.c.d`, auto-normalized to `Inet4Address` by the JDK), but never unwraps the two IPv6 transition ranges that carry a real IPv4 payload in their low bits: NAT64 (`64:ff9b::/96`, RFC 6052) and 6to4 (`2002::/16`, RFC 3056). Neither range matches any of the eight existing predicates, so a `client_domain` resolving to `64:ff9b::<internal-ipv4>` or `2002:<internal-ipv4>::` passes both call sites that delegate to this classifier — the pre-fetch check and the connection-time DNS validator — and the platform connects through the operator's own NAT64/6to4 gateway to the embedded internal address. `0.0.0.0/8` had the same gap: only the exact `0.0.0.0` address was caught.

Fixing this by only unwrapping and re-checking the embedded IPv4 isn't quite enough on its own: RFC 6052 leaves a NAT64 gateway's handling of a private embedded address implementation-defined, and a gateway could also forward to a public IP the platform's network trusts only via that internal path. So both prefixes are also blocked outright, in addition to the unwrap-and-recheck.

**Changes**
- [x] `ClientDomainHelper.isNonPublicAddress`: unwraps NAT64, 6to4, and the deprecated IPv4-compatible IPv6 form (`::a.b.c.d`) via a new `unwrapEmbeddedIPv4` before running the existing IPv4 predicates against the real embedded address; adds `isThisNetwork` for `0.0.0.0/8`; blocks the NAT64/6to4 prefixes outright via new `isNat64WellKnown`/`is6to4` predicates, independent of what the embedded address resolves to.
- [x] `SsrfBlocklistBypassTest` (new): runs the reporter's own reproduction directly against `ClientDomainHelper.validateDomainNotPrivateNetwork` — a control case confirming existing ranges stay blocked, and cases confirming the NAT64/6to4/`0.0.0.0/8` addresses are now blocked.

**Acceptance Criteria**
- [x] `client_domain` resolving to `64:ff9b::<internal-ipv4>` (NAT64) is rejected by both `validateDomainNotPrivateNetwork` and `validatingDns`.
- [x] `client_domain` resolving to `2002:<internal-ipv4>::` (6to4) is rejected the same way.
- [x] `client_domain` resolving to any `0.0.0.0/8` address is rejected.
- [x] Existing blocked ranges (RFC1918, loopback, link-local, `fc00::/7`, CGNAT, IPv4-mapped) remain blocked.
- [x] SEP-45's auth endpoint, which shares this same guard, gets the fix with no separate change.

### Context

[HackerOne #3968541](https://hackerone.com/reports/3968541)

### Testing

- Unit: `./gradlew :core:test --tests "org.stellar.anchor.util.SsrfBlocklistBypassTest"`
- Unit: `./gradlew :core:test --tests "org.stellar.anchor.util.ClientDomainHelperTest"`
- Integration: `./gradlew :core:test` (full module regression, no failures)

### Documentation
N/A

### Known limitations

Doesn't change `Sep10Service.validateChallengeRequestClient`'s default of accepting any `client_domain` when `sep10.client_attribution_required` is unset and `sep10.client_allow_list` is empty. The report frames an allow-list as a recommended defense-in-depth improvement, not a required part of this fix — it's a separate, broader policy change affecting every deployment's default config, not just attacker-controlled input, and deserves its own scoping.