### PR TITLE
[ANCHOR-1296] Fix: GET /transactions leaks across memos on shared accounts (SEP-6 + SEP-24)

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24AccountIsolationTests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep24AccountIsolationTests.kt
@@ -1,0 +1,58 @@
+package org.stellar.anchor.platform.integrationtest
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.stellar.anchor.platform.IntegrationTestBase
+import org.stellar.anchor.platform.TestConfig
+import org.stellar.sdk.KeyPair
+import org.stellar.walletsdk.anchor.auth
+import org.stellar.walletsdk.asset.IssuedAssetId
+import org.stellar.walletsdk.horizon.SigningKeyPair
+
+class Sep24AccountIsolationTests : IntegrationTestBase(TestConfig()) {
+  private fun authenticateWithMemo(keyPair: SigningKeyPair, memoId: ULong) = runBlocking {
+    anchor.auth().authenticate(keyPair, memoId = memoId)
+  }
+
+  private fun authenticateWithoutMemo(keyPair: SigningKeyPair) = runBlocking {
+    anchor.auth().authenticate(keyPair)
+  }
+
+  @Test
+  fun `test sep24 GET transactions does not leak another memo's transactions on a shared account`() {
+    val sharedKeyPair = SigningKeyPair(KeyPair.random())
+    val noMemoToken = authenticateWithoutMemo(sharedKeyPair)
+    val memoAToken = authenticateWithMemo(sharedKeyPair, 111UL)
+    val memoBToken = authenticateWithMemo(sharedKeyPair, 222UL)
+
+    val noMemoTxnId =
+      runBlocking { anchor.sep24().deposit(USDC, noMemoToken, mapOf("amount" to "1")) }.id
+    val memoATxnId =
+      runBlocking { anchor.sep24().deposit(USDC, memoAToken, mapOf("amount" to "1")) }.id
+    val memoBTxnId =
+      runBlocking { anchor.sep24().deposit(USDC, memoBToken, mapOf("amount" to "1")) }.id
+
+    val listedIds =
+      runBlocking { anchor.sep24().getTransactionsForAsset(USDC, noMemoToken) }.map { it.id }
+
+    assertThat(listedIds)
+      .`as`("caller's own no-memo transaction should be visible in its own list")
+      .contains(noMemoTxnId)
+    assertThat(listedIds)
+      .`as`(
+        "GET /transactions leaked another memo's transaction ($memoATxnId) to a bare-account caller sharing the same Stellar account"
+      )
+      .doesNotContain(memoATxnId)
+    assertThat(listedIds)
+      .`as`(
+        "GET /transactions leaked another memo's transaction ($memoBTxnId) to a bare-account caller sharing the same Stellar account"
+      )
+      .doesNotContain(memoBTxnId)
+  }
+
+  companion object {
+    private val USDC =
+      IssuedAssetId("USDC", "GDQOE23CFSUMSVQK4Y5JHPPYK73VYCNHZHA7ENKCV37P6SUEO6XQBKPP")
+  }
+}

--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.integrationtest
 
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -15,11 +16,21 @@ import org.stellar.anchor.platform.TestSecrets.CLIENT_WALLET_SECRET
 import org.stellar.anchor.platform.gson
 import org.stellar.anchor.util.Log
 import org.stellar.sdk.KeyPair
