### PR TITLE
alchemy-anchor SEP-24 card integration

### DIFF
--- a/docs/alchemy-anchor-integration.md
+++ b/docs/alchemy-anchor-integration.md
@@ -1,0 +1,36 @@
+# alchemy-anchor integration
+
+This fork integrates the public SEP-24 card wrapper
+[drQedwards/alchemy-anchor](https://github.com/drQedwards/alchemy-anchor)
+with the Stellar Anchor Platform.
+
+## What this is
+
+- SEP-24 deposit/withdraw host in the Node repo (`src/serve.js`).
+- Alchemy Pay hosted checkout is the card rail. Card PAN never touches this process.
+- First settlement is existing Circle USDC (`GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`). Transfer only. Never mint.
+- After a Stellar payment lands, the host hashes the XDR envelope and prepares a human-signed `store` of the 32-byte digest on live `pmll_anchor` `CCF3B64AXLS4OLY5RN4H4K2CFZAYNZCJQY5MKCKCVAKMZNH7G7F7XUUF`. The CLI does not broadcast that invoke.
+- Minted-coin disbursements (Q / QI only) require a completed MoonPay transaction UUID. Circle USDC, BTC, SOL, XLM, and ETH are not minted here.
+
+## Endpoints
+
+The Node host is not publicly deployed yet. Until a live host exists, these stay local:
+
+- Info: `http://127.0.0.1:8787/sep24/info`
+- TOML: `http://127.0.0.1:8787/.well-known/stellar.toml`
+- Auth: `http://127.0.0.1:8787/auth`
+- SEP-24: `http://127.0.0.1:8787/sep24`
+- Wrap preview: `http://127.0.0.1:8787/wrap`
+
+Do not point `TRANSFER_SERVER_SEP0024` at a guessed public URL.
+
+## Platform fit
+
+Anchor Platform still owns SEP plumbing, fees, and status callbacks. alchemy-anchor is the card business server:
+
+1. Wallet opens SEP-24 interactive deposit.
+2. Host returns an Alchemy Pay sandbox or production checkout URL.
+3. Stellar USDC (or optional XLM hop) lands.
+4. Human reviews the digest, then signs `pmll_anchor.store`.
+
+Hop assets recorded off-chain for the interchainer: USDC, BTC, SOL, XLM, ETH. Commitments only.


### PR DESCRIPTION
### Description

This open PR is the integration track for the public SEP-24 card wrapper [drQedwards/alchemy-anchor](https://github.com/drQedwards/alchemy-anchor).

The fork-side wiring already landed on `Jito-io/anchor-platform-alchemy-anchor` in [pull/1](https://github.com/Jito-io/anchor-platform-alchemy-anchor/pull/1). This PR carries that same contract onto `stellar/anchor-platform` as `docs/alchemy-anchor-integration.md`. No runtime code change in this diff.

- SEP-24 deposit/withdraw stays in the Node host.
- Alchemy Pay hosted checkout is the card rail. Card PAN never touches this process.
- First settlement is existing Circle USDC (`GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`). Transfer only. This host never mints a dollar.
- After a Stellar payment lands, the host hashes the XDR envelope and prepares a human-signed `store` of the 32-byte digest on live `pmll_anchor` `CCF3B64AXLS4OLY5RN4H4K2CFZAYNZCJQY5MKCKCVAKMZNH7G7F7XUUF`. The CLI does not broadcast that invoke.
- Circle CCTP inbound mint is a separate contract: `CctpForwarder` `CBZL2IH7F6BIDAA3WBNXYKIXSATJGMSW7K5P5MJ6STX5RXN47TZJDF5T` `mint_and_forward(message, attestation)`. The settlement is keyed by that same XDR SHA. This host does not call it and does not broadcast.
- Minted-coin disbursements (Q / QI only) require a completed MoonPay transaction UUID.

### Context

The Node host is not publicly deployed. `TRANSFER_SERVER_SEP0024` and the other endpoints stay on `http://127.0.0.1:8787` until a live host exists. This PR is the place that contract lives so the platform does not point at a guessed public URL.

Live Circle CCTP on Stellar (domain 27), not invoked from here:

- `CctpForwarder`: `CBZL2IH7F6BIDAA3WBNXYKIXSATJGMSW7K5P5MJ6STX5RXN47TZJDF5T` (`mint_and_forward`)
- `TokenMessengerMinter`: `CAE2G5Z77UP7GYPYGFOWFGW7C7J6I4YP2AFGSADRKQY62SYUFLPNFTXL` (`deposit_for_burn`, `handle_recv_*`)
- `MessageTransmitter`: `CACMENFFJPJMSDAJQLX4R7K3SFZIW2LJSE3R2UMLGSWHFHS353FVXAZV`

### Testing

- N/A for platform Gradle. Documentation plus the recorded integration contract.
- Confirm the doc matches the Node host routes: `/sep24/info`, `/.well-known/stellar.toml`, `/auth`, `/sep24`, `/wrap`.

### Documentation

- Added `docs/alchemy-anchor-integration.md`.
- No stellar-docs PR. This is the integration track for this wrapper, not a new Anchor Platform feature.

### Known limitations

- No live host yet, so endpoints remain localhost.
- Circle USDC, BTC, SOL, XLM, and ETH are not minted by this host.
- `pmll_anchor.store` stays human-signed.
- `mint_and_forward` stays on Circle's forwarder. Not called from this PR.