### PR TITLE
[ANCHOR-1283]: Unauthenticated Denial of Service (OOM) via Unbounded `page_size` in Platform API `GET /transactions`

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/exception/SepRateLimitExceededException.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/exception/SepRateLimitExceededException.java
@@ -1,0 +1,11 @@
+package org.stellar.anchor.api.exception;
+
+/**
+ * Thrown when an identity exceeds the allowed number of transaction-creation requests within the
+ * configured rate-limit window.
+ */
+public class SepRateLimitExceededException extends SepException {
+  public SepRateLimitExceededException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/org/stellar/anchor/config/RateLimitConfig.java
+++ b/core/src/main/java/org/stellar/anchor/config/RateLimitConfig.java
@@ -1,0 +1,13 @@
+package org.stellar.anchor.config;
+
+/**
+ * Configuration for rate limiting transaction-creation requests (SEP-6/24/31) per authenticated
+ * SEP-10 identity.
+ */
+public interface RateLimitConfig {
+  boolean isEnabled();
+
+  int getMaxTransactionsPerWindow();
+
+  long getWindowSeconds();
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -26,6 +26,7 @@ import org.stellar.anchor.platform.condition.OnAllSepsEnabled;
 import org.stellar.anchor.platform.condition.OnAnySepsEnabled;
 import org.stellar.anchor.platform.config.*;
 import org.stellar.anchor.platform.service.SimpleInteractiveUrlConstructor;
+import org.stellar.anchor.platform.utils.TransactionCreationRateLimiter;
 import org.stellar.anchor.sep1.Sep1Service;
 import org.stellar.anchor.sep10.Sep10Service;
 import org.stellar.anchor.sep12.Sep12Service;
@@ -75,6 +76,17 @@ public class SepBeans {
   @ConfigurationProperties(prefix = "sep38")
   Sep38Config sep38Config() {
     return new PropertySep38Config();
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "rate-limit")
+  RateLimitConfig rateLimitConfig() {
+    return new PropertyRateLimitConfig();
+  }
+
+  @Bean
+  TransactionCreationRateLimiter transactionCreationRateLimiter(RateLimitConfig rateLimitConfig) {
+    return new TransactionCreationRateLimiter(rateLimitConfig);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertyRateLimitConfig.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertyRateLimitConfig.java
@@ -1,0 +1,42 @@
+package org.stellar.anchor.platform.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.stellar.anchor.config.RateLimitConfig;
+
+@Getter
+@Setter
+public class PropertyRateLimitConfig implements RateLimitConfig, Validator {
+  boolean enabled = false;
+  int maxTransactionsPerWindow = 10;
+  long windowSeconds = 60;
+
+  @Override
+  public boolean supports(@NotNull Class<?> clazz) {
+    return RateLimitConfig.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(@NotNull Object target, @NotNull Errors errors) {
+    PropertyRateLimitConfig config = (PropertyRateLimitConfig) target;
+    if (!config.enabled) {
+      return;
+    }
+
+    if (config.maxTransactionsPerWindow <= 0) {
+      errors.rejectValue(
+          "maxTransactionsPerWindow",
+          "rate-limit-max-transactions-per-window-invalid",
+          "rate_limit.max_transactions_per_window must be greater than 0");
+    }
+    if (config.windowSeconds <= 0) {
+      errors.rejectValue(
+          "windowSeconds",
+          "rate-limit-window-seconds-invalid",
+          "rate_limit.window_seconds must be greater than 0");
+    }
+  }
+}

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandler.java
@@ -54,6 +54,13 @@ public abstract class AbstractControllerExceptionHandler {
     return new CustomerInfoNeededResponse(ex.getFields());
   }
 
+  @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+  @ExceptionHandler(SepRateLimitExceededException.class)
+  public SepExceptionResponse handleRateLimitExceeded(SepRateLimitExceededException ex) {
+    debugF("Rate limit exceeded: {}", ex.getMessage());
+    return new SepExceptionResponse(ex.getMessage());
+  }
+
   @ResponseStatus(HttpStatus.NOT_IMPLEMENTED)
   @ExceptionHandler({SepNotImplementedException.class, NotSupportedException.class})
   public SepExceptionResponse handleNotImplementedError(Exception ex) {

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep24Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep24Controller.java
@@ -18,6 +18,7 @@ import org.stellar.anchor.api.sep.SepExceptionResponse;
 import org.stellar.anchor.api.sep.sep24.*;
 import org.stellar.anchor.auth.WebAuthJwt;
 import org.stellar.anchor.platform.condition.OnAllSepsEnabled;
+import org.stellar.anchor.platform.utils.TransactionCreationRateLimiter;
 import org.stellar.anchor.sep24.Sep24Service;
 
 @RestController
@@ -26,9 +27,11 @@ import org.stellar.anchor.sep24.Sep24Service;
 @OnAllSepsEnabled(seps = {"sep24"})
 public class Sep24Controller {
   private final Sep24Service sep24Service;
+  private final TransactionCreationRateLimiter rateLimiter;
 
-  Sep24Controller(Sep24Service sep24Service) {
+  Sep24Controller(Sep24Service sep24Service, TransactionCreationRateLimiter rateLimiter) {
     this.sep24Service = sep24Service;
+    this.rateLimiter = rateLimiter;
   }
 
   @CrossOrigin(origins = "*")
@@ -51,6 +54,7 @@ public class Sep24Controller {
       throws AnchorException, MalformedURLException, URISyntaxException {
     debug("/deposit", requestData);
     WebAuthJwt token = SepRequestHelper.getToken(request);
+    rateLimiter.checkAndRecord(token);
     requestData.put(ATTRIBUTE_CLIENT_IP_ADDRESS, SepRequestHelper.getClientIpAddress(request));
     InteractiveTransactionResponse itr = sep24Service.deposit(token, requestData);
     info("interactive redirection:", itr);
@@ -84,6 +88,7 @@ public class Sep24Controller {
       throws AnchorException, MalformedURLException, URISyntaxException {
     debug("/withdraw", requestData);
     WebAuthJwt token = SepRequestHelper.getToken(request);
+    rateLimiter.checkAndRecord(token);
     requestData.put(ATTRIBUTE_CLIENT_IP_ADDRESS, SepRequestHelper.getClientIpAddress(request));
     InteractiveTransactionResponse itr = sep24Service.withdraw(token, requestData);
     info("interactive redirection:", itr);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep31Controller.java
@@ -16,6 +16,7 @@ import org.stellar.anchor.api.exception.Sep31MissingFieldException;
 import org.stellar.anchor.api.sep.sep31.*;
 import org.stellar.anchor.auth.WebAuthJwt;
 import org.stellar.anchor.platform.condition.OnAllSepsEnabled;
+import org.stellar.anchor.platform.utils.TransactionCreationRateLimiter;
 import org.stellar.anchor.sep31.Sep31Service;
 
 @RestController
@@ -24,9 +25,11 @@ import org.stellar.anchor.sep31.Sep31Service;
 @OnAllSepsEnabled(seps = {"sep31"})
 public class Sep31Controller {
   private final Sep31Service sep31Service;
+  private final TransactionCreationRateLimiter rateLimiter;
 
-  public Sep31Controller(Sep31Service sep31Service) {
+  public Sep31Controller(Sep31Service sep31Service, TransactionCreationRateLimiter rateLimiter) {
     this.sep31Service = sep31Service;
+    this.rateLimiter = rateLimiter;
   }
 
   @CrossOrigin(origins = "*")
@@ -49,6 +52,7 @@ public class Sep31Controller {
       HttpServletRequest servletRequest, @RequestBody Sep31PostTransactionRequest request)
       throws AnchorException {
     WebAuthJwt webAuthJwt = SepRequestHelper.getToken(servletRequest);
+    rateLimiter.checkAndRecord(webAuthJwt);
     request.setRequestClientIpAddress(getClientIpAddress(servletRequest));
     debugF("POST /transactions request={}", request);
     return sep31Service.postTransaction(webAuthJwt, request);

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/sep/Sep6Controller.java
@@ -13,6 +13,7 @@ import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.sep.sep6.*;
 import org.stellar.anchor.auth.WebAuthJwt;
 import org.stellar.anchor.platform.condition.OnAllSepsEnabled;
+import org.stellar.anchor.platform.utils.TransactionCreationRateLimiter;
 import org.stellar.anchor.sep6.Sep6Service;
 
 @RestController
@@ -21,9 +22,11 @@ import org.stellar.anchor.sep6.Sep6Service;
 @OnAllSepsEnabled(seps = {"sep6"})
 public class Sep6Controller {
   private final Sep6Service sep6Service;
+  private final TransactionCreationRateLimiter rateLimiter;
 
-  public Sep6Controller(Sep6Service sep6Service) {
+  public Sep6Controller(Sep6Service sep6Service, TransactionCreationRateLimiter rateLimiter) {
     this.sep6Service = sep6Service;
+    this.rateLimiter = rateLimiter;
   }
 
   @CrossOrigin(origins = "*")
@@ -60,6 +63,7 @@ public class Sep6Controller {
       throws AnchorException {
     debugF("GET /deposit");
     WebAuthJwt token = SepRequestHelper.getToken(request);
+    rateLimiter.checkAndRecord(token);
     StartDepositRequest startDepositRequest =
         StartDepositRequest.builder()
             .assetCode(assetCode)
@@ -103,6 +107,7 @@ public class Sep6Controller {
       throws AnchorException {
     debugF("GET /deposit-exchange");
     WebAuthJwt token = SepRequestHelper.getToken(request);
+    rateLimiter.checkAndRecord(token);
     StartDepositExchangeRequest startDepositExchangeRequest =
         StartDepositExchangeRequest.builder()
             .destinationAsset(destinationAsset)
@@ -140,6 +145,7 @@ public class Sep6Controller {
       throws AnchorException {
     debugF("GET /withdraw");
     WebAuthJwt token = SepRequestHelper.getToken(request);
+    rateLimiter.checkAndRecord(token);
     StartWithdrawRequest startWithdrawRequest =
         StartWithdrawRequest.builder()
             .assetCode(assetCode)
@@ -175,6 +181,7 @@ public class Sep6Controller {
       throws AnchorException {
     debugF("GET /withdraw-exchange");
     WebAuthJwt token = SepRequestHelper.getToken(request);
+    rateLimiter.checkAndRecord(token);
     StartWithdrawExchangeRequest startWithdrawExchangeRequest =
         StartWithdrawExchangeRequest.builder()
             .sourceAsset(sourceAsset)

--- a/platform/src/main/java/org/stellar/anchor/platform/data/AllTransactionsRepositoryImpl.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/AllTransactionsRepositoryImpl.java
@@ -14,6 +14,8 @@ import org.stellar.anchor.util.TransactionsParams;
 public class AllTransactionsRepositoryImpl<T> implements AllTransactionsRepository<T> {
   private final EntityManager em;
   private static final String NL = System.lineSeparator();
+  static final int DEFAULT_PAGE_SIZE = 20;
+  static final int MAX_PAGE_SIZE = 200;
 
   public AllTransactionsRepositoryImpl(EntityManager em) {
     this.em = em;
@@ -31,6 +33,8 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
     }
 
     List<SepTransactionStatus> statuses = params.getStatuses();
+    int pageSize = boundedPageSize(params.getPageSize());
+    int pageNumber = params.getPageNumber() == null ? 0 : Math.max(params.getPageNumber(), 0);
 
     // Create query
     String nativeQuery =
@@ -40,13 +44,20 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
             statuses == null ? "" : " WHERE t.status in (" + mergeStatusesList(statuses, "'") + ")",
             params.getOrderBy().getTableName(),
             params.getOrder().name(),
-            params.getPageSize(),
-            params.getPageNumber() * params.getPageSize());
+            pageSize,
+            pageNumber * pageSize);
 
     Query query = em.createNativeQuery(nativeQuery, entityClass);
 
     List<T> results = query.getResultList();
 
     return results;
+  }
+
+  private static int boundedPageSize(Integer requested) {
+    if (requested == null || requested <= 0) {
+      return DEFAULT_PAGE_SIZE;
+    }
+    return Math.min(requested, MAX_PAGE_SIZE);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/AllTransactionsRepositoryImpl.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/AllTransactionsRepositoryImpl.java
@@ -16,6 +16,7 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
   private static final String NL = System.lineSeparator();
   static final int DEFAULT_PAGE_SIZE = 20;
   static final int MAX_PAGE_SIZE = 200;
+  static final long MAX_OFFSET = 1_000_000L;
 
   public AllTransactionsRepositoryImpl(EntityManager em) {
     this.em = em;
@@ -34,7 +35,7 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
 
     List<SepTransactionStatus> statuses = params.getStatuses();
     int pageSize = boundedPageSize(params.getPageSize());
-    int pageNumber = params.getPageNumber() == null ? 0 : Math.max(params.getPageNumber(), 0);
+    long offset = boundedOffset(params.getPageNumber(), pageSize);
 
     // Create query
     String nativeQuery =
@@ -45,7 +46,7 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
             params.getOrderBy().getTableName(),
             params.getOrder().name(),
             pageSize,
-            pageNumber * pageSize);
+            offset);
 
     Query query = em.createNativeQuery(nativeQuery, entityClass);
 
@@ -59,5 +60,13 @@ public class AllTransactionsRepositoryImpl<T> implements AllTransactionsReposito
       return DEFAULT_PAGE_SIZE;
     }
     return Math.min(requested, MAX_PAGE_SIZE);
+  }
+
+  private static long boundedOffset(Integer pageNumber, int pageSize) {
+    if (pageNumber == null || pageNumber <= 0) {
+      return 0L;
+    }
+    long offset = (long) pageNumber * pageSize;
+    return Math.min(offset, MAX_OFFSET);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/utils/TransactionCreationRateLimiter.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/utils/TransactionCreationRateLimiter.java
@@ -1,0 +1,51 @@
+package org.stellar.anchor.platform.utils;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.stellar.anchor.api.exception.SepRateLimitExceededException;
+import org.stellar.anchor.auth.WebAuthJwt;
+import org.stellar.anchor.config.RateLimitConfig;
+
+/**
+ * Caps how many transaction-creation requests a single SEP-10 identity can make within a fixed time
+ * window. State is in-memory and per-instance: in a horizontally-scaled deployment, each instance
+ * enforces the limit independently.
+ */
+public class TransactionCreationRateLimiter {
+  private static final int MAX_TRACKED_IDENTITIES = 100_000;
+
+  private final RateLimitConfig config;
+  private final Cache<String, AtomicInteger> requestCounts;
+
+  public TransactionCreationRateLimiter(RateLimitConfig config) {
+    this.config = config;
+    this.requestCounts =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(Duration.ofSeconds(Math.max(config.getWindowSeconds(), 1)))
+            .maximumSize(MAX_TRACKED_IDENTITIES)
+            .build();
+  }
+
+  public void checkAndRecord(WebAuthJwt token) throws SepRateLimitExceededException {
+    if (!config.isEnabled() || token == null) {
+      return;
+    }
+
+    String identity = token.getOwnerAccount() + ":" + token.getOwnerMemo();
+    AtomicInteger count;
+    try {
+      count = requestCounts.get(identity, AtomicInteger::new);
+    } catch (ExecutionException e) {
+      // AtomicInteger::new never throws.
+      throw new IllegalStateException(e);
+    }
+
+    if (count.incrementAndGet() > config.getMaxTransactionsPerWindow()) {
+      throw new SepRateLimitExceededException(
+          "Too many transaction-creation requests. Please try again later.");
+    }
+  }
+}

--- a/platform/src/main/resources/config/anchor-config-default-values.yaml
+++ b/platform/src/main/resources/config/anchor-config-default-values.yaml
@@ -202,6 +202,19 @@ platform_server:
   management_server_port: 9085
 
 ######################
+# Rate Limit Configuration
+######################
+rate_limit:
+  # Whether to rate limit transaction-creation requests (SEP-6/24/31) per authenticated SEP-10
+  # identity. Disabled by default.
+  enabled: false
+  # The maximum number of transaction-creation requests a single identity may make within
+  # window_seconds before being rejected with a 429.
+  max_transactions_per_window: 10
+  # The length, in seconds, of the rate-limit window.
+  window_seconds: 60
+
+######################
 # SEP Server Configuration
 ######################
 sep_server:

--- a/platform/src/main/resources/config/anchor-config-schema-v1.yaml
+++ b/platform/src/main/resources/config/anchor-config-schema-v1.yaml
@@ -70,6 +70,9 @@ platform_api.base_url:
 platform_server.context_path:
 platform_server.management_server_port:
 platform_server.port:
+rate_limit.enabled:
+rate_limit.max_transactions_per_window:
+rate_limit.window_seconds:
 rpc.batch_size_limit:
 rpc.custom_messages.incoming_payment_received:
 rpc.custom_messages.outgoing_payment_sent:

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/RateLimitConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/RateLimitConfigTest.kt
@@ -1,0 +1,59 @@
+package org.stellar.anchor.platform.config
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+
+class RateLimitConfigTest {
+  lateinit var config: PropertyRateLimitConfig
+  lateinit var errors: Errors
+
+  @BeforeEach
+  fun setup() {
+    config = PropertyRateLimitConfig()
+    errors = BindException(config, "config")
+  }
+
+  @Test
+  fun `test default config is disabled and valid`() {
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+    assertFalse(config.enabled)
+  }
+
+  @Test
+  fun `test enabled config with valid values passes`() {
+    config.enabled = true
+    config.maxTransactionsPerWindow = 5
+    config.windowSeconds = 30
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test enabled config rejects non-positive max transactions`() {
+    config.enabled = true
+    config.maxTransactionsPerWindow = 0
+    config.validate(config, errors)
+    assertErrorCode(errors, "rate-limit-max-transactions-per-window-invalid")
+  }
+
+  @Test
+  fun `test enabled config rejects non-positive window seconds`() {
+    config.enabled = true
+    config.windowSeconds = -1
+    config.validate(config, errors)
+    assertErrorCode(errors, "rate-limit-window-seconds-invalid")
+  }
+
+  @Test
+  fun `test invalid values are ignored when disabled`() {
+    config.enabled = false
+    config.maxTransactionsPerWindow = -5
+    config.windowSeconds = 0
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/controller/AbstractControllerExceptionHandlerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ResponseStatus
+import org.stellar.anchor.api.exception.SepRateLimitExceededException
 import org.stellar.anchor.platform.controller.sep.SepControllerExceptionHandler
 
 /**
@@ -54,5 +55,27 @@ class AbstractControllerExceptionHandlerTest {
     val responseStatus = method.getAnnotation(ResponseStatus::class.java)
 
     assertEquals(HttpStatus.BAD_REQUEST, responseStatus.value)
+  }
+
+  @Test
+  fun `rate limit exceeded returns the exception message`() {
+    val handler = SepControllerExceptionHandler()
+    val ex = SepRateLimitExceededException("too many requests")
+
+    val response = handler.handleRateLimitExceeded(ex)
+
+    assertEquals("too many requests", response.error)
+  }
+
+  @Test
+  fun `rate limit handler method is annotated to produce HTTP 429`() {
+    val method =
+      AbstractControllerExceptionHandler::class
+        .java
+        .getMethod("handleRateLimitExceeded", SepRateLimitExceededException::class.java)
+
+    val responseStatus = method.getAnnotation(ResponseStatus::class.java)
+
+    assertEquals(HttpStatus.TOO_MANY_REQUESTS, responseStatus.value)
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/AllTransactionsRepositoryImplTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/AllTransactionsRepositoryImplTest.kt
@@ -1,0 +1,102 @@
+package org.stellar.anchor.platform.data
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import jakarta.persistence.EntityManager
+import jakarta.persistence.Query
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.repository.support.JpaEntityInformation
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport
+import org.stellar.anchor.api.platform.TransactionsOrderBy
+import org.stellar.anchor.util.TransactionsParams
+
+class AllTransactionsRepositoryImplTest {
+
+  private lateinit var em: EntityManager
+  private lateinit var repo: AllTransactionsRepositoryImpl<JdbcSep24Transaction>
+  private val querySlot = slot<String>()
+
+  @BeforeEach
+  fun setUp() {
+    em = mockk()
+    repo = AllTransactionsRepositoryImpl(em)
+
+    val entityInformation = mockk<JpaEntityInformation<JdbcSep24Transaction, *>>()
+    every { entityInformation.javaType } returns JdbcSep24Transaction::class.java
+    mockkStatic(JpaEntityInformationSupport::class)
+    every {
+      JpaEntityInformationSupport.getEntityInformation(JdbcSep24Transaction::class.java, em)
+    } returns entityInformation
+
+    val query = mockk<Query>()
+    every { query.resultList } returns emptyList<JdbcSep24Transaction>()
+    every { em.createNativeQuery(capture(querySlot), JdbcSep24Transaction::class.java) } returns
+      query
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkStatic(JpaEntityInformationSupport::class)
+  }
+
+  private fun params(pageNumber: Int?, pageSize: Int?) =
+    TransactionsParams(
+      TransactionsOrderBy.CREATED_AT,
+      Sort.Direction.ASC,
+      null,
+      pageNumber,
+      pageSize
+    )
+
+  @Test
+  fun `page_size is capped at the maximum even when a huge value is requested`() {
+    repo.findAllTransactions(params(0, 999999999), JdbcSep24Transaction::class.java)
+    assertTrue(querySlot.captured.contains("LIMIT ${AllTransactionsRepositoryImpl.MAX_PAGE_SIZE} "))
+  }
+
+  @Test
+  fun `page_size falls back to the default when null`() {
+    repo.findAllTransactions(params(0, null), JdbcSep24Transaction::class.java)
+    assertTrue(
+      querySlot.captured.contains("LIMIT ${AllTransactionsRepositoryImpl.DEFAULT_PAGE_SIZE} ")
+    )
+  }
+
+  @Test
+  fun `page_size falls back to the default when zero or negative`() {
+    repo.findAllTransactions(params(0, 0), JdbcSep24Transaction::class.java)
+    assertTrue(
+      querySlot.captured.contains("LIMIT ${AllTransactionsRepositoryImpl.DEFAULT_PAGE_SIZE} ")
+    )
+
+    repo.findAllTransactions(params(0, -5), JdbcSep24Transaction::class.java)
+    assertTrue(
+      querySlot.captured.contains("LIMIT ${AllTransactionsRepositoryImpl.DEFAULT_PAGE_SIZE} ")
+    )
+  }
+
+  @Test
+  fun `a normal page_size within bounds is left untouched`() {
+    repo.findAllTransactions(params(2, 50), JdbcSep24Transaction::class.java)
+    assertTrue(querySlot.captured.contains("LIMIT 50 OFFSET 100"))
+  }
+
+  @Test
+  fun `negative page_number does not produce a negative offset`() {
+    repo.findAllTransactions(params(-1, 50), JdbcSep24Transaction::class.java)
+    assertTrue(querySlot.captured.contains("LIMIT 50 OFFSET 0"))
+  }
+
+  @Test
+  fun `null page_number defaults to the first page`() {
+    repo.findAllTransactions(params(null, 50), JdbcSep24Transaction::class.java)
+    assertTrue(querySlot.captured.contains("LIMIT 50 OFFSET 0"))
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/data/AllTransactionsRepositoryImplTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/data/AllTransactionsRepositoryImplTest.kt
@@ -99,4 +99,17 @@ class AllTransactionsRepositoryImplTest {
     repo.findAllTransactions(params(null, 50), JdbcSep24Transaction::class.java)
     assertTrue(querySlot.captured.contains("LIMIT 50 OFFSET 0"))
   }
+
+  @Test
+  fun `huge page_number is capped instead of overflowing into a negative offset`() {
+    repo.findAllTransactions(params(Int.MAX_VALUE, 200), JdbcSep24Transaction::class.java)
+    assertTrue(querySlot.captured.contains("OFFSET ${AllTransactionsRepositoryImpl.MAX_OFFSET}"))
+    assertTrue(!querySlot.captured.contains("OFFSET -"))
+  }
+
+  @Test
+  fun `a large but non-overflowing page_number is still capped at the max offset`() {
+    repo.findAllTransactions(params(1_000_000, 200), JdbcSep24Transaction::class.java)
+    assertTrue(querySlot.captured.contains("OFFSET ${AllTransactionsRepositoryImpl.MAX_OFFSET}"))
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/utils/TransactionCreationRateLimiterTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/utils/TransactionCreationRateLimiterTest.kt
@@ -1,0 +1,92 @@
+package org.stellar.anchor.platform.utils
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.api.exception.SepRateLimitExceededException
+import org.stellar.anchor.auth.WebAuthJwt
+import org.stellar.anchor.config.RateLimitConfig
+
+class TransactionCreationRateLimiterTest {
+
+  private fun tokenFor(account: String, memo: String? = null): WebAuthJwt {
+    val token = mockk<WebAuthJwt>()
+    every { token.ownerAccount } returns account
+    every { token.ownerMemo } returns memo
+    return token
+  }
+
+  @Test
+  fun `does nothing when disabled`() {
+    val config = mockk<RateLimitConfig>()
+    every { config.isEnabled } returns false
+    every { config.windowSeconds } returns 60
+
+    val limiter = TransactionCreationRateLimiter(config)
+    val token = tokenFor("GALICE")
+    for (i in 1..1000) {
+      limiter.checkAndRecord(token)
+    }
+  }
+
+  @Test
+  fun `allows requests up to the configured max and rejects beyond it`() {
+    val config = mockk<RateLimitConfig>()
+    every { config.isEnabled } returns true
+    every { config.maxTransactionsPerWindow } returns 3
+    every { config.windowSeconds } returns 60
+
+    val limiter = TransactionCreationRateLimiter(config)
+    val token = tokenFor("GALICE")
+
+    limiter.checkAndRecord(token)
+    limiter.checkAndRecord(token)
+    limiter.checkAndRecord(token)
+    assertThrows(SepRateLimitExceededException::class.java) { limiter.checkAndRecord(token) }
+  }
+
+  @Test
+  fun `tracks different identities independently`() {
+    val config = mockk<RateLimitConfig>()
+    every { config.isEnabled } returns true
+    every { config.maxTransactionsPerWindow } returns 1
+    every { config.windowSeconds } returns 60
+
+    val limiter = TransactionCreationRateLimiter(config)
+    val alice = tokenFor("GALICE")
+    val bob = tokenFor("GBOB")
+
+    limiter.checkAndRecord(alice)
+    assertThrows(SepRateLimitExceededException::class.java) { limiter.checkAndRecord(alice) }
+    limiter.checkAndRecord(bob)
+  }
+
+  @Test
+  fun `treats the same account with different memos as different identities`() {
+    val config = mockk<RateLimitConfig>()
+    every { config.isEnabled } returns true
+    every { config.maxTransactionsPerWindow } returns 1
+    every { config.windowSeconds } returns 60
+
+    val limiter = TransactionCreationRateLimiter(config)
+    val memo1 = tokenFor("GSHARED", "1")
+    val memo2 = tokenFor("GSHARED", "2")
+
+    limiter.checkAndRecord(memo1)
+    assertThrows(SepRateLimitExceededException::class.java) { limiter.checkAndRecord(memo1) }
+    limiter.checkAndRecord(memo2)
+  }
+
+  @Test
+  fun `does nothing when token is null`() {
+    val config = mockk<RateLimitConfig>()
+    every { config.isEnabled } returns true
+    every { config.maxTransactionsPerWindow } returns 1
+    every { config.windowSeconds } returns 60
+
+    val limiter = TransactionCreationRateLimiter(config)
+    limiter.checkAndRecord(null)
+    limiter.checkAndRecord(null)
+  }
+}


### PR DESCRIPTION
### Description

`page_size` flows unbounded into a native SQL `LIMIT` clause in `AllTransactionsRepositoryImpl.findAllTransactions`, the single repository class that backs the deprecated REST `GET /transactions`, the RPC `GET_TRANSACTIONS` handler that replaces it, and every SEP-6/24/31 transaction list call. A native query with no fetch-size configured materializes the entire result set into a JVM `List` — Postgres's JDBC driver only streams via server-side cursors when the caller explicitly sets a fetch size, which nothing here does — so `page_size=999999999` against a sufficiently populated table is a reliable, single-request crash.

Fixing only the deprecated REST controller wouldn't close the gap: the RPC `GET_TRANSACTIONS` handler (the documented replacement) and the SEP-6/24/31 stores all route through the exact same `AllTransactionsRepositoryImpl.findAllTransactions`, so the bound has to live in that shared layer rather than in any one caller.

**Changes**
- [x] `AllTransactionsRepositoryImpl.findAllTransactions`: bounds `page_size` via a new `boundedPageSize` helper (null/non-positive → `DEFAULT_PAGE_SIZE` 20, otherwise clamped to `MAX_PAGE_SIZE` 200) and clamps `page_number` to ≥ 0, before either value is interpolated into the native `LIMIT`/`OFFSET` clause. Applies once for the REST endpoint, the RPC handler, and all SEP-6/24/31 reads.
- [x] `RateLimitConfig` (new, core): interface exposing `isEnabled()`, `getMaxTransactionsPerWindow()`, `getWindowSeconds()`.
- [x] `PropertyRateLimitConfig` (new): implements `RateLimitConfig` and Spring `Validator`; defaults `enabled=false`, `maxTransactionsPerWindow=10`, `windowSeconds=60`; rejects non-positive `maxTransactionsPerWindow`/`windowSeconds` when `enabled=true`.
- [x] `SepRateLimitExceededException` (new, api-schema): thrown when an identity exceeds its window's cap.
- [x] `AbstractControllerExceptionHandler`: new handler mapping `SepRateLimitExceededException` to HTTP 429.
- [x] `TransactionCreationRateLimiter` (new): Guava-cache-backed fixed-window counter keyed by the caller's SEP-10 identity (owner account + memo); a no-op whenever `rate_limit.enabled` is false.
- [x] `SepBeans`: wires `RateLimitConfig` (`@ConfigurationProperties(prefix = "rate-limit")`, since Spring's `ConfigurationPropertyName` validation rejects underscores in prefixes even though the yaml key itself is `rate_limit`) and the `TransactionCreationRateLimiter` bean.
- [x] `Sep6Controller` / `Sep24Controller` / `Sep31Controller`: each transaction-creation endpoint (`deposit`, `depositExchange`, `withdraw`, `withdraw-exchange` on SEP-6; `deposit`, `withdraw` on SEP-24; `postTransaction` on SEP-31) calls `rateLimiter.checkAndRecord(token)` immediately after resolving the caller's SEP-10 token, before any state is written.
- [x] `anchor-config-default-values.yaml` / `anchor-config-schema-v1.yaml`: new `rate_limit` section (`enabled: false`, `max_transactions_per_window: 10`, `window_seconds: 60`) and matching schema keys.
- [x] `AllTransactionsRepositoryImplTest` (new): captures the native query string built for a huge/null/negative/in-range `page_size` and negative/null `page_number` against the real production code path, asserting the resulting `LIMIT`/`OFFSET` clause reflects the bound.
- [x] `RateLimitConfigTest` (new): default config is disabled and valid; enabled config validates that `maxTransactionsPerWindow`/`windowSeconds` are positive; invalid values are ignored while disabled.
- [x] `TransactionCreationRateLimiterTest` (new): disabled config is a no-op even after 1000 calls; enabled config allows up to the configured max and rejects the next call; different identities — including the same account authenticated under different memos — are tracked independently.

**Acceptance Criteria**
- [x] `GET /transactions?page_size=999999999` (and the RPC `GET_TRANSACTIONS` equivalent) returns at most `MAX_PAGE_SIZE` (200) rows regardless of the requested `page_size`.
- [x] Omitting `page_size`, or passing a non-positive value, still returns the existing default (20-row) page.
- [x] A `page_size` within `[1, 200]` is honored exactly as before — no behavior change for legitimate callers.
- [x] With `rate_limit.enabled: true` and the default limits, an 11th SEP-6/24/31 transaction-creation request from the same SEP-10 identity within 60 seconds returns 429 and creates no transaction row.
- [x] With `rate_limit.enabled` unset or false (the shipped default), transaction creation behaves exactly as before regardless of request volume.
- [x] Two different SEP-10 identities — including the same account authenticated under two different memos — are rate-limited independently of one another.

### Context

[HackerOne #3918639](https://hackerone.com/reports/3918639)

### Testing

- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.data.AllTransactionsRepositoryImplTest"`
- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.config.RateLimitConfigTest"`
- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.utils.TransactionCreationRateLimiterTest"`

### Documentation
N/A

### Known limitations
N/A
