### PR TITLE
[ANCHOR-1302]: Observe destination accounts in SEP6/24

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/component/share/ObservingAccountsBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/share/ObservingAccountsBeans.java
@@ -20,10 +20,16 @@ public class ObservingAccountsBeans {
     PaymentObservingAccountsManager bean =
         new PaymentObservingAccountsManager(paymentObservingAccountStore);
 
-    if (env.getProperty("sep31.enabled", Boolean.class, false)) {
+    if (shouldStartEvictionScheduler(env)) {
       bean.start();
     }
 
     return bean;
+  }
+
+  static boolean shouldStartEvictionScheduler(Environment env) {
+    return env.getProperty("sep6.enabled", Boolean.class, false)
+        || env.getProperty("sep24.enabled", Boolean.class, false)
+        || env.getProperty("sep31.enabled", Boolean.class, false);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
@@ -60,7 +60,7 @@ public class PaymentObservingAccountsManager {
     this.evict(getEvictMaxIdleTime());
     Log.debug("Persisting accounts...");
     for (ObservingAccount account : this.getAccounts()) {
-      store.upsert(account.account, account.lastObserved);
+      persistUpsert(account.account, account.lastObserved);
     }
   }
 
@@ -83,21 +83,23 @@ public class PaymentObservingAccountsManager {
    */
   public void upsert(ObservingAccount observingAccount) {
     if (observingAccount != null) {
-      String canonicalAccount = canonicalize(observingAccount.account);
+      String canonicalAccount = safeCanonicalize(observingAccount.account);
       ObservingAccount existingAccount = allAccounts.get(canonicalAccount);
       if (existingAccount == null) {
         ObservingAccount toStore =
             new ObservingAccount(
                 canonicalAccount, observingAccount.lastObserved, observingAccount.type);
         allAccounts.put(canonicalAccount, toStore);
-        // update the database
-        store.upsert(canonicalAccount, observingAccount.lastObserved);
+        persistUpsert(canonicalAccount, observingAccount.lastObserved);
       } else {
         existingAccount.account = canonicalAccount;
         existingAccount.lastObserved = observingAccount.lastObserved;
         if (existingAccount.type == AccountType.TRANSIENT) {
           existingAccount.type = observingAccount.type;
         }
+      }
+      if (!canonicalAccount.equals(observingAccount.account)) {
+        persistDelete(observingAccount.account);
       }
     }
   }
@@ -107,6 +109,31 @@ public class PaymentObservingAccountsManager {
       return new MuxedAccount(account).getAccountId();
     }
     return account;
+  }
+
+  private static String safeCanonicalize(String account) {
+    try {
+      return canonicalize(account);
+    } catch (RuntimeException ex) {
+      Log.errorEx(String.format("Failed to canonicalize observing account %s", account), ex);
+      return account;
+    }
+  }
+
+  private void persistUpsert(String account, Instant lastObserved) {
+    try {
+      store.upsert(account, lastObserved);
+    } catch (RuntimeException ex) {
+      Log.errorEx(String.format("Failed to persist observing account %s", account), ex);
+    }
+  }
+
+  private void persistDelete(String account) {
+    try {
+      store.delete(account);
+    } catch (RuntimeException ex) {
+      Log.errorEx(String.format("Failed to delete stale observing account %s", account), ex);
+    }
   }
 
   /**
@@ -150,7 +177,7 @@ public class PaymentObservingAccountsManager {
       Duration idleTime = Duration.between(Instant.now(), acct.lastObserved).abs();
       if (idleTime.compareTo(maxIdleTime) > 0) {
         allAccounts.remove(acct.account);
-        store.delete(acct.account);
+        persistDelete(acct.account);
       }
     }
   }

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
@@ -84,23 +84,24 @@ public class PaymentObservingAccountsManager {
   public void upsert(ObservingAccount observingAccount) {
     if (observingAccount != null) {
       String canonicalAccount = safeCanonicalize(observingAccount.account);
-      ObservingAccount existingAccount = allAccounts.get(canonicalAccount);
-      if (existingAccount == null) {
-        ObservingAccount toStore =
-            new ObservingAccount(
-                canonicalAccount, observingAccount.lastObserved, observingAccount.type);
-        allAccounts.put(canonicalAccount, toStore);
-      } else {
-        existingAccount.account = canonicalAccount;
-        if (observingAccount.lastObserved.isAfter(existingAccount.lastObserved)) {
-          existingAccount.lastObserved = observingAccount.lastObserved;
-        }
-        if (existingAccount.type == AccountType.TRANSIENT) {
-          existingAccount.type = observingAccount.type;
-        }
-      }
-      ObservingAccount current = allAccounts.get(canonicalAccount);
-      boolean persisted = persistUpsert(current.account, current.lastObserved);
+      ObservingAccount merged =
+          allAccounts.compute(
+              canonicalAccount,
+              (key, existing) -> {
+                if (existing == null) {
+                  return new ObservingAccount(
+                      canonicalAccount, observingAccount.lastObserved, observingAccount.type);
+                }
+                Instant lastObserved =
+                    observingAccount.lastObserved.isAfter(existing.lastObserved)
+                        ? observingAccount.lastObserved
+                        : existing.lastObserved;
+                AccountType type =
+                    existing.type == AccountType.TRANSIENT ? observingAccount.type : existing.type;
+                return new ObservingAccount(canonicalAccount, lastObserved, type);
+              });
+
+      boolean persisted = persistUpsert(merged.account, merged.lastObserved);
       if (persisted && !canonicalAccount.equals(observingAccount.account)) {
         persistDelete(observingAccount.account);
       }
@@ -162,12 +163,14 @@ public class PaymentObservingAccountsManager {
       return false;
     }
 
-    account = canonicalize(account);
+    String canonicalAccount = canonicalize(account);
 
-    ObservingAccount acct = allAccounts.get(account);
-    if (acct == null) return false;
-    acct.lastObserved = Instant.now();
-    return true;
+    ObservingAccount updated =
+        allAccounts.computeIfPresent(
+            canonicalAccount,
+            (key, existing) ->
+                new ObservingAccount(existing.account, Instant.now(), existing.type));
+    return updated != null;
   }
 
   /**

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
@@ -83,19 +83,30 @@ public class PaymentObservingAccountsManager {
    */
   public void upsert(ObservingAccount observingAccount) {
     if (observingAccount != null) {
-      ObservingAccount existingAccount = allAccounts.get(observingAccount.account);
+      String canonicalAccount = canonicalize(observingAccount.account);
+      ObservingAccount existingAccount = allAccounts.get(canonicalAccount);
       if (existingAccount == null) {
-        allAccounts.put(observingAccount.account, observingAccount);
+        ObservingAccount toStore =
+            new ObservingAccount(
+                canonicalAccount, observingAccount.lastObserved, observingAccount.type);
+        allAccounts.put(canonicalAccount, toStore);
         // update the database
-        store.upsert(observingAccount.account, observingAccount.lastObserved);
+        store.upsert(canonicalAccount, observingAccount.lastObserved);
       } else {
-        existingAccount.account = observingAccount.account;
+        existingAccount.account = canonicalAccount;
         existingAccount.lastObserved = observingAccount.lastObserved;
         if (existingAccount.type == AccountType.TRANSIENT) {
           existingAccount.type = observingAccount.type;
         }
       }
     }
+  }
+
+  private static String canonicalize(String account) {
+    if (account != null && account.startsWith("M")) {
+      return new MuxedAccount(account).getAccountId();
+    }
+    return account;
   }
 
   /**
@@ -119,12 +130,7 @@ public class PaymentObservingAccountsManager {
       return false;
     }
 
-    // MuxedAccount handles both muxed and non-muxed accounts
-    if (account.startsWith("M")) {
-      // If the account is a muxed account, we need to extract the G-account ID
-      MuxedAccount muxedAccount = new MuxedAccount(account);
-      account = muxedAccount.getAccountId();
-    }
+    account = canonicalize(account);
 
     ObservingAccount acct = allAccounts.get(account);
     if (acct == null) return false;

--- a/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManager.java
@@ -90,15 +90,18 @@ public class PaymentObservingAccountsManager {
             new ObservingAccount(
                 canonicalAccount, observingAccount.lastObserved, observingAccount.type);
         allAccounts.put(canonicalAccount, toStore);
-        persistUpsert(canonicalAccount, observingAccount.lastObserved);
       } else {
         existingAccount.account = canonicalAccount;
-        existingAccount.lastObserved = observingAccount.lastObserved;
+        if (observingAccount.lastObserved.isAfter(existingAccount.lastObserved)) {
+          existingAccount.lastObserved = observingAccount.lastObserved;
+        }
         if (existingAccount.type == AccountType.TRANSIENT) {
           existingAccount.type = observingAccount.type;
         }
       }
-      if (!canonicalAccount.equals(observingAccount.account)) {
+      ObservingAccount current = allAccounts.get(canonicalAccount);
+      boolean persisted = persistUpsert(current.account, current.lastObserved);
+      if (persisted && !canonicalAccount.equals(observingAccount.account)) {
         persistDelete(observingAccount.account);
       }
     }
@@ -120,11 +123,13 @@ public class PaymentObservingAccountsManager {
     }
   }
 
-  private void persistUpsert(String account, Instant lastObserved) {
+  private boolean persistUpsert(String account, Instant lastObserved) {
     try {
       store.upsert(account, lastObserved);
+      return true;
     } catch (RuntimeException ex) {
       Log.errorEx(String.format("Failed to persist observing account %s", account), ex);
+      return false;
     }
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -300,9 +300,6 @@ public class RequestOnchainFundsHandler
           txn6.setMemo(sep6DepositInfo.getMemo());
           txn6.setMemoType("id");
         }
-
-        paymentObservingAccountsManager.upsert(
-            txn6.getToAccount(), PaymentObservingAccountsManager.AccountType.TRANSIENT);
         break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
@@ -326,9 +323,6 @@ public class RequestOnchainFundsHandler
           txn24.setMemo(sep24DepositInfo.getMemo());
           txn24.setMemoType("id");
         }
-
-        paymentObservingAccountsManager.upsert(
-            txn24.getToAccount(), PaymentObservingAccountsManager.AccountType.TRANSIENT);
         break;
       case SEP_31:
         JdbcSep31Transaction txn31 = (JdbcSep31Transaction) txn;
@@ -352,12 +346,30 @@ public class RequestOnchainFundsHandler
         }
 
         Log.infoF("Memo set to {} {}", txn31.getStellarMemoType(), txn31.getStellarMemo());
-
-        paymentObservingAccountsManager.upsert(
-            txn31.getToAccount(), PaymentObservingAccountsManager.AccountType.TRANSIENT);
         break;
       default:
         break;
     }
+  }
+
+  @Override
+  protected void afterTransactionSaved(JdbcSepTransaction txn, RequestOnchainFundsRequest request)
+      throws AnchorException {
+    String toAccount;
+    switch (Sep.from(txn.getProtocol())) {
+      case SEP_6:
+        toAccount = ((JdbcSep6Transaction) txn).getToAccount();
+        break;
+      case SEP_24:
+        toAccount = ((JdbcSep24Transaction) txn).getToAccount();
+        break;
+      case SEP_31:
+        toAccount = ((JdbcSep31Transaction) txn).getToAccount();
+        break;
+      default:
+        return;
+    }
+    paymentObservingAccountsManager.upsert(
+        toAccount, PaymentObservingAccountsManager.AccountType.TRANSIENT);
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandler.java
@@ -300,6 +300,9 @@ public class RequestOnchainFundsHandler
           txn6.setMemo(sep6DepositInfo.getMemo());
           txn6.setMemoType("id");
         }
+
+        paymentObservingAccountsManager.upsert(
+            txn6.getToAccount(), PaymentObservingAccountsManager.AccountType.TRANSIENT);
         break;
       case SEP_24:
         JdbcSep24Transaction txn24 = (JdbcSep24Transaction) txn;
@@ -323,6 +326,9 @@ public class RequestOnchainFundsHandler
           txn24.setMemo(sep24DepositInfo.getMemo());
           txn24.setMemoType("id");
         }
+
+        paymentObservingAccountsManager.upsert(
+            txn24.getToAccount(), PaymentObservingAccountsManager.AccountType.TRANSIENT);
         break;
       case SEP_31:
         JdbcSep31Transaction txn31 = (JdbcSep31Transaction) txn;

--- a/platform/src/main/java/org/stellar/anchor/platform/rpc/RpcTransactionStatusHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/rpc/RpcTransactionStatusHandler.java
@@ -132,6 +132,8 @@ public abstract class RpcTransactionStatusHandler<T extends RpcMethodParamsReque
   protected abstract void updateTransactionWithRpcRequest(JdbcSepTransaction txn, T request)
       throws AnchorException;
 
+  protected void afterTransactionSaved(JdbcSepTransaction txn, T request) throws AnchorException {}
+
   protected JdbcSepTransaction getTransaction(String transactionId) throws AnchorException {
     Sep31Transaction txn31 = txn31Store.findByTransactionId(transactionId);
     if (txn31 != null) {
@@ -215,6 +217,8 @@ public abstract class RpcTransactionStatusHandler<T extends RpcMethodParamsReque
         txn31Store.save(txn31);
         break;
     }
+
+    afterTransactionSaved(txn, request);
 
     updateMetrics(txn);
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/component/share/ObservingAccountsBeansTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/component/share/ObservingAccountsBeansTest.kt
@@ -1,0 +1,38 @@
+package org.stellar.anchor.platform.component.share
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.core.env.Environment
+
+class ObservingAccountsBeansTest {
+  private fun envWith(sep6: Boolean, sep24: Boolean, sep31: Boolean): Environment {
+    val env = mockk<Environment>()
+    every { env.getProperty("sep6.enabled", Boolean::class.javaObjectType, false) } returns sep6
+    every { env.getProperty("sep24.enabled", Boolean::class.javaObjectType, false) } returns sep24
+    every { env.getProperty("sep31.enabled", Boolean::class.javaObjectType, false) } returns sep31
+    return env
+  }
+
+  @Test
+  fun `test scheduler is not started when no protocol using transient observation is enabled`() {
+    assertFalse(ObservingAccountsBeans.shouldStartEvictionScheduler(envWith(false, false, false)))
+  }
+
+  @Test
+  fun `test scheduler is started when only sep6 is enabled`() {
+    assertTrue(ObservingAccountsBeans.shouldStartEvictionScheduler(envWith(true, false, false)))
+  }
+
+  @Test
+  fun `test scheduler is started when only sep24 is enabled`() {
+    assertTrue(ObservingAccountsBeans.shouldStartEvictionScheduler(envWith(false, true, false)))
+  }
+
+  @Test
+  fun `test scheduler is started when only sep31 is enabled`() {
+    assertTrue(ObservingAccountsBeans.shouldStartEvictionScheduler(envWith(false, false, true)))
+  }
+}

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
@@ -138,19 +138,59 @@ class PaymentObservingAccountsManagerTest {
     assertTrue(obs.lookupAndUpdate(testMuxAcct100))
     assertTrue(obs.lookupAndUpdate(testMuxAcct200))
   }
+
+  @Test
+  fun `test loading a legacy muxed row canonicalizes and deletes the stale row`() {
+    paymentObservingAccountStore.upsert(testMuxAcct100, Instant.now())
+    assertEquals(1, paymentObservingAccountStore.list().size)
+    assertEquals(testMuxAcct100, paymentObservingAccountStore.list()[0].account)
+
+    val obs = PaymentObservingAccountsManager(paymentObservingAccountStore)
+    obs.initialize()
+
+    val persisted = paymentObservingAccountStore.list()
+    assertEquals(1, persisted.size)
+    assertEquals(testAcct4, persisted[0].account)
+    assertTrue(obs.lookupAndUpdate(testAcct4))
+  }
+
+  @Test
+  fun `test upsert does not throw when the store fails to persist`() {
+    val obs = PaymentObservingAccountsManager(ThrowingPaymentObservingAccountStore())
+    obs.initialize()
+
+    assertDoesNotThrow { obs.upsert(testAcct1, TRANSIENT) }
+    assertEquals(1, obs.accounts.size)
+    assertTrue(obs.lookupAndUpdate(testAcct1))
+
+    assertDoesNotThrow { obs.evict(Duration.ZERO) }
+    assertEquals(0, obs.accounts.size)
+  }
 }
 
 class MemoryPaymentObservingAccountStore : PaymentObservingAccountStore(null) {
   private val accounts = mutableListOf<PaymentObservingAccount>()
 
-  override fun list(): List<PaymentObservingAccount> = accounts
+  public override fun list(): List<PaymentObservingAccount> = accounts
 
-  override fun upsert(account: String?, lastObserved: Instant?) {
+  public override fun upsert(account: String?, lastObserved: Instant?) {
     accounts.removeIf { it.account == account }
     accounts.add(PaymentObservingAccount(account, lastObserved))
   }
 
-  override fun delete(account: String) {
+  public override fun delete(account: String) {
     accounts.removeIf { it.account == account }
+  }
+}
+
+class ThrowingPaymentObservingAccountStore : PaymentObservingAccountStore(null) {
+  override fun list(): List<PaymentObservingAccount> = emptyList()
+
+  override fun upsert(account: String?, lastObserved: Instant?) {
+    throw RuntimeException("store unavailable")
+  }
+
+  override fun delete(account: String) {
+    throw RuntimeException("store unavailable")
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
@@ -166,6 +166,37 @@ class PaymentObservingAccountsManagerTest {
     assertDoesNotThrow { obs.evict(Duration.ZERO) }
     assertEquals(0, obs.accounts.size)
   }
+
+  @Test
+  fun `test legacy muxed row is not deleted when the canonical write fails`() {
+    val store = FlakyPaymentObservingAccountStore()
+    store.upsert(testMuxAcct100, Instant.now())
+    assertEquals(1, store.list().size)
+
+    store.failNextUpsert = true
+    val obs = PaymentObservingAccountsManager(store)
+    obs.initialize()
+
+    val persisted = store.list()
+    assertEquals(1, persisted.size)
+    assertEquals(testMuxAcct100, persisted[0].account)
+    assertTrue(obs.lookupAndUpdate(testAcct4))
+  }
+
+  @Test
+  fun `test a stale duplicate does not clobber a newer lastObserved timestamp`() {
+    val obs = PaymentObservingAccountsManager(paymentObservingAccountStore)
+    obs.initialize()
+
+    val newer = Instant.now()
+    val older = newer.minusSeconds(60)
+
+    obs.upsert(PaymentObservingAccountsManager.ObservingAccount(testAcct4, newer, TRANSIENT))
+    obs.upsert(PaymentObservingAccountsManager.ObservingAccount(testMuxAcct100, older, TRANSIENT))
+
+    assertEquals(1, obs.accounts.size)
+    assertEquals(newer, obs.accounts[0].lastObserved)
+  }
 }
 
 class MemoryPaymentObservingAccountStore : PaymentObservingAccountStore(null) {
@@ -192,5 +223,25 @@ class ThrowingPaymentObservingAccountStore : PaymentObservingAccountStore(null) 
 
   override fun delete(account: String) {
     throw RuntimeException("store unavailable")
+  }
+}
+
+class FlakyPaymentObservingAccountStore : PaymentObservingAccountStore(null) {
+  private val accounts = mutableListOf<PaymentObservingAccount>()
+  var failNextUpsert = false
+
+  public override fun list(): List<PaymentObservingAccount> = accounts
+
+  public override fun upsert(account: String?, lastObserved: Instant?) {
+    if (failNextUpsert) {
+      failNextUpsert = false
+      throw RuntimeException("store unavailable")
+    }
+    accounts.removeIf { it.account == account }
+    accounts.add(PaymentObservingAccount(account, lastObserved))
+  }
+
+  public override fun delete(account: String) {
+    accounts.removeIf { it.account == account }
   }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
@@ -7,6 +7,9 @@ import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
 import java.time.temporal.ChronoUnit.HOURS
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*
 import org.stellar.anchor.platform.data.PaymentObservingAccount
@@ -197,6 +200,39 @@ class PaymentObservingAccountsManagerTest {
     assertEquals(1, obs.accounts.size)
     assertEquals(newer, obs.accounts[0].lastObserved)
   }
+
+  @Test
+  fun `test concurrent upserts never lose the newest lastObserved under race`() {
+    val obs = PaymentObservingAccountsManager(NoopPaymentObservingAccountStore())
+    obs.initialize()
+
+    val threadCount = 32
+    val perThread = 500
+    val pool = Executors.newFixedThreadPool(threadCount)
+    val start = CountDownLatch(1)
+    val base = Instant.now()
+
+    try {
+      repeat(threadCount) { threadIndex ->
+        pool.submit {
+          start.await()
+          for (i in 0 until perThread) {
+            val ts = base.plusNanos((threadIndex.toLong() * perThread + i) * 1000)
+            obs.upsert(PaymentObservingAccountsManager.ObservingAccount(testAcct1, ts, TRANSIENT))
+          }
+        }
+      }
+      start.countDown()
+      pool.shutdown()
+      assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "upsert pool did not finish in time")
+    } finally {
+      pool.shutdownNow()
+    }
+
+    val expectedMax = base.plusNanos((threadCount.toLong() * perThread - 1) * 1000)
+    val finalAccount = obs.accounts.first { it.account == testAcct1 }
+    assertEquals(expectedMax, finalAccount.lastObserved)
+  }
 }
 
 class MemoryPaymentObservingAccountStore : PaymentObservingAccountStore(null) {
@@ -224,6 +260,14 @@ class ThrowingPaymentObservingAccountStore : PaymentObservingAccountStore(null) 
   override fun delete(account: String) {
     throw RuntimeException("store unavailable")
   }
+}
+
+class NoopPaymentObservingAccountStore : PaymentObservingAccountStore(null) {
+  override fun list(): List<PaymentObservingAccount> = emptyList()
+
+  override fun upsert(account: String?, lastObserved: Instant?) {}
+
+  override fun delete(account: String) {}
 }
 
 class FlakyPaymentObservingAccountStore : PaymentObservingAccountStore(null) {

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/observer/stellar/PaymentObservingAccountsManagerTest.kt
@@ -21,8 +21,8 @@ class PaymentObservingAccountsManagerTest {
   private val testAcct2 = KeyPair.random().accountId
   private val testAcct3 = KeyPair.random().accountId
   private val testAcct4 = KeyPair.random().accountId
-  private val testMuxAcct100 = MuxedAccount(testAcct4, BigInteger("100")).accountId
-  private val testMuxAcct200 = MuxedAccount(testAcct4, BigInteger("100")).accountId
+  private val testMuxAcct100 = MuxedAccount(testAcct4, BigInteger("100")).address
+  private val testMuxAcct200 = MuxedAccount(testAcct4, BigInteger("200")).address
 
   @Test
   fun `test add and lookup`() {
@@ -122,6 +122,19 @@ class PaymentObservingAccountsManagerTest {
     obs.initialize()
 
     obs.upsert(testAcct4, TRANSIENT)
+    assertTrue(obs.lookupAndUpdate(testMuxAcct100))
+    assertTrue(obs.lookupAndUpdate(testMuxAcct200))
+  }
+
+  @Test
+  fun `test registering by muxed account is found by the base account`() {
+    val obs = PaymentObservingAccountsManager(paymentObservingAccountStore)
+    obs.initialize()
+
+    obs.upsert(testMuxAcct100, TRANSIENT)
+    assertEquals(1, obs.accounts.size)
+
+    assertTrue(obs.lookupAndUpdate(testAcct4))
     assertTrue(obs.lookupAndUpdate(testMuxAcct100))
     assertTrue(obs.lookupAndUpdate(testMuxAcct200))
   }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -617,6 +617,10 @@ class RequestOnchainFundsHandlerTest {
         PaymentObservingAccountsManager.AccountType.TRANSIENT,
       )
     }
+    verifyOrder {
+      txn24Store.save(any())
+      paymentObservingAccountsManager.upsert(any(), any())
+    }
 
     val expectedSep24Txn = JdbcSep24Transaction()
     expectedSep24Txn.kind = WITHDRAWAL.kind
@@ -1341,6 +1345,10 @@ class RequestOnchainFundsHandlerTest {
         PaymentObservingAccountsManager.AccountType.TRANSIENT,
       )
     }
+    verifyOrder {
+      txn6Store.save(any())
+      paymentObservingAccountsManager.upsert(any(), any())
+    }
 
     val expectedSep6Txn = JdbcSep6Transaction()
     expectedSep6Txn.kind = kind
@@ -1748,6 +1756,16 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
+    verify(exactly = 1) {
+      paymentObservingAccountsManager.upsert(
+        DESTINATION_ACCOUNT,
+        PaymentObservingAccountsManager.AccountType.TRANSIENT,
+      )
+    }
+    verifyOrder {
+      txn31Store.save(any())
+      paymentObservingAccountsManager.upsert(any(), any())
+    }
 
     val expectedSep31Txn = JdbcSep31Transaction()
     expectedSep31Txn.status = PENDING_SENDER.toString()

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/rpc/RequestOnchainFundsHandlerTest.kt
@@ -611,6 +611,12 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn6Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
+    verify(exactly = 1) {
+      paymentObservingAccountsManager.upsert(
+        DESTINATION_ACCOUNT,
+        PaymentObservingAccountsManager.AccountType.TRANSIENT,
+      )
+    }
 
     val expectedSep24Txn = JdbcSep24Transaction()
     expectedSep24Txn.kind = WITHDRAWAL.kind
@@ -1329,6 +1335,12 @@ class RequestOnchainFundsHandlerTest {
     verify(exactly = 0) { txn24Store.save(any()) }
     verify(exactly = 0) { txn31Store.save(any()) }
     verify(exactly = 1) { sepTransactionCounter.increment() }
+    verify(exactly = 1) {
+      paymentObservingAccountsManager.upsert(
+        DESTINATION_ACCOUNT,
+        PaymentObservingAccountsManager.AccountType.TRANSIENT,
+      )
+    }
 
     val expectedSep6Txn = JdbcSep6Transaction()
     expectedSep6Txn.kind = kind


### PR DESCRIPTION
### Description

`RequestOnchainFundsHandler.updateTransactionWithRpcRequest` assigns a `toAccount` for the withdrawal/receive leg of every protocol, but only the SEP-31 branch tells the Payment Observer to watch that account — it calls `paymentObservingAccountsManager.upsert(txn31.getToAccount(), TRANSIENT)` unconditionally, after either the custom-destination path or the auto-generated-deposit-info path. The SEP-6 and SEP-24 branches set `toAccount`/`withdrawAnchorAccount` the same way but never call `upsert`.

In practice this is masked whenever the deposit info generator hands back the anchor's own distribution account, since `PaymentObserverBeans` registers every configured distribution account as `RESIDENTIAL` at startup — already-watched, so the missing `upsert` is a no-op in that case. The gap only surfaces when `request_onchain_funds` is called with the "none" deposit-info generator and an RPC-supplied `destination_account` that isn't the anchor's distribution account: nothing ever registers that address with the observer, so an incoming payment to it is never matched back to the transaction.

**Changes**
- [x] `RequestOnchainFundsHandler.updateTransactionWithRpcRequest`: after `txn6.setToAccount(...)`, calls `paymentObservingAccountsManager.upsert(txn6.getToAccount(), TRANSIENT)`; after `txn24.setToAccount(...)`, calls the equivalent for `txn24`. Placed unconditionally after both branches (custom destination and auto-generated), mirroring the existing SEP-31 call.
- [x] `RequestOnchainFundsHandlerTest`: added `verify(exactly = 1) { paymentObservingAccountsManager.upsert(DESTINATION_ACCOUNT, TRANSIENT) }` to the existing SEP-24 (`test_handle_ok_sep24_withExpectedAmount`) and SEP-6 (`test_handle_sep6_ok_withoutAmountExpected`) tests that already exercise a custom `destination_account`.

**Acceptance Criteria**
- [x] A SEP-6 `request_onchain_funds` call with the "none" generator and an explicit `destination_account` registers that account with the Payment Observer as `TRANSIENT`.
- [x] A SEP-24 `request_onchain_funds` call with the "none" generator and an explicit `destination_account` registers that account with the Payment Observer as `TRANSIENT`.
- [x] SEP-31 behavior is unchanged.
- [x] All existing `RequestOnchainFundsHandlerTest` tests pass.

### Context

N/A

### Testing

- Unit: `./gradlew :platform:test --tests "org.stellar.anchor.platform.rpc.RequestOnchainFundsHandlerTest"`
- Integration: `./gradlew :core:test :platform:test` — full module regression, no failures

### Documentation
N/A

### Known limitations
N/A
