### PR TITLE
[ANCHOR-1296]: SEP-6 REST validation coverage

### DIFF
--- a/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
+++ b/essential-tests/src/testFixtures/kotlin/org/stellar/anchor/platform/integrationtest/Sep6Tests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.assertThrows
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.stellar.anchor.api.exception.SepException
+import org.stellar.anchor.api.exception.SepNotAuthorizedException
 import org.stellar.anchor.api.sep.sep38.Sep38Context
 import org.stellar.anchor.client.Sep38Client
 import org.stellar.anchor.client.Sep6Client
@@ -248,6 +249,86 @@ class Sep6Tests : IntegrationTestBase(TestConfig()) {
       }
     assert(ex.message!!.contains("Provided 'account' is not allowed")) {
       "Expected destination policy error but got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 deposit rejects request without JWT`() {
+    val noAuthClient = Sep6Client(toml.getString("TRANSFER_SERVER"), null)
+    assertThrows<SepNotAuthorizedException> {
+      noAuthClient.deposit(
+        mapOf(
+          "asset_code" to "USDC",
+          "account" to clientWalletAccount,
+          "amount" to "1",
+          "type" to "SWIFT",
+        )
+      )
+    }
+  }
+
+  @Test
+  fun `test sep6 withdraw rejects request without JWT`() {
+    val noAuthClient = Sep6Client(toml.getString("TRANSFER_SERVER"), null)
+    assertThrows<SepNotAuthorizedException> {
+      noAuthClient.withdraw(
+        mapOf("asset_code" to "USDC", "type" to "bank_account", "amount" to "1")
+      )
+    }
+  }
+
+  @Test
+  fun `test sep6 deposit rejects request without asset_code`() {
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.deposit(
+          mapOf("account" to clientWalletAccount, "amount" to "1", "type" to "SWIFT")
+        )
+      }
+    assert(ex.message!!.contains("asset_code")) {
+      "Expected a missing 'asset_code' parameter error but got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 withdraw rejects request without asset_code`() {
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.withdraw(mapOf("type" to "bank_account", "amount" to "1"))
+      }
+    assert(ex.message!!.contains("asset_code")) {
+      "Expected a missing 'asset_code' parameter error but got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 deposit rejects unsupported asset_code`() {
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.deposit(
+          mapOf(
+            "asset_code" to "DOES_NOT_EXIST",
+            "account" to clientWalletAccount,
+            "amount" to "1",
+            "type" to "SWIFT",
+          )
+        )
+      }
+    assert(ex.message!!.contains("invalid operation for asset")) {
+      "Expected an unsupported-asset error but got: ${ex.message}"
+    }
+  }
+
+  @Test
+  fun `test sep6 withdraw rejects unsupported asset_code`() {
+    val ex =
+      assertThrows<SepException> {
+        sep6Client.withdraw(
+          mapOf("asset_code" to "DOES_NOT_EXIST", "type" to "bank_account", "amount" to "1")
+        )
+      }
+    assert(ex.message!!.contains("invalid operation for asset")) {
+      "Expected an unsupported-asset error but got: ${ex.message}"
     }
   }
 

--- a/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep6Client.kt
+++ b/lib-util/src/main/kotlin/org/stellar/anchor/client/Sep6Client.kt
@@ -5,7 +5,7 @@ import org.stellar.anchor.api.sep.sep6.Sep6GetTransactionResponse
 import org.stellar.anchor.api.sep.sep6.StartDepositResponse
 import org.stellar.anchor.api.sep.sep6.StartWithdrawResponse
 
-class Sep6Client(private val endpoint: String, var jwt: String) : SepClient() {
+class Sep6Client(private val endpoint: String, var jwt: String?) : SepClient() {
   fun getInfo(): InfoResponse {
     val responseBody = httpGet("$endpoint/info")
     return gson.fromJson(responseBody, InfoResponse::class.java)


### PR DESCRIPTION
### Description

- Adds e2e test coverage for SEP-6 `/deposit` and `/withdraw` REST parameter validation: rejecting requests missing a JWT, missing `asset_code`, or using an unsupported `asset_code`.

### Context

- Closes assertions #1, #2, #5, #33, #34, #37 from the ANCHOR-1279 SEP-6 coverage audit (`docs/audits/ANCHOR-1279-sep-coverage-audit.md`) — these were previously either completely untested (Gap) or only exercised via mocked service logic in a unit test (Name-match-only), never against the real HTTP endpoint.

### Testing

- `./gradlew test`
- `./gradlew clean runEssentialTests` — 6 new e2e tests added to `Sep6Tests.kt`, all passing against a local reference server (`startServersWithTestProfile`)
- Full local 6-dimension review (security / requirements / test coverage / architecture / regression / performance) run pre-push against the diff — zero blocking findings

### Documentation

N/A — test-only change, no public API or feature change.

### Known limitations

- `/deposit-exchange` and `/withdraw-exchange` have the same JWT/required-param validation gaps but aren't covered here — out of scope per the audit table, which only lists assertions for plain deposit/withdraw. Not filed as its own ticket yet.
- SEP-6's `authentication_required` flag is hardcoded `true` in `Sep6Service` (never actually configurable), so the audit's "if authentication_required is false" assertions (#3, #4, #35, #36) describe behavior that doesn't exist in this codebase and aren't testable.
- Found but intentionally not fixed here: `/deposit`'s `account` query param is missing `required = false` on `Sep6Controller` (unlike `/withdraw`'s), making `Sep6Service.deposit()`'s own account-fallback logic dead code. Tracked separately for a future `fix/anchor-1296-sep6-deposit-account-param` branch, kept out of this test-coverage PR per the project's fix/test separation convention.