+import org.stellar.walletsdk.anchor.auth
+import org.stellar.walletsdk.horizon.SigningKeyPair
 
 class Sep6Tests : IntegrationTestBase(TestConfig()) {
   private val sep6Client = Sep6Client(toml.getString("TRANSFER_SERVER"), token.token)
   private val sep38Client = Sep38Client(toml.getString("ANCHOR_QUOTE_SERVER"), this.token.token)
   private val clientWalletAccount = KeyPair.fromSecretSeed(CLIENT_WALLET_SECRET).accountId
+
+  private fun authenticateWithMemo(keyPair: SigningKeyPair, memoId: ULong): String {
+    return runBlocking { anchor.auth().authenticate(keyPair, memoId = memoId) }.token
+  }
+
+  private fun authenticateWithoutMemo(keyPair: SigningKeyPair): String {
+    return runBlocking { anchor.auth().authenticate(keyPair) }.token
+  }
 
   @Test
   fun `test Sep6 info endpoint`() {
@@ -47,6 +58,46 @@ class Sep6Tests : IntegrationTestBase(TestConfig()) {
       JSONCompareMode.LENIENT,
     )
     Assertions.assertNotNull(savedDepositTxn.transaction.moreInfoUrl)
+  }
+
+  @Test
+  fun `test sep6 GET transactions does not leak another memo's transactions on a shared account`() {
+    val sharedKeyPair = SigningKeyPair(KeyPair.random())
+    val noMemoJwt = authenticateWithoutMemo(sharedKeyPair)
+    val memoAJwt = authenticateWithMemo(sharedKeyPair, 111UL)
+    val memoBJwt = authenticateWithMemo(sharedKeyPair, 222UL)
+
+    val noMemoClient = Sep6Client(toml.getString("TRANSFER_SERVER"), noMemoJwt)
+    val memoAClient = Sep6Client(toml.getString("TRANSFER_SERVER"), memoAJwt)
+    val memoBClient = Sep6Client(toml.getString("TRANSFER_SERVER"), memoBJwt)
+
+    fun depositRequest() =
+      mapOf(
+        "asset_code" to "USDC",
+        "account" to sharedKeyPair.address,
+        "amount" to "1",
+        "type" to "SWIFT",
+      )
+
+    val noMemoTxnId = noMemoClient.deposit(depositRequest()).id!!
+    val memoATxnId = memoAClient.deposit(depositRequest()).id!!
+    val memoBTxnId = memoBClient.deposit(depositRequest()).id!!
+
+    val listedIds =
+      noMemoClient
+        .getTransactions(mapOf("asset_code" to "USDC", "account" to sharedKeyPair.address))
+        .transactions
+        .map { it.id }
+
+    Assertions.assertTrue(listedIds.contains(noMemoTxnId)) {
+      "caller's own no-memo transaction should be visible in its own list"
+    }
+    Assertions.assertFalse(listedIds.contains(memoATxnId)) {
+      "GET /transactions leaked another memo's transaction ($memoATxnId) to a bare-account caller sharing the same Stellar account"
+    }
+    Assertions.assertFalse(listedIds.contains(memoBTxnId)) {
+      "GET /transactions leaked another memo's transaction ($memoBTxnId) to a bare-account caller sharing the same Stellar account"
+    }
   }
 
   @Test

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep6Client.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep6Client.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.client
 
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.stellar.anchor.api.sep.sep6.GetTransactionsResponse
 import org.stellar.anchor.api.sep.sep6.InfoResponse
 import org.stellar.anchor.api.sep.sep6.Sep6GetTransactionResponse
@@ -37,10 +38,10 @@ class Sep6Client(private val endpoint: String, var jwt: String) : SepClient() {
   }
 
   fun getTransactions(request: Map<String, String>): GetTransactionsResponse {
-    val baseUrl = "$endpoint/transactions?"
-    val url = request.entries.fold(baseUrl) { acc, entry -> "$acc${entry.key}=${entry.value}&" }
+    val urlBuilder = "$endpoint/transactions".toHttpUrl().newBuilder()
+    request.forEach { (key, value) -> urlBuilder.addQueryParameter(key, value) }
 
-    val responseBody = httpGet(url, jwt)
+    val responseBody = httpGet(urlBuilder.build().toString(), jwt)
     return gson.fromJson(responseBody, GetTransactionsResponse::class.java)
   }
 }

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep6Client.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep6Client.kt
@@ -1,5 +1,6 @@
 package org.stellar.anchor.client
 
+import org.stellar.anchor.api.sep.sep6.GetTransactionsResponse
 import org.stellar.anchor.api.sep.sep6.InfoResponse
 import org.stellar.anchor.api.sep.sep6.Sep6GetTransactionResponse
 import org.stellar.anchor.api.sep.sep6.StartDepositResponse
@@ -33,5 +34,13 @@ class Sep6Client(private val endpoint: String, var jwt: String) : SepClient() {
 
     val responseBody = httpGet(url, jwt)
     return gson.fromJson(responseBody, Sep6GetTransactionResponse::class.java)
+  }
+
+  fun getTransactions(request: Map<String, String>): GetTransactionsResponse {
+    val baseUrl = "$endpoint/transactions?"
+    val url = request.entries.fold(baseUrl) { acc, entry -> "$acc${entry.key}=${entry.value}&" }
+
+    val responseBody = httpGet(url, jwt)
+    return gson.fromJson(responseBody, GetTransactionsResponse::class.java)
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -28,6 +28,7 @@ public interface JdbcSep24TransactionRepo
 
   @Query(
       "SELECT t FROM JdbcSep24Transaction t WHERE t.webAuthAccount = :account"
+          + " AND t.webAuthAccountMemo IS NULL"
           + " AND t.requestAssetCode = :assetCode"
           + " AND (:kind IS NULL OR t.kind = :kind)"
           + " AND t.startedAt > :noOlderThan"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -27,13 +27,15 @@ public interface JdbcSep24TransactionRepo
       String withdrawAnchorAccount, String memo, String status);
 
   /**
-   * Matches only transactions whose caller authenticated without a memo (bare {@code G...} SEP-10
-   * subject). Use {@link #findTransactionsWithMemoAndFilters} for a memo-scoped caller — the two
-   * are not interchangeable: a caller's memo (or lack of one) is part of their identity, so mixing
-   * them would leak transactions across users sharing the same underlying Stellar account. The
-   * legacy-row fallback in {@code JdbcSep24TransactionStore} also relies on this method matching
-   * only null-memo rows, since legacy {@code account:memo}-encoded rows always leave {@code
-   * webAuthAccountMemo} null.
+   * Matches only transactions whose {@code webAuthAccountMemo} column is null — i.e. the caller's
+   * SEP-10 token carried no memo, whether the token's subject was a bare {@code G...} account or a
+   * muxed {@code M...} account (muxed callers never populate this column; their disambiguator lives
+   * in the {@code webAuthAccount} value itself). Use {@link #findTransactionsWithMemoAndFilters}
+   * for a memo-scoped caller — the two are not interchangeable: a caller's memo (or lack of one) is
+   * part of their identity, so mixing them would leak transactions across users sharing the same
+   * underlying Stellar account. The legacy-row fallback in {@code JdbcSep24TransactionStore} also
+   * relies on this method matching only null-memo rows, since legacy {@code account:memo}-encoded
+   * rows always leave {@code webAuthAccountMemo} null.
    */
   @Query(
       "SELECT t FROM JdbcSep24Transaction t WHERE t.webAuthAccount = :account"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -26,6 +26,15 @@ public interface JdbcSep24TransactionRepo
   List<JdbcSep24Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
+  /**
+   * Matches only transactions whose caller authenticated without a memo (bare {@code G...} SEP-10
+   * subject). Use {@link #findTransactionsWithMemoAndFilters} for a memo-scoped caller — the two
+   * are not interchangeable: a caller's memo (or lack of one) is part of their identity, so mixing
+   * them would leak transactions across users sharing the same underlying Stellar account. The
+   * legacy-row fallback in {@code JdbcSep24TransactionStore} also relies on this method matching
+   * only null-memo rows, since legacy {@code account:memo}-encoded rows always leave {@code
+   * webAuthAccountMemo} null.
+   */
   @Query(
       "SELECT t FROM JdbcSep24Transaction t WHERE t.webAuthAccount = :account"
           + " AND t.webAuthAccountMemo IS NULL"
@@ -42,6 +51,10 @@ public interface JdbcSep24TransactionRepo
       @Param("olderThan") Instant olderThan,
       Pageable pageable);
 
+  /**
+   * Matches only transactions whose caller authenticated with the given memo. Use {@link
+   * #findTransactionsWithFilters} for a memo-less caller.
+   */
   @Query(
       "SELECT t FROM JdbcSep24Transaction t WHERE t.webAuthAccount = :account"
           + " AND t.webAuthAccountMemo = :accountMemo"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -109,7 +109,9 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
               olderThan,
               pageable);
       // Backward compatibility for legacy rows that may have stored account:memo in
-      // web_auth_account and left web_auth_account_memo empty.
+      // web_auth_account and left web_auth_account_memo empty. findTransactionsWithFilters only
+      // matches null-memo rows (see its Javadoc), which is safe here only because these legacy
+      // rows are guaranteed to have webAuthAccountMemo == null.
       if (txns.isEmpty()) {
         txns =
             txnRepo.findTransactionsWithFilters(

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -30,6 +30,7 @@ public interface JdbcSep6TransactionRepo
 
   @Query(
       "SELECT t FROM JdbcSep6Transaction t WHERE t.webAuthAccount = :account"
+          + " AND t.webAuthAccountMemo IS NULL"
           + " AND t.requestAssetCode = :assetCode"
           + " AND (:kind IS NULL OR t.kind = :kind)"
           + " AND t.startedAt > :noOlderThan"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -28,6 +28,12 @@ public interface JdbcSep6TransactionRepo
   List<JdbcSep6Transaction> findAllByWithdrawAnchorAccountAndMemoAndStatus(
       String withdrawAnchorAccount, String memo, String status);
 
+  /**
+   * Matches only transactions whose caller authenticated without a memo (bare {@code G...} SEP-10
+   * subject). Use {@link #findTransactionsWithMemoAndFilters} for a memo-scoped caller — the two
+   * are not interchangeable: a caller's memo (or lack of one) is part of their identity, so mixing
+   * them would leak transactions across users sharing the same underlying Stellar account.
+   */
   @Query(
       "SELECT t FROM JdbcSep6Transaction t WHERE t.webAuthAccount = :account"
           + " AND t.webAuthAccountMemo IS NULL"
@@ -44,6 +50,10 @@ public interface JdbcSep6TransactionRepo
       @Param("olderThan") Instant olderThan,
       Pageable pageable);
 
+  /**
+   * Matches only transactions whose caller authenticated with the given memo. Use {@link
+   * #findTransactionsWithFilters} for a memo-less caller.
+   */
   @Query(
       "SELECT t FROM JdbcSep6Transaction t WHERE t.webAuthAccount = :account"
           + " AND t.webAuthAccountMemo = :accountMemo"

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep6TransactionRepo.java
@@ -29,10 +29,13 @@ public interface JdbcSep6TransactionRepo
       String withdrawAnchorAccount, String memo, String status);
 
   /**
-   * Matches only transactions whose caller authenticated without a memo (bare {@code G...} SEP-10
-   * subject). Use {@link #findTransactionsWithMemoAndFilters} for a memo-scoped caller — the two
-   * are not interchangeable: a caller's memo (or lack of one) is part of their identity, so mixing
-   * them would leak transactions across users sharing the same underlying Stellar account.
+   * Matches only transactions whose {@code webAuthAccountMemo} column is null — i.e. the caller's
+   * SEP-10 token carried no memo, whether the token's subject was a bare {@code G...} account or a
+   * muxed {@code M...} account (muxed callers never populate this column; their disambiguator lives
+   * in the {@code webAuthAccount} value itself). Use {@link #findTransactionsWithMemoAndFilters}
+   * for a memo-scoped caller — the two are not interchangeable: a caller's memo (or lack of one) is
+   * part of their identity, so mixing them would leak transactions across users sharing the same
+   * underlying Stellar account.
    */
   @Query(
       "SELECT t FROM JdbcSep6Transaction t WHERE t.webAuthAccount = :account"


### PR DESCRIPTION
### Description

- Fixes a data-isolation bug on `GET /transactions` in both SEP-6 and SEP-24: a SEP-10 JWT with no memo (bare `G...` sub) returned *every* transaction for that underlying Stellar account, including transactions created by other users authenticated with a memo (`G...:111`, `G...:222`, etc.) sharing the same custodial account.
- Adds `Sep6Client.getTransactions()` (lib-util) — SEP-6 had no HTTP client for the list endpoint at all.

### Context

- Found during the ANCHOR-1279 SEP-coverage audit as an investigative-first item: "SEP-6 never verifies muxed/memo-scoped account isolation on `/transactions`" (untested by both AP's own suite and `stellar-anchor-tests`).
- Root cause: `JdbcSep6TransactionRepo`/`JdbcSep24TransactionRepo`'s `findTransactionsWithFilters` query (used whenever the caller's memo is `null`) had no memo predicate at all — not even `webAuthAccountMemo IS NULL` — unlike the singular `GET /transaction/:id` endpoint, which already does a strict equality check on memo. Muxed (`M...`) accounts were already isolated correctly (ANCHOR-1202).
- The identical bug was found copy-pasted in SEP-24, which the original audit didn't flag. Fixed both here in one branch rather than splitting into a separate SEP-24 ticket — this also closes that gap for ANCHOR-1297.

### Testing

- `./gradlew test`
- Wrote e2e tests first and confirmed they reproduced the leak against a live server + real Postgres (not mocks) before applying the fix, then confirmed they pass after: `Sep6Tests.kt` (`test sep6 GET transactions does not leak another memo's transactions on a shared account`) and the new `Sep24AccountIsolationTests.kt`.
- Ran existing unit tests for the touched classes (`JdbcSep6TransactionStoreTest`, `JdbcSep24TransactionStoreTest`, `Sep6ServiceTest`, `Sep24ServiceTest`) — all green, no regressions.
- `spotlessCheck` clean.

### Documentation

N/A — internal bug fix, no public API or user-facing behavior change (the fix makes existing documented SEP-6/24 spec behavior actually correct).

### Known limitations

- Remaining SEP-6 audit items (`test/anchor-1296-sep6-rest-validation`, `fix/anchor-1296-sep6-transactions-client`, `test/anchor-1296-sep6-transaction-404s`) are tracked separately and not part of this PR.